### PR TITLE
Remove roadmap references

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ Check out [objectiv.io](https://www.objectiv.io) to learn more.
 * [Objectiv Docs](https://www.objectiv.io/docs) - Objectiv's official documentation.
 * [Objectiv on Slack](https://join.slack.com/t/objectiv-io/shared_invite/zt-u6xma89w-DLDvOB7pQer5QUs5B_~5pg) - Get help & join the discussion on where to take Objectiv next.
 * [Contribution Guide](https://www.objectiv.io/docs/the-project/contribute) - Report bugs, request features and contribution information.
-* [Github Roadmap](https://github.com/objectiv/objectiv-analytics/projects/2) - Learn about Objectiv's future plans.
 
 
 This repository is part of the source code for Objectiv, which is released under the Apache 2.0 License. Please refer to [LICENSE.md](LICENSE.md) for details. Unless otherwise noted, all files © 2021 Objectiv B.V.

--- a/analysis/bach_open_taxonomy/README.md
+++ b/analysis/bach_open_taxonomy/README.md
@@ -17,9 +17,6 @@ If you’ve found an issue or have a feature request, please check out the [Cont
 ## Security Disclosure
 Found a security issue? Please don’t use the issue tracker but contact us directly. See [SECURITY.md](../SECURITY.md) for details.
 
-## Roadmap
-Future plans for Objectiv can be found on our [Github Roadmap](https://github.com/objectiv/objectiv-analytics/projects/2).
-
 ## Custom development & contributing code
 If you want to contribute to Objectiv or use it as a base for custom development, take a look at [CONTRIBUTING.md](CONTRIBUTING.md). It contains detailed development instructions and a link to information about our contribution process and where you can fit in.
 

--- a/bach/README.md
+++ b/bach/README.md
@@ -28,9 +28,6 @@ If you’ve found an issue or have a feature request, please check out the [Cont
 ## Security Disclosure
 Found a security issue? Please don’t use the issue tracker but contact us directly. See [SECURITY.md](../SECURITY.md) for details.
 
-## Roadmap
-Future plans for Objectiv can be found on our [Github Roadmap](https://github.com/objectiv/objectiv-analytics/projects/2).
-
 ## Custom development & contributing code
 If you want to contribute to Objectiv or use it as a base for custom development, take a look at [CONTRIBUTING.md](CONTRIBUTING.md). It contains detailed development instructions and a link to information about our contribution process and where you can fit in.
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -26,9 +26,6 @@ If you’ve found an issue or have a feature request, please check out the [Cont
 ## Security Disclosure
 Found a security issue? Please don’t use the issue tracker but contact us directly. See [SECURITY.md](../SECURITY.md) for details.
 
-## Roadmap
-Future plans for Objectiv can be found on our [Github Roadmap](https://github.com/objectiv/objectiv-analytics/projects/2).
-
 ## Custom Development & Contributing Code
 If you want to contribute to Objectiv or use it as a base for custom development, take a look at [CONTRIBUTING.md](CONTRIBUTING.md). It contains detailed development instructions and a link to information about our contribution process and where you can fit in.
 

--- a/schema/README.md
+++ b/schema/README.md
@@ -2,7 +2,7 @@
 
 The Open Taxonomy for Analytics is Objectiv’s proposal for a common way to collect, structure and validate data. It defines classes for each common event type and the contexts in which they can happen. It describes their properties, requirements and their relationships with other classes. 
 
-The current version of the taxonomy is built for product analytics. We have plans to support other fields as well. Check out our [Github Roadmap](https://github.com/objectiv/objectiv-analytics/projects/2) for details. 
+The current version of the taxonomy is built for product analytics. We have plans to support other fields as well.
 
 Objectiv uses the Open Taxonomy to:
 * Enable realtime validation of instrumentation and provide debugging feedback.
@@ -25,9 +25,6 @@ If you’ve found an issue or have a feature request, please check out the [Cont
 
 ## Security Disclosure
 Found a security issue? Please don’t use the issue tracker but contact us directly. See [SECURITY.md](../SECURITY.md) for details.
-
-## Roadmap
-Future plans for Objectiv can be found on our [Github Roadmap](https://github.com/objectiv/objectiv-analytics/projects/2).
 
 ## Custom Development & Contributing Code
 If you want to contribute to the Open Taxonomy or use it as a base for custom development, take a look at [CONTRIBUTING.md](CONTRIBUTING.md). It contains detailed development instructions and a link to information about our contribution process and where you can fit in.

--- a/tracker/README.md
+++ b/tracker/README.md
@@ -24,9 +24,6 @@ If you’ve found an issue or have a feature request, please check out the [Cont
 ## Security Disclosure
 Found a security issue? Please don’t use the issue tracker but contact us directly. See [SECURITY.md](../SECURITY.md) for details.
 
-## Roadmap
-Future plans for Objectiv can be found on our [Github Roadmap](https://github.com/objectiv/objectiv-analytics/projects/2).
-
 ## Custom Development & Contributing Code
 If you want to contribute to Objectiv or use it as a base for custom development, take a look at [CONTRIBUTING.md](CONTRIBUTING.md). It contains detailed development instructions and a link to information about our contribution process and where you can fit in.
 


### PR DESCRIPTION
We're moving to another solution, so let's remove the links to the roadmap in GitHub for now.