### PR TITLE
Bach: Add copy() to Series and DataFrame

### DIFF
--- a/bach/bach/dataframe.py
+++ b/bach/bach/dataframe.py
@@ -510,6 +510,21 @@ class DataFrame:
             order_by=order_by
         )
 
+    def copy(self):
+        """
+        Return a copy of this DataFrame.
+
+        As this dataframe only represents data in the backing SQL store, and does not contain any data,
+        this is a metadata copy only, no actual data is duplicated and changes to the underlying data
+        will represented in both copy and original.
+        Changes to data, index, sorting, grouping etc. on the copy will not affect the original.
+
+        If you want to create a snapshot of the data, have a look at :py:meth:`get_sample()`
+
+        :returns: a copy of the dataframe
+        """
+        return self.copy_override()
+
     def materialize(self, node_name='manual_materialize', inplace=False, limit: Any = None) -> 'DataFrame':
         """
         Create a copy of this DataFrame with as base_node the current DataFrame's state.

--- a/bach/bach/series/series.py
+++ b/bach/bach/series/series.py
@@ -284,6 +284,21 @@ class Series(ABC):
         )
         return result
 
+    def copy(self):
+        """
+        Return a copy of this Series.
+
+        As this series only represents data in the backing SQL store, and does not contain any data,
+        this is a metadata copy only, no actual data is duplicated and changes to the underlying data
+        will represented in both copy and original.
+        Changes to index, sorting, grouping etc. on the copy will not affect the original.
+
+        If you want to create a snapshot of the data, have a look at :py:meth:`bach.DataFrame.get_sample()`
+
+        :returns: a copy of the series
+        """
+        return self.copy_override()
+
     def copy_override(self,
                       dtype=None,
                       engine=None,

--- a/bach/docs/source/DataFrame.rst
+++ b/bach/docs/source/DataFrame.rst
@@ -88,7 +88,7 @@ Creation
     DataFrame.from_table
     DataFrame.from_model
     DataFrame.from_pandas
-
+    DataFrame.copy
 
 Value accessors
 ~~~~~~~~~~~~~~~

--- a/bach/docs/source/Series.rst
+++ b/bach/docs/source/Series.rst
@@ -102,6 +102,7 @@ Creation / re-framing
 
     Series.from_const
     Series.to_frame
+    Series.copy
 
 Value accessors
 ~~~~~~~~~~~~~~~


### PR DESCRIPTION
No materialization is done, it's a real, simple copy. Added both in code and docs.
```
copy = df.copy()
df.drop( ... )

# magically everything still in copy
copy.do_something_useful()
```