### PR TITLE
Bach: More consistent use of groupby index

### DIFF
--- a/bach/bach/dataframe.py
+++ b/bach/bach/dataframe.py
@@ -113,20 +113,21 @@ class DataFrame:
 
     # A DataFrame holds the state of a set of operations on it's base node
     #
-    # The main component in this are the dicts of Series that it keeps: `index` and `data`
+    # The main components in this are the dicts of Series that it keeps: `index` and `data`
     # The `data` Series represent all data columns, possibly waiting for aggregation.
     # The `index` Series are used as an index in key lookups, but serve no other purpose but for nice
     # visualisation when converting to pandas Dataframes.
     #
-    # When a Series is used as an index, it should be free from any pending aggregation (and thus `group_by`
-    # should be None, and its `Series.index` should be `{}`.
+    # When a Series is used as an index, it should be free from any pending aggregation (and thus
+    # `Series.group_by` should be None, and its `Series.index` should be `{}`.
     #
     # `DataFrame.group_by` should always match the `Series.group_by` for all Series in the `data` dict.
-    # Series in the `index`, should have `Series.index` == `{}`.
+    #  (and `Series.index` should match `Series.group_by.index`, but that's checked in `Series.__init__`)
     #
+    # To illustrate (copied verbatim from Series docs):
     # The rule here: If a series needs a `group_by` to be evaluated, then and only then it should carry that
-    # `group_by`. This implies that index Series coming from a GroupBy, do not carry that `group_by`. Only
-    # the data columns do.
+    # `group_by`. This implies that index Series coming from `GroupBy.index`, do not carry that `group_by`.
+    # Only the data Series that actually need the aggregation to happen do.
     #
     # Order is also tracked in `order_by`. It can either be None or a list of SortColumns. Ordering is mostly
     # kept throughout operations, but for example materialization resets the sort order.

--- a/bach/bach/dataframe.py
+++ b/bach/bach/dataframe.py
@@ -110,6 +110,26 @@ class DataFrame:
     # todo note on ordering for slices?
     # todo 'meaning that they originate from the same data source' ok, by approximation
     # todo _get_dtypes also queries the database
+
+    # A DataFrame holds the state of a set of operations on it's base node
+    #
+    # The main component in this is the dists of Series that it keeps: `index` and `data`
+    # The `data` Series represent all data columns, possibly waiting for aggregation.
+    # The `index` Series are used as an index in key lookups, but serve no other purpose but for nice
+    # visualisation when conversion to pandas Dataframes.
+    #
+    # When a Series is used as an index, it should be free from any pending aggregation (and thus `group_by`
+    # should be None, and its `Series.index` should be `{}`.
+    #
+    # `DataFrame.group_by` should always match the `Series.group_by` for all Series in the `data` dict.
+    # Series in the `index`, should have `Series.index` == `{}`.
+    #
+    # The rule here: If a series needs a `group_by` to be evaluated, then and only then it should carry that
+    # `group_by`. This implies that index Series coming from a GroupBy, do not carry that group_by. Only
+    # the data columns do.
+    #
+    # Order is also tracked in `order_by`. It can either be None or a list of SortColumns. Ordering is mostly
+    # kept throughout operations, but for example materialization resets the sort order.
     def __init__(
             self,
             engine: Engine,
@@ -155,6 +175,8 @@ class DataFrame:
         for value in index.values():
             if value.index != {}:
                 raise ValueError('Index series can not have non-empty index property')
+            if value.group_by:
+                raise ValueError('Index series can not have a group_by')
 
         if group_by is not None and not dict_name_series_equals(group_by.index, index):
             raise ValueError('Index should match group_by index')
@@ -524,6 +546,10 @@ class DataFrame:
         :param inplace: Perform operation on self if ``inplace=True``, or create a copy. Not supported yet.
         :param limit: The limit (slice, int) to apply.
         :returns: New DataFrame with the current DataFrame's state as base_node
+
+        .. note::
+            Calling materialize() resets the order of the dataframe. Call :py:meth:`sort_values()` again on
+            the result if order is important.
         """
         if inplace:
             raise NotImplementedError("inplace materialization is not supported")
@@ -537,7 +563,9 @@ class DataFrame:
             index_dtypes=index_dtypes,
             series_dtypes=series_dtypes,
             group_by=[None],
-            order_by=[]  # filtering rows resets any sorting
+            # materializing resets any sorting as we don't have a way to translate the sorting expressions
+            # to new columns reliably. This needs attention # TODO
+            order_by=[]
         )
 
     def get_sample(self,
@@ -688,29 +716,39 @@ class DataFrame:
             else:
                 single_value = False  # there is no way for us to know. User has to slice the result first
 
+                if key.base_node != self.base_node:
+                    raise ValueError('Cannot apply Boolean series with a different base_node to DataFrame. '
+                                     'Hint: make sure the Boolean series is derived from this DataFrame and '
+                                     'that is has the same group by or use df.merge(series) to merge the '
+                                     'series with the df first, and then create a new Boolean series on the '
+                                     'resulting merged data.')
+
+                # window functions do not have group_by set, but they can't be used without materialization
                 if key.expression.has_windowed_aggregate_function:
                     raise ValueError('Cannot apply a Boolean series containing a window function to '
-                                     'DataFrame. '
-                                     'Hint: materialize() that DataFrame before creating the Boolean series')
+                                     'DataFrame. Hint: materialize() the DataFrame before creating the '
+                                     'Boolean series')
 
-                if key.base_node != self.base_node or key.group_by != self._group_by:
-                    raise ValueError('Cannot apply Boolean series with a different base_node or group by '
-                                     'to DataFrame. '
-                                     'Hint: make sure the Boolean series is derived from this DataFrame and '
-                                     'that is has the same group by. '
-                                     'Alternative: use df.merge(series) to merge the series with the df '
-                                     'first, and then create a new Boolean series on the resulting merged '
-                                     'data.')
+                # If the key has no group_by but the df has, this is a filter before aggregation. This is
+                # supported. It can change the aggregated results though, but that makes sense.
+                # A common case here is a filter on the columns in the group_by e.g. the index of this df.
+                # We don't support using aggregated series to filter on a non-aggregated df though:
+                if key.group_by and not self._group_by:
+                    raise ValueError('Can not apply aggregated BooleanSeries to a non-grouped df.'
+                                     'Please merge() the selector df with this df first.')
 
-                if self._group_by is not None and key.expression.has_aggregate_function:
+                # If a group_by is set on both, they have to match.
+                if key.group_by and key.group_by != self._group_by:
+                    raise ValueError('Can not apply aggregated BooleanSeries with non matching group_by.'
+                                     'Please merge() the selector df with thisdf first.')
+
+                if key.group_by is not None and key.expression.has_aggregate_function:
+                    # Create a having-condition if the key is aggregated
                     node = self.get_current_node(
                         name='getitem_having_boolean',
                         having_clause=Expression.construct("having {}", key.expression))
-                elif key.expression.has_aggregate_function:
-                    # This is very weird, does this ever happen?
-                    raise ValueError("Cannot use a Boolean series that contains a non-materialized "
-                                     "aggregation function or a windowing function as Boolean row selector.")
                 else:
+                    # A normal where-condition will do
                     node = self.get_current_node(
                         name='getitem_where_boolean',
                         where_clause=Expression.construct("where {}", key.expression))
@@ -718,7 +756,6 @@ class DataFrame:
             return self.copy_override(
                 base_node=node,
                 group_by=[None],
-                order_by=[],  # filtering rows resets any sorting
                 index_dtypes={name: series.dtype for name, series in self.index.items()},
                 series_dtypes={name: series.dtype for name, series in self.data.items()},
                 single_value=single_value
@@ -1388,7 +1425,8 @@ class DataFrame:
         where_clause = where_clause if where_clause else Expression.construct('')
         if self._group_by:
 
-            not_aggregated = [s.name for s in self._data.values() if not s.expression.has_aggregate_function]
+            not_aggregated = [s.name for s in self._data.values()
+                              if not s.expression.has_aggregate_function]
             if len(not_aggregated) > 0:
                 raise ValueError(f'Series {not_aggregated} need(s) to have an aggregation function set. '
                                  f'Setup aggregation through agg() or on all individual series first.')

--- a/bach/bach/dataframe.py
+++ b/bach/bach/dataframe.py
@@ -1431,8 +1431,10 @@ class DataFrame:
             not_aggregated = [s.name for s in self._data.values()
                               if not s.expression.has_aggregate_function]
             if len(not_aggregated) > 0:
-                raise ValueError(f'Series {not_aggregated} need(s) to have an aggregation function set. '
-                                 f'Setup aggregation through agg() or on all individual series first.')
+                raise ValueError(f'The df has groupby set, but contains Series that have no aggregation '
+                                 f'function yet. Please make sure to first: remove these from the frame, '
+                                 f'setup aggregation through agg(), or on all individual series.'
+                                 f'Unaggregated series: {not_aggregated}')
 
             group_by_column_expr = self.group_by.get_group_by_column_expression()
             if group_by_column_expr:

--- a/bach/bach/dataframe.py
+++ b/bach/bach/dataframe.py
@@ -731,8 +731,10 @@ class DataFrame:
                                      'Boolean series')
 
                 # If the key has no group_by but the df has, this is a filter before aggregation. This is
-                # supported. It can change the aggregated results though, but that makes sense.
-                # A common case here is a filter on the columns in the group_by e.g. the index of this df.
+                # supported but it can change the aggregated results.
+                # (A common case is a filter on the columns in the group_by e.g. the index of this df.)
+                # We might come back to this when we keep conditions (where/having) as state.
+
                 # We don't support using aggregated series to filter on a non-aggregated df though:
                 if key.group_by and not self._group_by:
                     raise ValueError('Can not apply aggregated BooleanSeries to a non-grouped df.'

--- a/bach/bach/dataframe.py
+++ b/bach/bach/dataframe.py
@@ -113,10 +113,10 @@ class DataFrame:
 
     # A DataFrame holds the state of a set of operations on it's base node
     #
-    # The main component in this is the dists of Series that it keeps: `index` and `data`
+    # The main component in this are the dicts of Series that it keeps: `index` and `data`
     # The `data` Series represent all data columns, possibly waiting for aggregation.
     # The `index` Series are used as an index in key lookups, but serve no other purpose but for nice
-    # visualisation when conversion to pandas Dataframes.
+    # visualisation when converting to pandas Dataframes.
     #
     # When a Series is used as an index, it should be free from any pending aggregation (and thus `group_by`
     # should be None, and its `Series.index` should be `{}`.
@@ -125,7 +125,7 @@ class DataFrame:
     # Series in the `index`, should have `Series.index` == `{}`.
     #
     # The rule here: If a series needs a `group_by` to be evaluated, then and only then it should carry that
-    # `group_by`. This implies that index Series coming from a GroupBy, do not carry that group_by. Only
+    # `group_by`. This implies that index Series coming from a GroupBy, do not carry that `group_by`. Only
     # the data columns do.
     #
     # Order is also tracked in `order_by`. It can either be None or a list of SortColumns. Ordering is mostly

--- a/bach/bach/expression.py
+++ b/bach/bach/expression.py
@@ -270,7 +270,7 @@ class SingleValueExpression(Expression):
         # If this Expression is wrapped around a IndependentSubqueryExpression, most likely, there will be
         # just one in here, but let's make sure.
         all_isq = [d.is_independent_subquery for d in self._data if isinstance(d, Expression)]
-        return len(all_isq) and all(all_isq)
+        return len(all_isq) > 0 and all(all_isq)
 
 
 class ConstValueExpression(SingleValueExpression):

--- a/bach/bach/partitioning.py
+++ b/bach/bach/partitioning.py
@@ -68,7 +68,9 @@ class GroupBy:
                 raise ValueError('Aggregate functions can not be used to group, '
                                  'please materialize first.')
 
-            self._index[col.name] = col.copy_override(index={}, group_by=[self])
+            # index columns have no index themselves, and can also be evaluated without group_by as
+            # they will not be aggregated by this group_by
+            self._index[col.name] = col.copy_override(index={}, group_by=[None])
 
     def __eq__(self, other):
         if not isinstance(other, GroupBy):

--- a/bach/bach/series/series.py
+++ b/bach/bach/series/series.py
@@ -36,9 +36,14 @@ class Series(ABC):
     """
     # A series is defined by an expression and a name, and it exists within the scope of the base_node.
     # Its index can be a simple (dict of) Series in case of an already materialised base_node.
-    # If group_by has been set, the index represents the future index of this Series. The series is now part
-    # of the aggregation as defined by the GroupBy and base_node and
-    # can only be evaluated as such.
+    #
+    # If group_by has been set, Series.index represents the future index of this Series. The series is now
+    # part of the aggregation as defined by the GroupBy and base_node and can only be evaluated as such.
+    # If no group_by is set, the expression can be used as is, as is the case for normal column expressions
+    # as well as correctly setup window expressions.
+    #
+    # When a Series is used as an index, it should be free from any pending aggregation (and thus group_by
+    # should be None, and its index should be {}.
     #
     # * Mostly immutable *
     # The attributes of this class are either immutable, or this class is guaranteed not
@@ -80,6 +85,14 @@ class Series(ABC):
         :param group_by: The requested aggregation for this series.
         :param sorted_ascending: None for no sorting, True for sorted ascending, False for sorted descending
         """
+        if index == {} and group_by and group_by.index != {}:
+            # not a completely watertight check, because a group_by on {} is valid.
+            raise ValueError(f'Index Series should be free of pending aggregation.')
+        if group_by and not dict_name_series_equals(group_by.index, index):
+            raise ValueError(f'Series and aggregation index do not match: {group_by.index} != {index}')
+        if not group_by and expression.has_aggregate_function:
+            raise ValueError('Expression has an aggregation function set, but there is no group_by')
+
         self._engine = engine
         self._base_node = base_node
         self._index = copy(index)

--- a/bach/bach/series/series.py
+++ b/bach/bach/series/series.py
@@ -42,6 +42,10 @@ class Series(ABC):
     # If no group_by is set, the expression can be used as is, as is the case for normal column expressions
     # as well as correctly setup window expressions.
     #
+    # The rule here: If a series needs a `group_by` to be evaluated, then and only then it should carry that
+    # `group_by`. This implies that index Series coming from `GroupBy.index`, do not carry that `group_by`.
+    # Only the data Series that actually need the aggregation to happen do.
+    #
     # When a Series is used as an index, it should be free from any pending aggregation (and thus group_by
     # should be None, and its index should be {}.
     #

--- a/bach/tests/functional/bach/test_df.py
+++ b/bach/tests/functional/bach/test_df.py
@@ -161,16 +161,16 @@ def test_materialize_with_non_aggregation_series():
     bt = get_bt_with_test_data()[['municipality', 'founding', 'inhabitants']]
     btg = bt.groupby('municipality')
     assert btg.group_by is not None
-    with pytest.raises(ValueError, match="Series \\['_index_skating_order', 'inhabitants', 'founding'\\] "
-                                         "need\\(s\\) to have an aggregation function set."):
+    with pytest.raises(ValueError, match="groupby set, but contains Series that have no aggregation func.*"
+                                         "\\['_index_skating_order', 'inhabitants', 'founding'\\]"):
         btg.materialize()
 
     assert btg.base_node == bt.base_node
 
     # Add one that's aggregated, should still fail
     btg['founding'] = btg.founding.sum()
-    with pytest.raises(ValueError, match="Series \\['_index_skating_order', 'inhabitants'\\] "
-                                         "need\\(s\\) to have an aggregation function set"):
+    with pytest.raises(ValueError, match="groupby set, but contains Series that have no aggregation func.*"
+                                         "\\['_index_skating_order', 'inhabitants'\\]"):
         btg.materialize()
     assert btg.base_node == bt.base_node
 

--- a/bach/tests/functional/bach/test_df_getitem.py
+++ b/bach/tests/functional/bach/test_df_getitem.py
@@ -158,6 +158,11 @@ def test_get_item_mixed_groupby():
     grouped_other = bt.groupby(bt.municipality.str[:3])
     grouped_other_sum = grouped_other.inhabitants.sum()
 
+    # This does not work because it has to materialize to filter, but no aggregations functions have been
+    # applied yet, so we can't.
+    with pytest.raises(ValueError, match="groupby set, but contains Series that have no aggregation func"):
+        grouped[bt.founding < 1300]
+
     # check that it's illegal to mix different groupings in filters
     with pytest.raises(ValueError, match="Can not apply aggregated BooleanSeries with non matching group_by"):
         grouped[grouped_other_sum > 50000]

--- a/bach/tests/functional/bach/test_df_getitem.py
+++ b/bach/tests/functional/bach/test_df_getitem.py
@@ -113,15 +113,57 @@ def test_get_item_materialize():
         ]
     )
 
+def test_get_item_mixed_groupby():
+    bt = get_bt_with_test_data(full_data_set=True)[['municipality', 'inhabitants', 'founding']]
 
-def test_get_item_slice():
-    bt = get_bt_with_test_data(full_data_set=True)[['municipality']]
-    r = bt[2:5]
+    grouped = bt.groupby('municipality')
+    grouped_sum = grouped.inhabitants.sum()
+    grouped_all_sum = grouped.sum()
 
+    with pytest.raises(ValueError, match="Can not apply aggregated BooleanSeries to a non-grouped df."):
+        bt[grouped_sum > 50000]
+
+    # Okay to apply same grouping filter
     assert_equals_data(
-        r,
-        expected_columns=['_index_skating_order', 'municipality'],
+        grouped_all_sum[grouped_sum > 50000],
+        order_by='inhabitants_sum',
+        expected_columns=['municipality', '_index_skating_order_sum', 'inhabitants_sum', 'founding_sum'],
         expected_data=[
-            [3, 'Súdwest-Fryslân'], [4, 'De Friese Meren'], [5, 'Súdwest-Fryslân']
+            ['Súdwest-Fryslân', 31, 52965, 7864],
+            ['Leeuwarden', 1, 93485, 1285]
         ]
     )
+
+    # Apply a filter on a column of the pre-aggregation df
+    assert_equals_data(
+        grouped_all_sum[bt.founding < 1300],
+        order_by='inhabitants_sum',
+        expected_columns=['municipality', '_index_skating_order_sum', 'inhabitants_sum', 'founding_sum'],
+        expected_data=[
+            ['Súdwest-Fryslân', 14, 4885, 3554], ['Noardeast-Fryslân', 11, 12675, 1298],
+            ['Harlingen', 9, 14740, 1234], ['Leeuwarden', 1, 93485, 1285]
+        ]
+    )
+
+    # Apply a filter on non-aggregated index column of the df
+    assert_equals_data(
+        grouped_all_sum[grouped_all_sum.index['municipality'] == 'Harlingen'],
+        order_by='inhabitants_sum',
+        expected_columns=['municipality', '_index_skating_order_sum', 'inhabitants_sum', 'founding_sum'],
+        expected_data=[
+            ['Harlingen', 9, 14740, 1234]
+        ]
+    )
+
+    grouped_other = bt.groupby(bt.municipality.str[:3])
+    grouped_other_sum = grouped_other.inhabitants.sum()
+
+    # check that it's illegal to mix different groupings in filters
+    with pytest.raises(ValueError, match="Can not apply aggregated BooleanSeries with non matching group_by"):
+        grouped[grouped_other_sum > 50000]
+    # check the other way around for good measure
+    with pytest.raises(ValueError, match="Can not apply aggregated BooleanSeries with non matching group_by"):
+        grouped_other[grouped_sum > 50000]
+    # or the combination of both, behold!
+    with pytest.raises(ValueError, match="rhs has a different base_node or group_by"):
+        grouped_other[grouped_sum > grouped_other_sum]

--- a/bach/tests/unit/bach/test_series.py
+++ b/bach/tests/unit/bach/test_series.py
@@ -2,12 +2,12 @@
 Copyright 2021 Objectiv B.V.
 """
 from bach import get_series_type_from_dtype
+from bach.expression import Expression
 from bach.partitioning import GroupBy
 from tests.unit.bach.util import get_fake_df
 
 
 def test_equals():
-
     left = get_fake_df(['a'], ['b', 'c'])
     right = get_fake_df(['a'], ['b', 'c'])
     result = left['b'].equals(left['b'])
@@ -32,36 +32,47 @@ def test_equals():
 
     int_type = get_series_type_from_dtype('int64')
     float_type = get_series_type_from_dtype('float64')
-    sleft = int_type(engine=None, base_node=None, index={}, name='test', expression='test', group_by=None)
-    sright = int_type(engine=None, base_node=None, index={}, name='test', expression='test', group_by=None)
+
+    expr_test = Expression.construct('test')
+    expr_other = Expression.construct('test::text')
+
+    sleft = int_type(engine=None, base_node=None, index={}, name='test',
+                     expression=expr_test, group_by=None)
+    sright = int_type(engine=None, base_node=None, index={}, name='test',
+                      expression=expr_test, group_by=None)
     assert sleft.equals(sright)
 
     # different expression
-    sright = int_type(engine=None, base_node=None, index={}, name='test', expression='test::text', group_by=None)
+    sright = int_type(engine=None, base_node=None, index={}, name='test',
+                      expression=expr_other, group_by=None)
     assert not sleft.equals(sright)
 
     # different name
-    sright = int_type(engine=None, base_node=None, index={}, name='test_2', expression='test', group_by=None)
+    sright = int_type(engine=None, base_node=None, index={}, name='test_2',
+                      expression=expr_test, group_by=None)
     assert not sleft.equals(sright)
 
     # different base_node
-    sright = int_type(engine=None, base_node='test', index={}, name='test', expression='test', group_by=None)
+    sright = int_type(engine=None, base_node='test', index={}, name='test',
+                      expression=expr_test, group_by=None)
     assert not sleft.equals(sright)
 
     # different engine
-    sright = int_type(engine='test', base_node=None, index={}, name='test', expression='test', group_by=None)
+    sright = int_type(engine='test', base_node=None, index={}, name='test',
+                      expression=expr_test, group_by=None)
     assert not sleft.equals(sright)
 
     # different type
-    sright = float_type(engine=None, base_node=None, index={}, name='test', expression='test', group_by=None)
+    sright = float_type(engine=None, base_node=None, index={}, name='test',
+                        expression=expr_test, group_by=None)
     assert not sleft.equals(sright)
 
     # different group_by
-    sright = float_type(engine=None, base_node=None, index={}, name='test', expression='test',
+    sright = float_type(engine=None, base_node=None, index={}, name='test', expression=expr_test,
                         group_by=GroupBy(group_by_columns=[]))
     assert not sleft.equals(sright)
 
     # different sorting
-    sright = float_type(engine=None, base_node=None, index={}, name='test', expression='test',
+    sright = float_type(engine=None, base_node=None, index={}, name='test', expression=expr_test,
                         sorted_ascending=True, group_by=None)
     assert not sleft.equals(sright)


### PR DESCRIPTION
Slightly change how we deal with `group_by` and `index` and Series and DataFrame.
Made possible by the fact that WindowFunctionExpressions are now their own type, so based on https://github.com/objectiv/objectiv-analytics/pull/293

From the added docs:
```
    # When a Series is used as an index, it should be free from any pending aggregation (and thus `group_by`
    # should be None, and its `Series.index` should be `{}`.
    #
    # `DataFrame.group_by` should always match the `Series.group_by` for all Series in the `data` dict.
    # Series in the `index`, should have `Series.index` == `{}`.
    #
    # The rule here: If a series needs a `group_by` to be evaluated, then and only then it should carry that
    # `group_by`. This implies that index Series coming from a GroupBy, do not carry that `group_by`. Only
    # the data columns do.
```

Main changes:
- Remove group_by from Series that are an index and add consistency checks around that to constructors.
- Add some documentation around how `Series.index`, `Series.group_by` and `DataFrame.group_by` interact.
- Make `DataFrame.__getitem__` more flexible, and improve #docs on how that all works
- Extend tests to deal with new situations.