### PR TITLE
Remove 'set up a dev environment' link

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ Check out [objectiv.io](https://www.objectiv.io) to learn more.
 
 1. [Play with Objectiv](https://notebook.objectiv.io/lab?path=product_analytics.ipynb) in our Live Demo Notebook
 2. [Test drive Objectiv locally](https://www.objectiv.io/docs/quickstart-guide) with a fully functional demo pipeline
-3. [Spin up a local development setup](https://www.objectiv.io/docs/how-to-guides/collector/getting-started) with just the essentials and no demo data
 
 ## Useful Resources
 


### PR DESCRIPTION
Remove 'set up a dev environment' link until the guide is fixed and in place.