### PR TITLE
Bach sample changes

### DIFF
--- a/bach/bach/dataframe.py
+++ b/bach/bach/dataframe.py
@@ -347,6 +347,9 @@ class DataFrame:
         a DataFrame will change it to be not materialized. Calling :py:meth:`materialize` on a
         non-materialized DataFrame will return a new DataFrame that is materialized.
 
+        TODO: a known problem is that DataFrames with 'json' columns are never in a materialized state, and
+         cannot be materialized with materialize()
+
         :returns: True if this DataFrame is in a materialized state, False otherwise
         """
         if self.group_by or self.order_by:
@@ -577,6 +580,8 @@ class DataFrame:
         expressions that you want to evaluate before further expressions are build on top of them. This might
         make sense for very large expressions, or for non-deterministic expressions (e.g. see
         :py:meth:`SeriesUuid.sql_gen_random_uuid`).
+
+        TODO: a known problem is that DataFrames with 'json' columns cannot be fully materialized.
 
         :param node_name: The name of the node that's going to be created
         :param inplace: Perform operation on self if ``inplace=True``, or create a copy. Not supported yet.

--- a/bach/bach/dataframe.py
+++ b/bach/bach/dataframe.py
@@ -619,6 +619,9 @@ class DataFrame:
         Use :py:meth:`get_unsampled` to switch back to the unsampled data later on. This returns a new
         DataFrame with all operations that have been done on the sample, applied to that DataFrame.
 
+        This function requires the DataFrame to be in a materialized state (see :py:attr:`is_materialized`),
+        otherwise an exception is raised.
+
         :param table_name: the name of the underlying sql table that stores the sampled data.
         :param filter: a filter to apply to the dataframe before creating the sample. If a filter is applied,
             sample_percentage is ignored and thus the bernoulli sample creation is skipped.

--- a/bach/bach/merge.py
+++ b/bach/bach/merge.py
@@ -220,26 +220,7 @@ def merge(
         suffixes: Tuple[str, str]
 ) -> DataFrame:
     """
-    Join the left and right Dataframes, or a DataFrame (left) and a Series (right). This will return a new
-    DataFrame that contains the combined columns of both dataframes, and the rows that result from joining
-    on the specified columns. The columns that are joined on can consists (partially or fully) out of index
-    columns.
-
-    If the column names on the left and right conflict, then the suffixes are used to distinguish them in the
-    resulting DataFrame. The algorithm for determining the resulting columns and their names is similar to
-    Pandas, but has slight differences when joining on indices and column names conflict.
-
-    :param left: left DataFrame
-    :param right: DataFrame or Series to join on left
-    :param how: supported values: {‘left’, ‘right’, ‘outer’, ‘inner’, ‘cross’}
-    :param on: optional, column(s) to join left and right on.
-    :param left_on: optional, column(s) from the left df to join on
-    :param right_on: optional, column(s) from the right df/series to join on
-    :param left_index: If true uses the index of the left df as columns to join on
-    :param right_index: If true uses the index of the right df/series as columns to join on
-    :param suffixes: Tuple of two strings. Will be used to suffix duplicate column names. Must make column
-        names unique
-    :return: A new Dataframe. The original frames are not modified.
+    See :py:meth:`bach.DataFrame.merge` for more information.
     """
     if how not in ('left', 'right', 'outer', 'inner', 'cross'):
         raise ValueError(f"how must be one of ('left', 'right', 'outer', 'inner', 'cross'), value: {how}")

--- a/bach/bach/sample.py
+++ b/bach/bach/sample.py
@@ -25,7 +25,11 @@ def get_sample(df: DataFrame,
     if sample_percentage is None and filter is None:
         raise ValueError('Either sample_percentage or filter must be set')
 
-    original_node = df.get_current_node(name='before_sampling')
+    if not df.is_materialized:
+        raise ValueError("Cannot call get_sample on a non-materialized dataframe. "
+                         "Call materialize() first.")
+
+    original_node = df.base_node
     if filter is not None:
         sample_percentage = None
         from bach.series import SeriesBoolean

--- a/bach/bach/sample.py
+++ b/bach/bach/sample.py
@@ -38,10 +38,6 @@ def get_sample(df: DataFrame,
         # Boolean argument implies return type of self[filter], help mypy a bit
         df = cast('DataFrame', df[filter])
 
-    if df._group_by is not None:
-        raise NotImplementedError('Dataframes that have an active grouping can currently not be sampled. '
-                                  'Call df.materialize() first.')
-
     with df.engine.connect() as conn:
         if overwrite:
             sql = f'DROP TABLE IF EXISTS {quote_identifier(table_name)}'

--- a/bach/bach/sample.py
+++ b/bach/bach/sample.py
@@ -1,0 +1,100 @@
+"""
+Copyright 2021 Objectiv B.V.
+"""
+from typing import cast, TYPE_CHECKING
+
+from bach import DataFrame
+from bach.dataframe import escape_parameter_characters
+from bach.sql_model import SampleSqlModel
+from sql_models.graph_operations import find_node, replace_node_in_graph
+from sql_models.util import quote_identifier
+
+if TYPE_CHECKING:
+    from bach import SeriesBoolean
+
+
+def get_sample(df: DataFrame,
+               table_name: str,
+               filter: 'SeriesBoolean' = None,
+               sample_percentage: int = None,
+               overwrite: bool = False,
+               seed: int = None) -> 'DataFrame':
+    """
+    See :py:meth:`bach.DataFrame.get_sample` for more information.
+    """
+    if sample_percentage is None and filter is None:
+        raise ValueError('Either sample_percentage or filter must be set')
+
+    original_node = df.get_current_node(name='before_sampling')
+    if filter is not None:
+        sample_percentage = None
+        from bach.series import SeriesBoolean
+        if not isinstance(filter, SeriesBoolean):
+            raise TypeError('Filter parameter needs to be a SeriesBoolean instance.')
+        # Boolean argument implies return type of self[filter], help mypy a bit
+        df = cast('DataFrame', df[filter])
+
+    if df._group_by is not None:
+        raise NotImplementedError('Dataframes that have an active grouping can currently not be sampled. '
+                                  'Call df.materialize() first.')
+
+    with df.engine.connect() as conn:
+        if overwrite:
+            sql = f'DROP TABLE IF EXISTS {quote_identifier(table_name)}'
+            sql = escape_parameter_characters(conn, sql)
+            conn.execute(sql)
+
+        if sample_percentage:
+            repeatable = f'repeatable ({seed})' if seed else ''
+
+            sql = f'''
+                create temporary table tmp_table_name on commit drop as
+                ({df.view_sql()});
+                create temporary table {quote_identifier(table_name)} as
+                (select * from tmp_table_name
+                tablesample bernoulli({sample_percentage}) {repeatable})
+            '''
+        else:
+            sql = f'create temporary table {quote_identifier(table_name)} as ({df.view_sql()})'
+        sql = escape_parameter_characters(conn, sql)
+        conn.execute(sql)
+
+    # Use SampleSqlModel, that way we can keep track of the current_node and undo this sampling
+    # in get_unsampled() by switching this new node for the old node again.
+    new_base_node = SampleSqlModel(table_name=table_name, previous=original_node)
+
+    return DataFrame.get_instance(
+        engine=df.engine,
+        base_node=new_base_node,
+        index_dtypes=df.index_dtypes,
+        dtypes=df.dtypes,
+        group_by=None
+    )
+
+
+def get_unsampled(df) -> 'DataFrame':
+    """
+    See :py:meth:`bach.DataFrame.get_unsampled` for more information.
+    """
+    if df._group_by:
+        df = df.materialize(node_name='get_unsampled')
+
+    # The returned DataFrame has a modified base_node graph, in which the node that introduced the
+    # sampling is removed.
+    sampled_node_tuple = find_node(
+        start_node=df.base_node,
+        function=lambda node: isinstance(node, SampleSqlModel)
+    )
+    if sampled_node_tuple is None:
+        raise ValueError('No sampled node found. Cannot un-sample data that has not been sampled.')
+
+    assert isinstance(sampled_node_tuple.model, SampleSqlModel)  # help mypy
+    updated_graph = replace_node_in_graph(
+        start_node=df.base_node,
+        reference_path=sampled_node_tuple.reference_path,
+        replacement_model=sampled_node_tuple.model.previous
+    )
+
+    index = {s.name: s.copy_override(base_node=updated_graph) for s in df._index.values()}
+    series = {s.name: s.copy_override(base_node=updated_graph, index=index) for s in df._data.values()}
+    return df.copy_override(base_node=updated_graph, index=index, series=series)

--- a/bach/bach/series/series.py
+++ b/bach/bach/series/series.py
@@ -862,6 +862,8 @@ class Series(ABC):
         else:
             if isinstance(wrapped, DataFrame):
                 unwrapped = wrapped.group_by
+                if unwrapped is None:
+                    unwrapped = GroupBy([])
             else:
                 unwrapped = wrapped
 

--- a/bach/tests/functional/bach/test_df.py
+++ b/bach/tests/functional/bach/test_df.py
@@ -216,3 +216,36 @@ def test_materialize_non_deterministic_expressions():
             [3, 'Drylts', ANY, ANY, False, ANY, True],
         ]
     assert_equals_data(bt, expected_columns=expected_columns, expected_data=expected_data)
+
+
+def test_is_materialized():
+    df_original = get_bt_with_test_data()
+    assert df_original.is_materialized
+    df = df_original.copy()
+    assert df.is_materialized
+
+    # adding column
+    df['x'] = 'test'
+    assert not df.is_materialized
+    del df['x']
+    assert df.is_materialized
+
+    # group by
+    df = df.groupby('municipality')
+    assert not df.is_materialized
+
+    # sort_values
+    df = df_original.copy()
+    assert df.is_materialized
+    df = df.sort_values('city')
+    assert not df.is_materialized
+
+
+    # switching columns
+    df = df_original.copy()
+    assert df.is_materialized
+    df['x'] = df['municipality']
+    df['municipality'] = df['city']
+    df['city'] = df['x']
+    del df['x']
+    assert not df.is_materialized

--- a/bach/tests/unit/bach/test_expression.py
+++ b/bach/tests/unit/bach/test_expression.py
@@ -144,7 +144,7 @@ def test_is_constant():
     assert not WindowFunctionExpression.construct('agg({}, {}, {})', const1, const2, const3).is_constant
 
 
-def test_is_constant():
+def test_is_single_value():
     df = get_fake_df(['i'], ['duration', 'irrelevant'])
     notsingle1 = Expression.column_reference('year')
     notsingle2 = Expression.construct('cast({} as bigint)', df.duration)


### PR DESCRIPTION
Change: Do not insert an additional node when calling `get_sample()`. This ensures that the DataFrame returned by `get_unsampled()` is compatible with the original DF.

To make this possible there is a new requirement to users calling `get_sample()` tho: The dataframe must be in a materialized state.

Other changes:
* Moved some code. Might be easiest to review this code per commit. As all code moving is in 59513106b7547d17d97913fade56695a91c459b2 (=first commit), and the actual changes are in ff4a359cddadca97af591580c529b10471931462 and c18aef8694d271706cc811439af5568748cc99ce
* Add some type annotations