### PR TITLE
Bach sample improvements

### DIFF
--- a/bach/bach/partitioning.py
+++ b/bach/bach/partitioning.py
@@ -1,10 +1,13 @@
 from copy import copy
 from enum import Enum
-from typing import List, Dict, Optional, cast
+from typing import List, Dict, Optional, cast, TypeVar
 
 from bach.series import Series, SeriesInt64
 from bach.expression import Expression, WindowFunctionExpression
 from bach.dataframe import SortColumn
+from sql_models.model import SqlModel
+
+G = TypeVar('G', bound='GroupBy')
 
 
 class WindowFrameMode(Enum):
@@ -58,9 +61,8 @@ class GroupBy:
         for col in group_by_columns:
             if not isinstance(col, Series):
                 raise ValueError(f'Unsupported argument type: {type(col)}')
-            if col.expression.is_constant and not isinstance(col, SeriesInt64):
-                # Dictated by PG
-                raise ValueError('Non-integer constant group by series not supported')
+            if col.expression.is_constant:
+                raise ValueError('Grouping on a Series whose expression is a constant, is not supported.')
             if col.expression.has_windowed_aggregate_function:
                 raise ValueError('Window functions can not be used to group, '
                                  'please materialize first.')
@@ -95,6 +97,10 @@ class GroupBy:
     @property
     def index(self) -> Dict[str, Series]:
         return copy(self._index)
+
+    def copy_override_base_node(self: G, base_node: SqlModel) -> G:
+        new_cols = [col.copy_override(base_node=base_node) for col in self.index.values()]
+        return self.__class__(group_by_columns=new_cols)
 
 
 class Cube(GroupBy):

--- a/bach/bach/partitioning.py
+++ b/bach/bach/partitioning.py
@@ -62,6 +62,10 @@ class GroupBy:
             if not isinstance(col, Series):
                 raise ValueError(f'Unsupported argument type: {type(col)}')
             if col.expression.is_constant:
+                # We don't support this currently. If we allow this we would generate sql of the form (this
+                # assumes the constants is '5'): `... group by (5)`. The sql is valid, it groups by the
+                # fifth column of the query. But it doesn't make any sense to support that, the user should
+                # be explicit in naming the columns that he wants to group on.
                 raise ValueError('Grouping on a Series whose expression is a constant, is not supported.')
             if col.expression.has_windowed_aggregate_function:
                 raise ValueError('Window functions can not be used to group, '

--- a/bach/bach/sample.py
+++ b/bach/bach/sample.py
@@ -7,6 +7,7 @@ from bach import DataFrame
 from bach.dataframe import escape_parameter_characters
 from bach.sql_model import SampleSqlModel
 from sql_models.graph_operations import find_node, replace_node_in_graph
+from sql_models.sql_generator import to_sql
 from sql_models.util import quote_identifier
 
 if TYPE_CHECKING:
@@ -24,10 +25,6 @@ def get_sample(df: DataFrame,
     """
     if sample_percentage is None and filter is None:
         raise ValueError('Either sample_percentage or filter must be set')
-
-    if not df.is_materialized:
-        raise ValueError("Cannot call get_sample on a non-materialized dataframe. "
-                         "Call materialize() first.")
 
     original_node = df.base_node
     if filter is not None:
@@ -49,7 +46,7 @@ def get_sample(df: DataFrame,
 
             sql = f'''
                 create temporary table tmp_table_name on commit drop as
-                ({df.view_sql()});
+                ({to_sql(df.base_node)});
                 create temporary table {quote_identifier(table_name)} as
                 (select * from tmp_table_name
                 tablesample bernoulli({sample_percentage}) {repeatable})
@@ -62,23 +59,13 @@ def get_sample(df: DataFrame,
     # Use SampleSqlModel, that way we can keep track of the current_node and undo this sampling
     # in get_unsampled() by switching this new node for the old node again.
     new_base_node = SampleSqlModel(table_name=table_name, previous=original_node)
-
-    return DataFrame.get_instance(
-        engine=df.engine,
-        base_node=new_base_node,
-        index_dtypes=df.index_dtypes,
-        dtypes=df.dtypes,
-        group_by=None
-    )
+    return df.copy_override_base_node(base_node=new_base_node)
 
 
 def get_unsampled(df) -> 'DataFrame':
     """
     See :py:meth:`bach.DataFrame.get_unsampled` for more information.
     """
-    if df._group_by:
-        df = df.materialize(node_name='get_unsampled')
-
     # The returned DataFrame has a modified base_node graph, in which the node that introduced the
     # sampling is removed.
     sampled_node_tuple = find_node(
@@ -94,7 +81,4 @@ def get_unsampled(df) -> 'DataFrame':
         reference_path=sampled_node_tuple.reference_path,
         replacement_model=sampled_node_tuple.model.previous
     )
-
-    index = {s.name: s.copy_override(base_node=updated_graph) for s in df._index.values()}
-    series = {s.name: s.copy_override(base_node=updated_graph, index=index) for s in df._data.values()}
-    return df.copy_override(base_node=updated_graph, index=index, series=series)
+    return df.copy_override_base_node(base_node=updated_graph)

--- a/bach/docs/source/intro.rst
+++ b/bach/docs/source/intro.rst
@@ -12,7 +12,7 @@ full dataset, and you can output models to SQL with a single command. It include
 enable effective feature creation for datasets that embrace the open taxonomy of analytics.
 
 We've set up a online `sandboxed notebook <https://notebook.objectiv.io/lab?path=product_analytics.ipynb>`_
-with Objective Analytics data for you to play around, to demonstrate what Bach can do without the need to
+with Objectiv Analytics data for you to play around, to demonstrate what Bach can do without the need to
 install anything. Beware this is python compiled to javascript, running in the browser; so the performance
 is not the same as running Bach in a normal python notebook. Especially the initial loading can be slow.
 


### PR DESCRIPTION
Changes:
* Don't require the `DataFrame` to be materialized when calling `get_sample()`
* Don't materialize in `get_unsampled()`. Previously we did that if `df._group_by` was set
* Also support sampling grouped DataFrames
* The `is_materialized` function is not used anymore now. But I do require it in another PR, so haven't removed it here.

I think somebody (hendrik?) asked me last time when I implemented #318 whether we couldn't skip the materialization requirement. I think I claimed then that that was not possible, no idea why :man_shrugging: I think this should work. Ran into this while working on the is_materialized stuff