### PR TITLE
Bach: Clean up datetime operations

### DIFF
--- a/analysis/notebooks/product_analytics.ipynb
+++ b/analysis/notebooks/product_analytics.ipynb
@@ -182,7 +182,7 @@
     "agg_level = 'YYYYMMDD'\n",
     "\n",
     "# add the time aggregation as new column to the dataframes, so we can group on this later\n",
-    "df['time_aggregation'] = df['moment'].format(agg_level)"
+    "df['time_aggregation'] = df['moment'].dt.sql_format(agg_level)"
    ]
   },
   {

--- a/bach/bach/series/__init__.py
+++ b/bach/bach/series/__init__.py
@@ -9,4 +9,4 @@ from bach.series.series_uuid import SeriesUuid
 from bach.series.series_json import SeriesJson, SeriesJsonb
 from bach.series.series_string import SeriesString
 from bach.series.series_datetime import \
-    SeriesDate, SeriesTime, SeriesTimestamp, SeriesTimedelta
+    SeriesAbstractDateTime, SeriesDate, SeriesTime, SeriesTimestamp, SeriesTimedelta

--- a/bach/bach/series/series_datetime.py
+++ b/bach/bach/series/series_datetime.py
@@ -229,7 +229,7 @@ class SeriesTimedelta(SeriesAbstractDateTime):
             return Expression.construct('cast({} as interval)', expression)
 
     def _comparator_operation(self, other, comparator,
-                              other_dtypes=('timedelta', 'string')) -> 'SeriesBoolean':
+                              other_dtypes=('timedelta', 'string')) -> SeriesBoolean:
         return super()._comparator_operation(other, comparator, other_dtypes)
 
     def __add__(self, other) -> 'Series':

--- a/bach/bach/series/series_datetime.py
+++ b/bach/bach/series/series_datetime.py
@@ -31,7 +31,8 @@ class DateTimeOperation:
 
         :returns: a SeriesString containing the formatted date.
         """
-        expression = Expression.construct(f"to_char({{}}, '{format_str}')", self._series)
+        expression = Expression.construct('to_char({}, {})',
+                                          self._series, Expression.string_value(format_str))
         return self._series.copy_override(dtype='string', expression=expression)
 
 

--- a/bach/bach/series/series_datetime.py
+++ b/bach/bach/series/series_datetime.py
@@ -12,7 +12,7 @@ from bach.expression import Expression
 from bach.series.series import WrappedPartition
 
 
-class DateOperation:
+class DateTimeOperation:
     def __init__(self, series: 'SeriesAbstractDateTime'):
         self._series = series
 
@@ -26,8 +26,8 @@ class DateOperation:
 
         .. code-block:: python
 
-            df['year'] = df.some_date_series.dt.format('YYYY')  # return year
-            df['date'] = df.some_date_series.dt.format('YYYYMMDD')  # return date
+            df['year'] = df.some_date_series.dt.sql_format('YYYY')  # return year
+            df['date'] = df.some_date_series.dt.sql_format('YYYYMMDD')  # return date
 
         :returns: a SeriesString containing the formatted date.
         """
@@ -45,21 +45,19 @@ class SeriesAbstractDateTime(Series, ABC):
     On any of the subtypes, you can access date operations through the `dt` accessor.
     """
     @property
-    def dt(self) -> DateOperation:
+    def dt(self) -> DateTimeOperation:
         """
         Get access to date operations.
 
-        .. autoclass:: bach.series.series_datetime.StringOperation
+        .. autoclass:: bach.series.series_datetime.DateTimeOperation
             :members:
 
         """
-        return DateOperation(self)
+        return DateTimeOperation(self)
 
     def _comparator_operation(self, other, comparator,
                               other_dtypes=('timestamp', 'date', 'time', 'string')) -> 'SeriesBoolean':
         return super()._comparator_operation(other, comparator, other_dtypes)
-
-
 
     @classmethod
     def _cast_to_date_if_dtype_date(cls, series: 'Series') -> 'Series':

--- a/bach/docs/source/Series.rst
+++ b/bach/docs/source/Series.rst
@@ -88,6 +88,7 @@ Reference
     Series
     SeriesBoolean
     SeriesAbstractNumeric
+    SeriesAbstractDateTime
     SeriesString
     SeriesJsonb
     SeriesJson

--- a/bach/tests/functional/bach/test_series_date.py
+++ b/bach/tests/functional/bach/test_series_date.py
@@ -85,10 +85,10 @@ def test_date_format():
     assert mt['moment'].dtype == 'timestamp'
     assert mt['date'].dtype == 'date'
 
-    assert mt['moment'].format('YYYY').dtype == 'string'
+    assert mt['moment'].dt.sql_format('YYYY').dtype == 'string'
 
-    mt['fyyyy'] = mt['moment'].format('YYYY')
-    mt['fday'] = mt['date'].format('Day')
+    mt['fyyyy'] = mt['moment'].dt.sql_format('YYYY')
+    mt['fday'] = mt['date'].dt.sql_format('Day')
 
     assert_equals_data(
         mt[['fyyyy', 'fday']],


### PR DESCRIPTION
- Move datetime operations to `dt` accessor
- Rename `format` -> `sql_format`

```
# old syntax
df['year'] = df.some_date_series.format('YYYY') 

# new syntax
df['year'] = df.some_date_series.dt.format('YYYY')
```
Includes some more fancy docs:
![image](https://user-images.githubusercontent.com/10804239/142634651-db44136a-6d23-436a-b37d-672f00d3a3c4.png)
