### PR TITLE
Add link to updated collector guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Check out [objectiv.io](https://www.objectiv.io) to learn more.
 
 1. [Play with Objectiv](https://notebook.objectiv.io/lab?path=product_analytics.ipynb) in our Live Demo Notebook
 2. [Test drive Objectiv locally](https://www.objectiv.io/docs/quickstart-guide) with a fully functional demo pipeline
+3. [Spin up a collector and data store](https://objectiv.io/docs/how-to-guides/collector/getting-started) for local development without any demo data
 
 ## Useful Resources
 


### PR DESCRIPTION
**Requires the changes from https://github.com/objectiv/objectiv.io/pull/156 to be deployed on live, or it will point to the outdated collector guide.**

Re-adds the link to the (updated) collector guide