### PR TITLE
Bach generic improvements

### DIFF
--- a/bach/bach/dataframe.py
+++ b/bach/bach/dataframe.py
@@ -8,7 +8,7 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.future import Connection
 
 from bach.expression import Expression, SingleValueExpression
-from bach.sql_model import BachSqlModel, SampleSqlModel
+from bach.sql_model import BachSqlModelBuilder, SampleSqlModel
 from bach.types import get_series_type_from_dtype, get_dtype_from_db_dtype
 from sql_models.graph_operations import replace_node_in_graph, find_node
 from sql_models.model import SqlModel
@@ -134,7 +134,7 @@ class DataFrame:
     def __init__(
             self,
             engine: Engine,
-            base_node: SqlModel[BachSqlModel],
+            base_node: SqlModel[BachSqlModelBuilder],
             index: Dict[str, 'Series'],
             series: Dict[str, 'Series'],
             group_by: Optional['GroupBy'],
@@ -189,7 +189,7 @@ class DataFrame:
     def copy_override(
             self,
             engine: Engine = None,
-            base_node: SqlModel[BachSqlModel] = None,
+            base_node: SqlModel[BachSqlModelBuilder] = None,
             index: Dict[str, 'Series'] = None,
             series: Dict[str, 'Series'] = None,
             group_by: List[Union['GroupBy', None]] = None,  # List so [None] != None
@@ -265,7 +265,7 @@ class DataFrame:
         return self._engine
 
     @property
-    def base_node(self) -> SqlModel[BachSqlModel]:
+    def base_node(self) -> SqlModel[BachSqlModelBuilder]:
         """
         INTERNAL: Get the current base node
         """
@@ -374,8 +374,8 @@ class DataFrame:
             self._order_by == other._order_by
 
     @classmethod
-    def _get_dtypes(cls, engine: Engine, node: SqlModel[BachSqlModel]) -> Dict[str, str]:
-        new_node = BachSqlModel(sql='select * from {{previous}} limit 0')(previous=node)
+    def _get_dtypes(cls, engine: Engine, node: SqlModel[BachSqlModelBuilder]) -> Dict[str, str]:
+        new_node = BachSqlModelBuilder(sql='select * from {{previous}} limit 0')(previous=node)
         select_statement = to_sql(new_node)
         sql = f"""
             create temporary table tmp_table_name on commit drop as
@@ -408,7 +408,7 @@ class DataFrame:
         """
         # todo: why is an index mandatory if you can reset it later?
         # todo: don't create a temporary table, the real table (and its meta data) already exists
-        model = BachSqlModel(sql=f'SELECT * FROM {table_name}').instantiate()
+        model = BachSqlModelBuilder(sql=f'SELECT * FROM {table_name}').instantiate()
         return cls._from_node(engine, model, index)
 
     @classmethod
@@ -427,11 +427,11 @@ class DataFrame:
         """
         # Wrap the model in a simple select, so we know for sure that the top-level model has no unexpected
         # select expressions, where clauses, or limits
-        wrapped_model = BachSqlModel(sql='SELECT * FROM {{model}}')(model=model)
+        wrapped_model = BachSqlModelBuilder(sql='SELECT * FROM {{model}}')(model=model)
         return cls._from_node(engine, wrapped_model, index)
 
     @classmethod
-    def _from_node(cls, engine, model: SqlModel[BachSqlModel], index: List[str]) -> 'DataFrame':
+    def _from_node(cls, engine, model: SqlModel[BachSqlModelBuilder], index: List[str]) -> 'DataFrame':
         dtypes = cls._get_dtypes(engine, model)
 
         index_dtypes = {k: dtypes[k] for k in index}
@@ -513,7 +513,7 @@ class DataFrame:
     def get_instance(
             cls,
             engine,
-            base_node: SqlModel[BachSqlModel],
+            base_node: SqlModel[BachSqlModelBuilder],
             index_dtypes: Dict[str, str],
             dtypes: Dict[str, str],
             group_by: Optional['GroupBy'],
@@ -1379,7 +1379,7 @@ class DataFrame:
     def get_current_node(self, name: str,
                          limit: Union[int, slice] = None,
                          where_clause: Expression = None,
-                         having_clause: Expression = None) -> SqlModel[BachSqlModel]:
+                         having_clause: Expression = None) -> SqlModel[BachSqlModelBuilder]:
         """
         INTERNAL: Translate the current state of this DataFrame into a SqlModel.
 
@@ -1435,7 +1435,7 @@ class DataFrame:
 
             columns += [s.get_column_expression() for s in self._data.values()]
 
-            model_builder = BachSqlModel(
+            model_builder = BachSqlModelBuilder(
                 name=name,
                 sql="""
                     select {columns}
@@ -1456,7 +1456,7 @@ class DataFrame:
                 prev=self.base_node
             )
         else:
-            model_builder = BachSqlModel(
+            model_builder = BachSqlModelBuilder(
                 name=name,
                 sql='select {columns} from {{_last_node}} {where} {order} {limit}'
             )

--- a/bach/bach/dataframe.py
+++ b/bach/bach/dataframe.py
@@ -8,12 +8,10 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.future import Connection
 
 from bach.expression import Expression, SingleValueExpression
-from bach.sql_model import BachSqlModelBuilder, SampleSqlModel
+from bach.sql_model import BachSqlModelBuilder
 from bach.types import get_series_type_from_dtype, get_dtype_from_db_dtype
-from sql_models.graph_operations import replace_node_in_graph, find_node
 from sql_models.model import SqlModel
 from sql_models.sql_generator import to_sql
-from sql_models.util import quote_identifier
 
 if TYPE_CHECKING:
     from bach.partitioning import Window, GroupBy
@@ -185,77 +183,6 @@ class DataFrame:
         if set(index.keys()) & set(series.keys()):
             raise ValueError(f"The names of the index series and data series should not intersect. "
                              f"Index series: {sorted(index.keys())} data series: {sorted(series.keys())}")
-
-    def copy_override(
-            self,
-            engine: Engine = None,
-            base_node: SqlModel[BachSqlModelBuilder] = None,
-            index: Dict[str, 'Series'] = None,
-            series: Dict[str, 'Series'] = None,
-            group_by: List[Union['GroupBy', None]] = None,  # List so [None] != None
-            order_by: List[SortColumn] = None,
-            index_dtypes: Dict[str, str] = None,
-            series_dtypes: Dict[str, str] = None,
-            single_value: bool = False,
-            **kwargs
-    ) -> 'DataFrame':
-        """
-        INTERNAL
-
-        Create a copy of self, with the given arguments overridden
-
-        Big fat warning: group_by can legally be None, but if you want to set that,
-        set the param in a list: [None], or [someitem]. If you set None, it will be left alone.
-
-        There are three special parameters: index_dtypes, series_dtypes and single_value. These are used to
-        create new index and data series iff index and/or series are not given. `single_value` determines
-        whether the Expressions for those newly created series should be SingleValueExpressions or not.
-        All other arguments are passed through to `__init__`, filled with current instance values if None is
-        given in the parameters.
-        """
-
-        if index_dtypes and index:
-            raise ValueError("Can not set both index and index_dtypes")
-
-        if series_dtypes and series:
-            raise ValueError("Can not set both series and series_dtypes")
-
-        args = {
-            'engine': engine if engine is not None else self.engine,
-            'base_node': base_node if base_node is not None else self._base_node,
-            'index': index if index is not None else self._index,
-            'series': series if series is not None else self._data,
-            'group_by': self._group_by if group_by is None else group_by[0],
-            'order_by': order_by if order_by is not None else self._order_by
-        }
-
-        expression_class = SingleValueExpression if single_value else Expression
-
-        if index_dtypes:
-            new_index: Dict[str, Series] = {}
-            for key, value in index_dtypes.items():
-                index_type = get_series_type_from_dtype(value)
-                new_index[key] = index_type(
-                    engine=args['engine'], base_node=args['base_node'],
-                    index={},  # Empty index for index series
-                    name=key, expression=expression_class.column_reference(key),
-                    group_by=args['group_by']
-                )
-            args['index'] = new_index
-
-        if series_dtypes:
-            new_series: Dict[str, Series] = {}
-            for key, value in series_dtypes.items():
-                series_type = get_series_type_from_dtype(value)
-                new_series[key] = series_type(
-                    engine=args['engine'], base_node=args['base_node'],
-                    index=args['index'],
-                    name=key, expression=expression_class.column_reference(key),
-                    group_by=args['group_by']
-                )
-                args['series'] = new_series
-
-        return self.__class__(**args, **kwargs)
 
     @property
     def engine(self):
@@ -555,6 +482,77 @@ class DataFrame:
             group_by=group_by,
             order_by=order_by
         )
+
+    def copy_override(
+            self,
+            engine: Engine = None,
+            base_node: SqlModel[BachSqlModelBuilder] = None,
+            index: Dict[str, 'Series'] = None,
+            series: Dict[str, 'Series'] = None,
+            group_by: List[Union['GroupBy', None]] = None,  # List so [None] != None
+            order_by: List[SortColumn] = None,
+            index_dtypes: Dict[str, str] = None,
+            series_dtypes: Dict[str, str] = None,
+            single_value: bool = False,
+            **kwargs
+    ) -> 'DataFrame':
+        """
+        INTERNAL
+
+        Create a copy of self, with the given arguments overridden
+
+        Big fat warning: group_by can legally be None, but if you want to set that,
+        set the param in a list: [None], or [someitem]. If you set None, it will be left alone.
+
+        There are three special parameters: index_dtypes, series_dtypes and single_value. These are used to
+        create new index and data series iff index and/or series are not given. `single_value` determines
+        whether the Expressions for those newly created series should be SingleValueExpressions or not.
+        All other arguments are passed through to `__init__`, filled with current instance values if None is
+        given in the parameters.
+        """
+
+        if index_dtypes and index:
+            raise ValueError("Can not set both index and index_dtypes")
+
+        if series_dtypes and series:
+            raise ValueError("Can not set both series and series_dtypes")
+
+        args = {
+            'engine': engine if engine is not None else self.engine,
+            'base_node': base_node if base_node is not None else self._base_node,
+            'index': index if index is not None else self._index,
+            'series': series if series is not None else self._data,
+            'group_by': self._group_by if group_by is None else group_by[0],
+            'order_by': order_by if order_by is not None else self._order_by
+        }
+
+        expression_class = SingleValueExpression if single_value else Expression
+
+        if index_dtypes:
+            new_index: Dict[str, Series] = {}
+            for key, value in index_dtypes.items():
+                index_type = get_series_type_from_dtype(value)
+                new_index[key] = index_type(
+                    engine=args['engine'], base_node=args['base_node'],
+                    index={},  # Empty index for index series
+                    name=key, expression=expression_class.column_reference(key),
+                    group_by=args['group_by']
+                )
+            args['index'] = new_index
+
+        if series_dtypes:
+            new_series: Dict[str, Series] = {}
+            for key, value in series_dtypes.items():
+                series_type = get_series_type_from_dtype(value)
+                new_series[key] = series_type(
+                    engine=args['engine'], base_node=args['base_node'],
+                    index=args['index'],
+                    name=key, expression=expression_class.column_reference(key),
+                    group_by=args['group_by']
+                )
+                args['series'] = new_series
+
+        return self.__class__(**args, **kwargs)
 
     def copy(self):
         """

--- a/bach/bach/expression.py
+++ b/bach/bach/expression.py
@@ -9,7 +9,7 @@ from sql_models.util import quote_string, quote_identifier
 
 if TYPE_CHECKING:
     from bach import Series
-    from bach.sql_model import BachSqlModel
+    from bach.sql_model import BachSqlModelBuilder
 
 
 @dataclass(frozen=True)
@@ -49,7 +49,7 @@ class ColumnReferenceToken(ExpressionToken):
 
 @dataclass(frozen=True)
 class ModelReferenceToken(ExpressionToken):
-    model: SqlModel['BachSqlModel']
+    model: SqlModel['BachSqlModelBuilder']
 
     def refname(self) -> str:
         return f'reference{self.model.hash}'
@@ -160,7 +160,7 @@ class Expression:
         return cls([ColumnReferenceToken(field_name)])
 
     @classmethod
-    def model_reference(cls, model: SqlModel['BachSqlModel']) -> 'Expression':
+    def model_reference(cls, model: SqlModel['BachSqlModelBuilder']) -> 'Expression':
         """ Construct an expression for model, where model is a reference to a model. """
         return cls([ModelReferenceToken(model)])
 
@@ -227,7 +227,7 @@ class Expression:
                 result.append(data_item)
         return self.__class__(result)
 
-    def get_references(self) -> Dict[str, SqlModel['BachSqlModel']]:
+    def get_references(self) -> Dict[str, SqlModel['BachSqlModelBuilder']]:
         rv = {}
         for data_item in self.data:
             if isinstance(data_item, Expression):

--- a/bach/bach/from_pandas.py
+++ b/bach/bach/from_pandas.py
@@ -9,7 +9,7 @@ from sqlalchemy.engine import Engine
 from bach import DataFrame, get_series_type_from_dtype
 from bach.expression import Expression
 from sql_models.util import quote_identifier
-from bach.sql_model import BachSqlModel
+from bach.sql_model import BachSqlModelBuilder
 
 
 def from_pandas(engine: Engine,
@@ -64,7 +64,7 @@ def from_pandas_store_table(engine: Engine,
     conn.close()
 
     # Todo, this should use from_table from here on.
-    model_builder = BachSqlModel(sql='select * from {table_name}', name=table_name)
+    model_builder = BachSqlModelBuilder(sql='select * from {table_name}', name=table_name)
     model = model_builder(table_name=quote_identifier(table_name))
 
     # Should this also use _df_or_series?
@@ -130,7 +130,7 @@ def from_pandas_ephemeral(
     )
 
     sql = 'select * from (values \n{all_values_expr}\n) as t({column_names_expr})\n'
-    model_builder = BachSqlModel(sql=sql, name=name)
+    model_builder = BachSqlModelBuilder(sql=sql, name=name)
     model = model_builder(all_values_expr=all_values_expr, column_names_expr=column_names_expr)
 
     return DataFrame.get_instance(

--- a/bach/bach/merge.py
+++ b/bach/bach/merge.py
@@ -7,7 +7,7 @@ from typing import Union, List, Tuple, Optional, Dict, Set, NamedTuple, TYPE_CHE
 from bach import DataFrameOrSeries, DataFrame, ColumnNames, Series
 from bach.expression import Expression
 from sql_models.util import quote_identifier
-from bach.sql_model import BachSqlModel
+from bach.sql_model import BachSqlModelBuilder
 from sql_models.model import SqlModel
 
 
@@ -274,7 +274,7 @@ def _get_merge_sql_model(
         real_left_on: List[str],
         real_right_on: List[str],
         new_column_list: List[ResultColumn],
-) -> SqlModel[BachSqlModel]:
+) -> SqlModel[BachSqlModelBuilder]:
     """
     Give the SqlModel to join left and right and select the new_column_list. This model also uses the
     join-type of how, matching rows on real_left_on and real_right_on.
@@ -301,7 +301,7 @@ def _get_merge_sql_model(
         from {{left_node}} as l {join_type}
         join {{right_node}} as r {on}
         '''
-    model_builder = BachSqlModel(name='merge_sql', sql=sql)
+    model_builder = BachSqlModelBuilder(name='merge_sql', sql=sql)
     model = model_builder(
         columns=columns_expr,
         join_type=join_type_expr,

--- a/bach/bach/sql_model.py
+++ b/bach/bach/sql_model.py
@@ -7,10 +7,10 @@ from bach.expression import Expression
 from sql_models.util import quote_identifier
 from sql_models.model import CustomSqlModelBuilder, SqlModel, SqlModelBuilder, SqlModelSpec, Materialization
 
-TB = TypeVar('TB', bound='BachSqlModel')
+TB = TypeVar('TB', bound='BachSqlModelBuilder')
 
 
-class BachSqlModel(CustomSqlModelBuilder):
+class BachSqlModelBuilder(CustomSqlModelBuilder):
 
     def __call__(self: TB, **values: Union[int, str, Expression, Sequence[Expression],
                                            SqlModel, SqlModelBuilder]) -> SqlModel[TB]:

--- a/bach/bach/sql_model.py
+++ b/bach/bach/sql_model.py
@@ -59,7 +59,7 @@ class SampleSqlModel(SqlModel):
     extra property: previous.
 
     The previous property is not used in the generated sql at all, but can be used to track a previous
-    SqlModel. This is useful for how we implemented sampling, as that effectively insert a sql-model in the
+    SqlModel. This is useful for how we implemented sampling, as that effectively inserts a sql-model in the
     graph that has no regular reference to the previous node in the graph. By storing the previous node
     here, we can later still reconstruct what the actual previous node was with some custom logic.
 

--- a/bach/bach/sql_model.py
+++ b/bach/bach/sql_model.py
@@ -5,12 +5,12 @@ from typing import Dict, Any, Union, Sequence, TypeVar
 
 from bach.expression import Expression
 from sql_models.util import quote_identifier
-from sql_models.model import CustomSqlModel, SqlModel, SqlModelBuilder, SqlModelSpec, Materialization
+from sql_models.model import CustomSqlModelBuilder, SqlModel, SqlModelBuilder, SqlModelSpec, Materialization
 
 TB = TypeVar('TB', bound='BachSqlModel')
 
 
-class BachSqlModel(CustomSqlModel):
+class BachSqlModel(CustomSqlModelBuilder):
 
     def __call__(self: TB, **values: Union[int, str, Expression, Sequence[Expression],
                                            SqlModel, SqlModelBuilder]) -> SqlModel[TB]:
@@ -69,7 +69,7 @@ class SampleSqlModel(SqlModel):
         self.previous = previous
         sql = 'SELECT * FROM {table_name}'
         super().__init__(
-            model_spec=CustomSqlModel(sql=sql, name=name),
+            model_spec=CustomSqlModelBuilder(sql=sql, name=name),
             properties={'table_name': quote_identifier(table_name)},
             references={},
             materialization=Materialization.CTE

--- a/bach/sql_models/cli_util.py
+++ b/bach/sql_models/cli_util.py
@@ -17,5 +17,6 @@ def print_node_info(node_info: NodeInfo):
     print(f'reference_path: {node_info.reference_path}')
     print(f'properties: {node_info.model.properties}')
     print(f'materialization: {node_info.model.materialization}')
+    print(f'materialization_name: {node_info.model.materialization_name}')
     print(f'inputs: {[in_node.node_id for in_node in node_info.in_edges]}')
     print(f'outputs: {[out_node.node_id for out_node in node_info.out_edges]}')

--- a/bach/sql_models/model.py
+++ b/bach/sql_models/model.py
@@ -7,16 +7,15 @@ Models:
 * `SqlModelSpec`: Specification class, that specifies basic properties of an SqlModel instance
 * `SqlModelBuilder`: Helper class to instantiate the (immutable) SqlModel objects. Generally models should
   extend this class and not the SqlModel class.
-* `CustomSqlModel`: Utility child of SqlModelSpec that can be used to add a node with custom sql to a
+* `CustomSqlModelBuilder`: Utility child of SqlModelSpec that can be used to add a node with custom sql to a
   model graph.
 
 """
-import collections
 import hashlib
 from abc import abstractmethod, ABCMeta
 from copy import deepcopy
 from enum import Enum
-from typing import TypeVar, Generic, Dict, Any, Set, Tuple, Type, Union, Hashable, NamedTuple, Optional, cast
+from typing import TypeVar, Generic, Dict, Any, Set, Tuple, Type, Union, Hashable, NamedTuple, Optional
 
 from sql_models.util import extract_format_fields
 
@@ -626,9 +625,9 @@ class SqlModel(Generic[T]):
         return hash(self.hash)
 
 
-class CustomSqlModel(SqlModelBuilder):
+class CustomSqlModelBuilder(SqlModelBuilder):
     """
-    Model that can run custom sql and refer custom tables.
+    Builder that instantiates a SqlModel that can run custom sql and refer custom tables.
     """
 
     def __init__(self, sql: str, name: str = None):
@@ -640,7 +639,7 @@ class CustomSqlModel(SqlModelBuilder):
         if name:
             self._generic_name = name
         else:
-            self._generic_name = self.__class__.__name__
+            self._generic_name = 'CustomSqlModel'
         super().__init__()
 
     @property

--- a/bach/sql_models/model.py
+++ b/bach/sql_models/model.py
@@ -252,7 +252,7 @@ class SqlModelBuilder(SqlModelSpec, metaclass=ABCMeta):
 
     def instantiate(self: TB) -> 'SqlModel[TB]':
         """
-        Create an instance of SqlModel[T] based on the properties, references,
+        Create an instance of SqlModel[TB] based on the properties, references,
         materialization, and properties_to_sql of self.
 
         If the exact same instance (as determined by result.hash) has been created already by this class,

--- a/bach/tests/unit/sql_models/test_model.py
+++ b/bach/tests/unit/sql_models/test_model.py
@@ -7,7 +7,7 @@ from typing import List
 import pytest
 
 from sql_models.graph_operations import get_node, get_graph_nodes_info
-from sql_models.model import SqlModel, RefPath, CustomSqlModel
+from sql_models.model import SqlModel, RefPath, CustomSqlModelBuilder
 from sql_models.sql_generator import to_sql
 from tests.unit.sql_models.util import RefModel, ValueModel, JoinModel
 
@@ -46,7 +46,7 @@ def test_equality_base_cases():
 def test_equality_different_classes():
     vm1 = ValueModel.build(key='X', val=1)
     vm2 = ValueModel.build(key='X', val=2)
-    csm1 = CustomSqlModel(
+    csm1 = CustomSqlModelBuilder(
         sql="select '{key}' as key, {val} as value",
     )(key='X', val=2)
     # csm1 has the same sql, properties, references, and materialization as vm2, but not the same name
@@ -57,7 +57,7 @@ def test_equality_different_classes():
     # csm2 has the same attributes as vm2: sql, properties, references, materialization, generic name, and
     # the properties are formatted by the same function into sql. The fact that it is actually a different
     # sub-class of SqlModel doesn't matter for the sql generation nor for the equality check, cs2m == vm2
-    csm2 = CustomSqlModel(
+    csm2 = CustomSqlModelBuilder(
         sql="select '{key}' as key, {val} as value",
         name='ValueModel'
     )(key='X', val=2)
@@ -66,8 +66,8 @@ def test_equality_different_classes():
 
 
 def test_equality_different_property_formatters():
-    csm_builder = CustomSqlModel(sql='select {val} as value')
-    csm_alt_builder = CustomSqlModel(sql='select {val} as value')
+    csm_builder = CustomSqlModelBuilder(sql='select {val} as value')
+    csm_alt_builder = CustomSqlModelBuilder(sql='select {val} as value')
     csm_alt_builder.properties_to_sql = \
         lambda properties: {key: f'{val + 1}' for key, val in properties.items()}
     csm1 = csm_builder(val=2)

--- a/bach/tests/unit/sql_models/test_sql_generator.py
+++ b/bach/tests/unit/sql_models/test_sql_generator.py
@@ -3,7 +3,7 @@ Copyright 2021 Objectiv B.V.
 """
 import pytest
 
-from sql_models.model import SqlModelBuilder, CustomSqlModel
+from sql_models.model import SqlModelBuilder, CustomSqlModelBuilder
 from sql_models.sql_generator import to_sql
 from tests.unit.sql_models.test_graph_operations import get_simple_test_graph
 from tests.unit.sql_models.util import assert_roughly_equal_sql
@@ -37,7 +37,7 @@ def test__escape_value():
 
 def test_format_injection():
     # Make sure that (parts of) format strings in the properties of a model don't mess up the sql generation.
-    mb = CustomSqlModel('select {a} from x')
+    mb = CustomSqlModelBuilder('select {a} from x')
     result = to_sql(mb(a='y'))
     assert result == 'select y from x'
     result = to_sql(mb(a="'{y}'"))
@@ -50,7 +50,7 @@ def test_format_injection():
     assert result == "select '{{{y}' from x"
 
     model = mb(a="'{{y}}'")
-    mb = CustomSqlModel('select {a} from {{x}}')
+    mb = CustomSqlModelBuilder('select {a} from {{x}}')
     result = to_sql(mb(a='y', x=model))
     expected = 'with "CustomSqlModel___1415e9e145b7bdd712c6fadaac5a6483" as (select \'{{y}}\' from x)\n' \
                'select y from "CustomSqlModel___1415e9e145b7bdd712c6fadaac5a6483"'


### PR DESCRIPTION
Extracted a lot of small changes that don't really change any logic but just improve naming, structure, comments etc. into this PR. Should be non-controversial and make other PRs more focused on the real changes.

Changes:
1. `CustomSqlModel` -> `CustomSqlModelBuilder`. This name is a lot clearer. This is a subclass of `SqlModelBuilder` not of `SqlModel` - f457058d6679bddff551fda8a7bdb4e23d87b220
2. `BachSqlModel` -> `BachSqlModelBuilder`. This name is a lot clearer. This is a subclass of `SqlModelBuilder` not of `SqlModel` - 7403a67df755a8a732a3b3cee1cee492a9024eba
3. Moved `DataFrame.copy_override()` closer to the `DataFrame.copy()` function - e7e5863f44ce4bff8e00ab558855159178292291
4. Some small docstring, import and other tweaks - a3c4d086814f57f53031492cf74485b35df9fc2b