### PR TITLE
Remove automatic tracking for visibility events of regular sections

### DIFF
--- a/tracker/core/tracker/tests/TrackerTransport.test.ts
+++ b/tracker/core/tracker/tests/TrackerTransport.test.ts
@@ -366,7 +366,6 @@ describe('TrackerTransportRetry', () => {
   });
 
   it('should stop retrying if we reached maxRetryMs', async () => {
-    jest.useRealTimers();
     const slowFailingTransport = {
       transportName: 'SlowFailingTransport',
       handle: async () => new Promise((_, reject) => setTimeout(() => reject(new TransportSendError()), 100)),
@@ -386,6 +385,8 @@ describe('TrackerTransportRetry', () => {
     await expect(retryTransportAttempt.run()).rejects.toEqual(
       expect.arrayContaining([new Error('maxRetryMs reached')])
     );
+
+    jest.runAllTimers();
 
     expect(retryTransportAttempt.retry).toHaveBeenCalledTimes(1);
     expect(slowFailingTransport.handle).toHaveBeenCalledTimes(1);

--- a/tracker/trackers/browser/src/definitions/LocationContext.ts
+++ b/tracker/trackers/browser/src/definitions/LocationContext.ts
@@ -231,3 +231,10 @@ export type AnyActionContext = Infer<typeof AnyActionContext>;
 export const AnyClickableContext = union([AnyActionContext, ExpandableSectionContext]);
 
 export type AnyClickableContext = Infer<typeof AnyClickableContext>;
+
+/**
+ * Struct union to match any Showable Context, that is Overlays and ExpandableSectionContext
+ */
+export const AnyShowableContext = union([OverlayContext, ExpandableSectionContext]);
+
+export type AnyShowableContext = Infer<typeof AnyShowableContext>;

--- a/tracker/trackers/browser/src/locationTaggers/tagLocation.ts
+++ b/tracker/trackers/browser/src/locationTaggers/tagLocation.ts
@@ -10,7 +10,7 @@ import { stringifyTrackClicks } from '../common/stringifiers/stringifyTrackClick
 import { stringifyTrackVisibility } from '../common/stringifiers/stringifyTrackVisibility';
 import { stringifyValidate } from '../common/stringifiers/stringifyValidate';
 import { trackerErrorHandler } from '../common/trackerErrorHandler';
-import { AnyClickableContext, AnySectionContext, InputContext } from '../definitions/LocationContext';
+import { AnyClickableContext, AnyShowableContext, InputContext } from '../definitions/LocationContext';
 import { TaggingAttribute } from '../definitions/TaggingAttribute';
 import { TagLocationAttributes } from '../definitions/TagLocationAttributes';
 import { TagLocationParameters } from '../definitions/TagLocationParameters';
@@ -38,12 +38,12 @@ export const tagLocation = (parameters: TagLocationParameters): TagLocationRetur
     // Determine Context type
     const isClickable = is(instance, AnyClickableContext);
     const isInput = is(instance, InputContext);
-    const isSection = is(instance, AnySectionContext);
+    const isShowable = is(instance, AnyShowableContext);
 
     // Process options. Gather default attribute values
     const trackClicks = options?.trackClicks ?? (isClickable ? true : undefined);
     const trackBlurs = options?.trackBlurs ?? (isInput ? true : undefined);
-    const trackVisibility = options?.trackVisibility ?? (isSection ? { mode: 'auto' } : undefined);
+    const trackVisibility = options?.trackVisibility ?? (isShowable ? { mode: 'auto' } : undefined);
     const parentElementId = options?.parent ? options.parent[TaggingAttribute.elementId] : undefined;
 
     // Create output attributes object

--- a/tracker/trackers/browser/tests/structs.test.ts
+++ b/tracker/trackers/browser/tests/structs.test.ts
@@ -22,7 +22,7 @@ import {
   ValidateAttribute,
 } from '../src';
 
-describe('Custom structs', () => {
+describe('structs', () => {
   describe('Location Contexts', () => {
     it('Should stringify and parse Section Context', () => {
       const context = makeSectionContext({ id: 'test' });
@@ -192,6 +192,7 @@ describe('Custom structs', () => {
             [TaggingAttribute.parentElementId]: undefined,
             [TaggingAttribute.trackBlurs]: undefined,
             [TaggingAttribute.trackClicks]: undefined,
+            [TaggingAttribute.trackVisibility]: undefined,
             [TaggingAttribute.validate]: undefined,
           },
         }))

--- a/tracker/trackers/browser/tests/tagLocation.test.ts
+++ b/tracker/trackers/browser/tests/tagLocation.test.ts
@@ -79,7 +79,6 @@ describe('tagLocation', () => {
         _type: 'SectionContext',
         id: 'test',
       }),
-      [TaggingAttribute.trackVisibility]: '{"mode":"auto"}',
     });
     expect(
       tagElement({
@@ -114,7 +113,6 @@ describe('tagLocation', () => {
         _type: 'SectionContext',
         id: 'test',
       }),
-      [TaggingAttribute.trackVisibility]: '{"mode":"auto"}',
     });
     expect(tagElement({ id: 'test', options: { parent } })).toStrictEqual({
       [TaggingAttribute.elementId]: matchUUID,
@@ -126,7 +124,6 @@ describe('tagLocation', () => {
         _type: 'SectionContext',
         id: 'test',
       }),
-      [TaggingAttribute.trackVisibility]: '{"mode":"auto"}',
     });
   });
 
@@ -162,7 +159,6 @@ describe('tagLocation', () => {
         _type: 'SectionContext',
         id: 'test-section',
       }),
-      [TaggingAttribute.trackVisibility]: '{"mode":"auto"}',
     };
 
     expect(taggingAttributes).toStrictEqual(expectedTaggingAttributes);
@@ -238,7 +234,6 @@ describe('tagLocation', () => {
         _type: 'MediaPlayerContext',
         id: 'test-media-player',
       }),
-      [TaggingAttribute.trackVisibility]: '{"mode":"auto"}',
     };
 
     expect(taggingAttributes).toStrictEqual(expectedTaggingAttributes);
@@ -255,7 +250,6 @@ describe('tagLocation', () => {
         _type: 'NavigationContext',
         id: 'test-nav',
       }),
-      [TaggingAttribute.trackVisibility]: '{"mode":"auto"}',
     };
 
     expect(taggingAttributes).toStrictEqual(expectedTaggingAttributes);

--- a/tracker/trackers/browser/tests/tagLocationHelpers.test.ts
+++ b/tracker/trackers/browser/tests/tagLocationHelpers.test.ts
@@ -92,7 +92,6 @@ describe('tagLocationHelpers', () => {
         _type: 'SectionContext',
         id: 'test-section',
       }),
-      [TaggingAttribute.trackVisibility]: '{"mode":"auto"}',
     };
 
     expect(taggingAttributes).toStrictEqual(expectedTaggingAttributes);
@@ -164,7 +163,6 @@ describe('tagLocationHelpers', () => {
         _type: 'MediaPlayerContext',
         id: 'test-media-player',
       }),
-      [TaggingAttribute.trackVisibility]: '{"mode":"auto"}',
     };
 
     expect(taggingAttributes).toStrictEqual(expectedTaggingAttributes);
@@ -181,7 +179,6 @@ describe('tagLocationHelpers', () => {
         _type: 'NavigationContext',
         id: 'test-nav',
       }),
-      [TaggingAttribute.trackVisibility]: '{"mode":"auto"}',
     };
 
     expect(taggingAttributes).toStrictEqual(expectedTaggingAttributes);

--- a/tracker/trackers/browser/tests/trackNewElements.test.ts
+++ b/tracker/trackers/browser/tests/trackNewElements.test.ts
@@ -3,15 +3,15 @@
  */
 
 import { matchUUID } from '@objectiv/testing-tools';
-import { generateUUID, makeSectionContext } from '@objectiv/tracker-core';
+import { generateUUID, makeOverlayContext } from '@objectiv/tracker-core';
 import {
   BrowserTracker,
   getTracker,
   getTrackerRepository,
   makeTracker,
   tagButton,
-  tagElement,
   TaggingAttribute,
+  tagOverlay,
 } from '../src';
 import { trackNewElements } from '../src/mutationObserver/trackNewElements';
 
@@ -35,7 +35,7 @@ describe('trackNewElements', () => {
       TaggingAttribute.tagChildren,
       JSON.stringify([
         { queryAll: '#button', tagAs: tagButton({ id: 'button', text: 'button' }) },
-        { queryAll: '#child-div', tagAs: tagElement({ id: 'child-div' }) },
+        { queryAll: '#child-div', tagAs: tagOverlay({ id: 'child-div' }) },
       ])
     );
 
@@ -64,7 +64,7 @@ describe('trackNewElements', () => {
         _type: 'SectionVisibleEvent',
         id: matchUUID,
         global_contexts: [],
-        location_stack: [makeSectionContext({ id: 'child-div' })],
+        location_stack: [makeOverlayContext({ id: 'child-div' })],
       })
     );
   });


### PR DESCRIPTION
As discussed, visibility tracking is a complex topic and we decided to only track those events automatically when we are 100% sure we are doing it correctly. 

This PR switches visibility automatic tracking off exception made for Overlays and Expandable contexts.