### PR TITLE
Readme docs alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Check out [objectiv.io](https://www.objectiv.io) to learn more.
 
 * [Objectiv Docs](https://www.objectiv.io/docs) - Objectiv's official documentation.
 * [Objectiv on Slack](https://join.slack.com/t/objectiv-io/shared_invite/zt-u6xma89w-DLDvOB7pQer5QUs5B_~5pg) - Get help & join the discussion on where to take Objectiv next.
-* [Contribution Guide](CONTRIBUTING.md) - Report bugs, request features and contribution information.
+* [Contribution Guide](https://www.objectiv.io/docs/the-project/contribute) - Report bugs, request features and contribution information.
 * [Github Roadmap](https://github.com/objectiv/objectiv-analytics/projects/2) - Learn about Objectiv's future plans.
 
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ with the goal of collecting better data and more effective modeling.
 
 ![Objectiv Pipeline](https://www.objectiv.io/docs/img/objectiv-pipeline.svg "Objectiv Pipeline")
 
-With [Objectiv Bach](https://www.objectiv.io/docs/modeling/) (our data modeling library), you can use familiar Pandas-like DataFrame operations on your full SQL dataset. It is designed for effective feature creation for datasets that embrace [the open taxonomy of analytics](https://objectiv.io/docs/taxonomy).
+With [Objectiv Bach](https://www.objectiv.io/docs/modeling/) (our data modeling library), you can use familiar Pandas-like DataFrame operations on your full SQL dataset. It includes extensions for effective feature creation for datasets that embrace [the open taxonomy of analytics](https://objectiv.io/docs/taxonomy).
 
 Check out [objectiv.io](https://www.objectiv.io) to learn more.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-Go to [Objectiv Docs](https://objectiv.io/docs/) for detailed installation & usage instructions
-
 ![Objectiv Logo](https://objectiv.io/docs/img/logo-objectiv-large.svg "Objectiv Logo")
 
 Objectiv is a data collection & modeling library that puts the data scientist first. It is built around 
@@ -8,55 +6,24 @@ structure and validate data. With Objectiv, you create a
 [contextual layer for your application](https://objectiv.io/docs/tracking/core-concepts/tagging) by mapping it to the taxonomy, 
 with the goal of collecting better data and more effective modeling.
 
+![Objectiv Pipeline](https://staging.objectiv.io/docs/img/objectiv-pipeline.svg "Objectiv Pipeline")
+
 Check out [objectiv.io](https://www.objectiv.io) to learn more.
 
 - - -
 
-## Play with Objectiv
-We’ve set up a [Live Demo Notebook](https://notebook.objectiv.io/lab?path=product_analytics.ipynb)  with real data from [objectiv.io](https://www.objectiv.io) for you to 
-play with. Give it a try and see what Objectiv can do.
+## Getting Started
 
-## Running Objectiv locally - Quickstart 
-In order to run Objectiv for local development, we'll help you set up the following components:
+* [Play with Objectiv](https://notebook.objectiv.io/lab?path=product_analytics.ipynb) in our Live Demo notebook.
+* [Follow the Quickstart Guide](https://www.objectiv.io/docs/) to run Objectiv locally.
 
-* The **Objectiv Tracker** to track user behavior from your website or web application. 
-* The **Objectiv Collector** and a **PostgreSQL data store** to collect, validate & store event data from the tracker.
-* A **Notebook** with the **Objectiv Bach** modeling library to explore and model your data.  
+## Useful Resources
 
-![Objectiv Pipeline](https://objectiv.io/docs/img/objectiv-pipeline.svg "Objectiv Pipeline")
-
-
-To get the latest stable build, run the following commands:
-```bash
-git clone git@github.com:objectiv/objectiv-analytics.git
-cd objectiv-analytics
-docker-compose pull  # pull pre-built images from gcr
-```
-
-Now, let's get started.
-
-### 1. Spin up the Collector & PostgreSQL
-Run the following command:
-```bash
-docker-compose up objectiv_collector
-```
-This will spin up the Collector backend and a PostgresQL data store, creating an endpoint for the tracker to send data to.
+* [Objectiv Docs](https://www.objectiv.io/docs) - Objectiv's official documentation.
+* [Objectiv on Slack](https://join.slack.com/t/objectiv-io/shared_invite/zt-u6xma89w-DLDvOB7pQer5QUs5B_~5pg) - Get help & join the discussion on where to take Objectiv next.
+* [Contribution Guide](CONTRIBUTING.md) - Report bugs, request features and contribution information.
+* [Github Roadmap](https://github.com/objectiv/objectiv-analytics/projects/2) - Learn about Objectiv's future plans.
 
 
-**Security Warning:** The above `docker-compose` command starts a postgres container that allows connections
-without verifying passwords. Do not use this in production or on a shared system!
+This repository is part of the source code for Objectiv, which is released under the Apache 2.0 License. Please refer to [LICENSE.md](LICENSE.md) for details. Unless otherwise noted, all files © 2021 Objectiv B.V.
 
-### 2. Instrument the Tracker
-The Tracker is available for multiple platforms. Follow one of the [step-by-step Tracking How-to Guides](https://www.objectiv.io/docs/how-to-guides) for your preferred platform to continue. 
-
-### 3. Spin up a Notebook with Objectiv Bach
-Run the following command: 
-```bash
-docker-compose up objectiv_notebook
-```
-This will spin up a notebook with the Objectiv Bach modeling library that enables you to analyze the data that you've collected. Check out the [Objectiv Docs modeling section](https://www.objectiv.io/docs/tracking//modeling) for detailed instructions on using Objectiv Bach.
-
----
-
-## Running Objectiv in production
-A detailed How-to guide is coming soon. 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ structure and validate data. With Objectiv, you create a
 [contextual layer for your application](https://objectiv.io/docs/tracking/core-concepts/tagging) by mapping it to the taxonomy, 
 with the goal of collecting better data and more effective modeling.
 
-![Objectiv Pipeline](https://staging.objectiv.io/docs/img/objectiv-pipeline.svg "Objectiv Pipeline")
+![Objectiv Pipeline](https://www.objectiv.io/docs/img/objectiv-pipeline.svg "Objectiv Pipeline")
 
 Check out [objectiv.io](https://www.objectiv.io) to learn more.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Check out [objectiv.io](https://www.objectiv.io) to learn more.
 
 ## Getting Started
 
-* [Play with Objectiv](https://notebook.objectiv.io/lab?path=product_analytics.ipynb) in our Live Demo notebook.
+* [Play with Objectiv](https://notebook.objectiv.io/lab?path=product_analytics.ipynb) in our Live Demo Notebook.
 * [Follow the Quickstart Guide](https://www.objectiv.io/docs/) to run Objectiv locally.
 
 ## Useful Resources

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ with the goal of collecting better data and more effective modeling.
 
 ![Objectiv Pipeline](https://www.objectiv.io/docs/img/objectiv-pipeline.svg "Objectiv Pipeline")
 
+With [Objectiv Bach](https://www.objectiv.io/docs/modeling/) (our data modeling library), you can use familiar Pandas-like DataFrame operations on your full SQL dataset. It is designed for effective feature creation for datasets that embrace [the open taxonomy of analytics](https://objectiv.io/docs/taxonomy).
+
 Check out [objectiv.io](https://www.objectiv.io) to learn more.
 
 - - -

--- a/README.md
+++ b/README.md
@@ -8,66 +8,55 @@ structure and validate data. With Objectiv, you create a
 [contextual layer for your application](https://objectiv.io/docs/tracking/core-concepts/tagging) by mapping it to the taxonomy, 
 with the goal of collecting better data and more effective modeling.
 
-#### Key features
-
-* [Event & context classes are predefined](https://objectiv.io/docs/taxonomy), designed to ensure the collected data 
-  covers a wide range of common analytics use cases. 
-* Instrumentation gets validated against the taxonomy to provide 
-  [live feedback in your IDE and console while you’re developing](https://objectiv.io/docs/tracking/core-concepts/validation).
-* Tracked events can carry multiple contexts, including the 
-  [exact location in the UI](https://objectiv.io/docs/tracking/core-concepts/locations) from where they were triggered.
-* Collected data is well-structured, self-descriptive and gets validated at the first step of the pipeline.
-* [Familiar Pandas-like dataframe operations can be used](https://objectiv.io/docs/modeling) on the full data set, straight from a notebook. 
-* Models can be built by taking parts of other models. Models can be reused for other projects by changing a 
-  single line of code.
+Check out [objectiv.io](https://www.objectiv.io) to learn more.
 
 - - -
 
-## Quick Start
-
-### Play with Objectiv
-We’ve set up a [sandboxed notebook with real data from objectiv.io](https://notebook.objectiv.io/lab?path=product_analytics.ipynb) for you to 
+## Play with Objectiv
+We’ve set up a [Live Demo Notebook](https://notebook.objectiv.io/lab?path=product_analytics.ipynb)  with real data from [objectiv.io](https://www.objectiv.io) for you to 
 play with. Give it a try and see what Objectiv can do.
 
-### Running all Objectiv components Dockerized
-This is a great way to run Objectiv locally and to see what it is about. With some additional work this
-setup can also be used for low-traffic sites and apps.
+## Running Objectiv locally - Quickstart 
+In order to run Objectiv for local development, we'll help you set up the following components:
 
-The below commands assume that you have `docker-compose` [installed](https://docs.docker.com/compose/install/).
+* The **Objectiv Tracker** to track user behavior from your website or web application. 
+* The **Objectiv Collector** and a **PostgreSQL data store** to collect, validate & store event data from the tracker.
+* A **Notebook** with the **Objectiv Bach** modeling library to explore and model your data.  
+
+![Objectiv Pipeline](https://objectiv.io/docs/img/objectiv-pipeline.svg "Objectiv Pipeline")
+
+
+To get the latest stable build, run the following commands:
 ```bash
+git clone git@github.com:objectiv/objectiv-analytics.git
+cd objectiv-analytics
 docker-compose pull  # pull pre-built images from gcr
-docker-compose up    # spin up Objective pipeline
 ```
-This will spin up three images:
-* `objectiv_collector` - Endpoint that the Objectiv-tracker can send events to (http://localhost:5000).
-* `objectiv_postgres` - Database to store data.
-* `objectiv_notebook` - Jupyter notebook that can be used to query the data (http://localhost:8888).
 
-SECURITY WARNING: The above `docker-compose` commands start a postgres container that allows connections
+Now, let's get started.
+
+### 1. Spin up the Collector & PostgreSQL
+Run the following command:
+```bash
+docker-compose up objectiv_collector
+```
+This will spin up the Collector backend and a PostgresQL data store, creating an endpoint for the tracker to send data to.
+
+
+**Security Warning:** The above `docker-compose` command starts a postgres container that allows connections
 without verifying passwords. Do not use this in production or on a shared system!
 
-### Instrumenting Objectiv
-To immediately jump into instrumenting your application, check out our detailed [How-to Guides](https://objectiv.io/docs/tracking/how-to-guides) for multiple 
-platforms and frameworks.
+### 2. Instrument the Tracker
+The Tracker is available for multiple platforms. Follow one of the [step-by-step Tracking How-to Guides](https://www.objectiv.io/docs/how-to-guides) for your preferred platform to continue. 
 
-- - -
+### 3. Spin up a Notebook with Objectiv Bach
+Run the following command: 
+```bash
+docker-compose up objectiv_notebook
+```
+This will spin up a notebook with the Objectiv Bach modeling library that enables you to analyze the data that you've collected. Check out the [Objectiv Docs modeling section](https://www.objectiv.io/docs/tracking//modeling) for detailed instructions on using Objectiv Bach.
 
-## Support & Troubleshooting
-If you need help using or installing Objectiv, join our [Slack channel](https://join.slack.com/t/objectiv-io/shared_invite/zt-u6xma89w-DLDvOB7pQer5QUs5B_~5pg) and post your question there. 
+---
 
-## Bug Reports & Feature Requests
-If you’ve found an issue or have a feature request, please check out the [Contribution Guide](https://www.objectiv.io/docs/the-project/contribute).
-
-## Security Disclosure
-Found a security issue? Please don’t use the issue tracker but contact us directly. See [SECURITY.md](SECURITY.md) for details.
-
-## Roadmap
-Future plans for Objectiv can be found on our [Github Roadmap](https://github.com/objectiv/objectiv-analytics/projects/2).
-
-## Contributing to Objectiv
-Thank you for considering to contribute to Objectiv! Please take a look at the [Contribution Guide](https://www.objectiv.io/docs/the-project/contributing) in our Docs. It contains information about our contribution process and where you can fit in.
-
-## License
-This repository is part of the source code for Objectiv, which is released under the Apache 2.0 License. Please refer to [LICENSE.md](LICENSE.md) for details.
-
-Unless otherwise noted, all files © 2021 Objectiv B.V.
+## Running Objectiv in production
+A detailed How-to guide is coming soon. 


### PR DESCRIPTION
I overhauled the main readme to align with the docs changes.

- removed the bulleted key features in favor of a better introduction with an image
- moved the installation instructions to the docs to have one place to maintain it
- made a more compact layout for the meta information to make it visually a bit less distracting

Note: the pipeline image is rather large at this moment. this will be fixed in the docs (as that's where it comes from)