### PR TITLE
Bach: Create Sample on filter

### DIFF
--- a/bach/bach/dataframe.py
+++ b/bach/bach/dataframe.py
@@ -432,7 +432,7 @@ class DataFrame:
                     tablesample bernoulli({sample_percentage}) repeatable ({seed}))
                 '''
             else:
-                sql = f'create table {table_name} as ({df.view_sql()})'
+                sql = f'create temporary table {table_name} as ({df.view_sql()})'
             conn.execute(sql)
 
         # Use SampleSqlModel, that way we can keep track of the current_node and undo this sampling

--- a/bach/tests/functional/bach/test_df_sample.py
+++ b/bach/tests/functional/bach/test_df_sample.py
@@ -28,6 +28,26 @@ def test_get_sample():
     )
 
 
+_EXPECTED_COLUMNS_OPERATIONS = [
+    '_index_skating_order',  # index
+    'skating_order', 'city', 'municipality', 'inhabitants', 'founding',
+    'better_city', 'a', 'big_city', 'b', 'extra_ppl'
+]
+_EXPECTED_DATA_OPERATIONS = [
+    [1, 1, 'Ljouwert', 'Leeuwarden', 93485, 1285, 'Ljouwert_better', 'LjLe', 93495, 94770, 93490],
+    [2, 2, 'Snits', 'Súdwest-Fryslân', 33520, 1456, 'Snits_better', 'SnSú', 33530, 34976, 33525],
+    [3, 3, 'Drylts', 'Súdwest-Fryslân', 3055, 1268, 'Drylts_better', 'DrSú', 3065, 4323, 3060],
+    [4, 4, 'Sleat', 'De Friese Meren', 700, 1426, 'Sleat_better', 'SlDe', 710, 2126, 705],
+    [5, 5, 'Starum', 'Súdwest-Fryslân', 960, 1061, 'Starum_better', 'StSú', 970, 2021, 965],
+    [6, 6, 'Hylpen', 'Súdwest-Fryslân', 870, 1225, 'Hylpen_better', 'HySú', 880, 2095, 875],
+    [7, 7, 'Warkum', 'Súdwest-Fryslân', 4440, 1399, 'Warkum_better', 'WaSú', 4450, 5839, 4445],
+    [8, 8, 'Boalsert', 'Súdwest-Fryslân', 10120, 1455, 'Boalsert_better', 'BoSú', 10130, 11575, 10125],
+    [9, 9, 'Harns', 'Harlingen', 14740, 1234, 'Harns_better', 'HaHa', 14750, 15974, 14745],
+    [10, 10, 'Frjentsjer', 'Waadhoeke', 12760, 1374, 'Frjentsjer_better', 'FrWa', 12770, 14134, 12765],
+    [11, 11, 'Dokkum', 'Noardeast-Fryslân', 12675, 1298, 'Dokkum_better', 'DoNo', 12685, 13973, 12680]
+]
+
+
 def test_sample_operations():
     bt = get_bt_with_test_data(True)
     bt_sample = bt.get_sample(table_name='test_data_sample',
@@ -46,24 +66,30 @@ def test_sample_operations():
 
     assert_equals_data(
         all_data_bt,
-        expected_columns=[
-            '_index_skating_order',  # index
-            'skating_order', 'city', 'municipality', 'inhabitants', 'founding',
-            'better_city', 'a', 'big_city', 'b', 'extra_ppl'
-        ],
-        expected_data=[
-            [1, 1, 'Ljouwert', 'Leeuwarden', 93485, 1285, 'Ljouwert_better', 'LjLe', 93495, 94770, 93490],
-            [2, 2, 'Snits', 'Súdwest-Fryslân', 33520, 1456, 'Snits_better', 'SnSú', 33530, 34976, 33525],
-            [3, 3, 'Drylts', 'Súdwest-Fryslân', 3055, 1268, 'Drylts_better', 'DrSú', 3065, 4323, 3060],
-            [4, 4, 'Sleat', 'De Friese Meren', 700, 1426, 'Sleat_better', 'SlDe', 710, 2126, 705],
-            [5, 5, 'Starum', 'Súdwest-Fryslân', 960, 1061, 'Starum_better', 'StSú', 970, 2021, 965],
-            [6, 6, 'Hylpen', 'Súdwest-Fryslân', 870, 1225, 'Hylpen_better', 'HySú', 880, 2095, 875],
-            [7, 7, 'Warkum', 'Súdwest-Fryslân', 4440, 1399, 'Warkum_better', 'WaSú', 4450, 5839, 4445],
-            [8, 8, 'Boalsert', 'Súdwest-Fryslân', 10120, 1455, 'Boalsert_better', 'BoSú', 10130, 11575, 10125],
-            [9, 9, 'Harns', 'Harlingen', 14740, 1234, 'Harns_better', 'HaHa', 14750, 15974, 14745],
-            [10, 10, 'Frjentsjer', 'Waadhoeke', 12760, 1374, 'Frjentsjer_better', 'FrWa', 12770, 14134, 12765],
-            [11, 11, 'Dokkum', 'Noardeast-Fryslân', 12675, 1298, 'Dokkum_better', 'DoNo', 12685, 13973, 12680]
-        ]
+        expected_columns=_EXPECTED_COLUMNS_OPERATIONS,
+        expected_data=_EXPECTED_DATA_OPERATIONS
+    )
+
+
+def test_sample_operations_filter():
+    bt = get_bt_with_test_data(True)
+    bt_sample = bt.get_sample(table_name='test_data_sample',
+                              filter=bt.skating_order % 2 == 0,
+                              overwrite=True)
+
+    bt_sample['better_city'] = bt_sample.city + '_better'
+    bt_sample['a'] = bt_sample.city.str[:2] + bt_sample.municipality.str[:2]
+    bt_sample['big_city'] = bt_sample.inhabitants + 10
+    bt_sample['b'] = bt_sample.inhabitants + bt_sample.founding
+    assert bt_sample.skating_order.nunique().value == 5
+
+    all_data_bt = bt_sample.get_unsampled()
+    all_data_bt['extra_ppl'] = all_data_bt.inhabitants + 5
+
+    assert_equals_data(
+        all_data_bt,
+        expected_columns=_EXPECTED_COLUMNS_OPERATIONS,
+        expected_data=_EXPECTED_DATA_OPERATIONS
     )
 
 


### PR DESCRIPTION
Allow creating a sample using a custom filter vs. Bernoulli sample.
```
bt_sample = bt.get_sample(table_name='test_data_sample', filter=bt.skating_order % 2 == 0, overwrite=True)
# do super fast stuff
bt_full = bt.get_unsampled()
bt_full.head(10)  # run on ful dataset, epic.
```