### PR TITLE
Fixbach  docs case

### DIFF
--- a/analysis/bach_open_taxonomy/bach_open_taxonomy/series/series_objectiv.py
+++ b/analysis/bach_open_taxonomy/bach_open_taxonomy/series/series_objectiv.py
@@ -774,7 +774,7 @@ class ObjectivFrame(DataFrame):
         allows for manipulating this data on a small data set, while all changes can be applied to all hits
         later. Use ObjectivFrame.apply_feature_frame_sample_changes later to apply changes made in this
         ObjectivFrame.
-        
+
         :param table_name: the name of the sql table to store the data of the unique location_stack and
             event_types.
         :param overwrite: if True, the sql table is overwritten if it already exists.

--- a/analysis/bach_open_taxonomy/bach_open_taxonomy/series/series_objectiv.py
+++ b/analysis/bach_open_taxonomy/bach_open_taxonomy/series/series_objectiv.py
@@ -647,6 +647,8 @@ class ObjectivFrame(DataFrame):
                    end_date=None,
                    time_aggregation: str = None) -> 'ObjectivFrame':
         """
+        Loads data from table into frame
+
         :param engine: a Sqlalchemy Engine for the database. If not given, env DSN is used to create one. If
             that's not there, the default of 'postgresql://objectiv:@localhost:5432/objectiv' will be used.
         :param start_date: first date for which data is loaded to the DataFrame. If None, data is loaded from
@@ -718,6 +720,7 @@ class ObjectivFrame(DataFrame):
         """
         Label events that are used as conversions. All labeled conversion events are set in
         ObjectivFrame.conversion_events.
+
         :param location_stack: the location stack that is labeled as conversion. Can be any slice in of a
             objectiv_location_stack type column. Optionally use in conjunction with event_type to label a
             conversion.
@@ -771,6 +774,7 @@ class ObjectivFrame(DataFrame):
         allows for manipulating this data on a small data set, while all changes can be applied to all hits
         later. Use ObjectivFrame.apply_feature_frame_sample_changes later to apply changes made in this
         ObjectivFrame.
+        
         :param table_name: the name of the sql table to store the data of the unique location_stack and
             event_types.
         :param overwrite: if True, the sql table is overwritten if it already exists.

--- a/analysis/notebooks/open-taxonomy-how-to.ipynb
+++ b/analysis/notebooks/open-taxonomy-how-to.ipynb
@@ -65,10 +65,10 @@
    "metadata": {},
    "source": [
     "The data for the DataFrame is still in the database and the database is not queried before any of the data is loaded to the python environment. The methods that query the database are: \n",
-    "* [`head()`](https://objectiv.io/docs/modeling/dataframe/bach.DataFrame.head#bach.DataFrame.head)\n",
-    "* [`to_pandas()`](https://objectiv.io/docs/modeling/dataframe/bach.DataFrame.to_pandas#bach.DataFrame.to_pandas)\n",
-    "* [`get_sample()`](https://objectiv.io/docs/modeling/dataframe/bach.DataFrame.get_sample#bach.DataFrame.get_sample)\n",
-    "* The property accessors [`values`](https://objectiv.io/docs/modeling/dataframe/bach.DataFrame.values#bach.DataFrame.values), [`Series.array`](https://objectiv.io/docs/modeling/series/bach.Series.array#bach.Series.array), [`Series.value`](https://objectiv.io/docs/modeling/series/bach.Series.value#bach.Series.value)\n",
+    "* [`head()`](https://objectiv.io/docs/modeling/DataFrame/bach.DataFrame.head#bach.DataFrame.head)\n",
+    "* [`to_pandas()`](https://objectiv.io/docs/modeling/DataFrame/bach.DataFrame.to_pandas#bach.DataFrame.to_pandas)\n",
+    "* [`get_sample()`](https://objectiv.io/docs/modeling/DataFrame/bach.DataFrame.get_sample#bach.DataFrame.get_sample)\n",
+    "* The property accessors [`values`](https://objectiv.io/docs/modeling/DataFrame/bach.DataFrame.values#bach.DataFrame.values), [`Series.array`](https://objectiv.io/docs/modeling/Series/bach.Series.array#bach.Series.array), [`Series.value`](https://objectiv.io/docs/modeling/Series/bach.Series.value#bach.Series.value)\n",
     "\n",
     "For demo puposes of this notebook, these methods are called often to show the results of our operations. To limit the number of executed queries on the full data set it is recommended to use these methods less often or [to sample the data first](#sampling)."
    ]
@@ -205,7 +205,7 @@
     " {'id': 'jansentom', '_type': 'SectionContext'},\n",
     " {'id': 'contributor-card', '_type': 'SectionContext'}]\n",
     "```\n",
-    "In case a location stack does not contain the object, `None` is returned. More info at the api reference: https://objectiv.io/docs/modeling/series/bach.SeriesJsonb.json#bach.SeriesJsonb.json"
+    "In case a location stack does not contain the object, `None` is returned. More info at the api reference: https://objectiv.io/docs/modeling/Series/bach.SeriesJsonb.json#bach.SeriesJsonb.json"
    ]
   },
   {
@@ -218,7 +218,7 @@
     "\n",
     "Because of the specific way the location information is labeled, validated, and stored using the Open Taxonomy, it can be used to slice and group your products' features in an efficient and easy way. The column is set as an `objectiv_location_stack` type, and therefore location stack specific methods can be used to access the data from the `location_stack`. These methods can be used using the `.ls` accessor on the column. The methods are:\n",
     "* The property accessors [`.ls.navigation_features`](https://objectiv.io/docs/modeling/objectiv/bach_open_taxonomy.SeriesLocationStack.ls#bach_open_taxonomy.SeriesLocationStack.ls), [`.ls.feature_stack`](https://objectiv.io/docs/modeling/objectiv/bach_open_taxonomy.SeriesLocationStack.ls#bach_open_taxonomy.SeriesLocationStack.ls), [`.ls.nice_name`](https://objectiv.io/docs/modeling/objectiv/bach_open_taxonomy.SeriesLocationStack.ls#bach_open_taxonomy.SeriesLocationStack.ls)\n",
-    "* all [methods](https://objectiv.io/docs/modeling/series/bach.SeriesJsonb.json#bach.SeriesJsonb.json) for the json(b) type can also be accessed using `.ls`\n",
+    "* all [methods](https://objectiv.io/docs/modeling/Series/bach.SeriesJsonb.json#bach.SeriesJsonb.json) for the json(b) type can also be accessed using `.ls`\n",
     "\n",
     "The full reference of location stack is [here](https://objectiv.io/docs/taxonomy/location-contexts). An example is queried below:"
    ]
@@ -242,7 +242,7 @@
     "The `global_contexts` column in an Objectiv Frame contain all information that is relevant to the logged event. As it is set as an `objectiv_global_context` type, specific methods can be used to access the data from the `global_contexts`. These methods can be used using the `.gc` accessor on the column. The methods are:\n",
     "* [`.gc.get_from_context_with_type_series(type, key)`](https://objectiv.io/docs/modeling/objectiv/bach_open_taxonomy.ObjectivStack#bach_open_taxonomy.ObjectivStack)\n",
     "* The property accessors [`.gc.cookie_id`](https://objectiv.io/docs/modeling/objectiv/bach_open_taxonomy.SeriesGlobalContexts.gc#bach_open_taxonomy.SeriesGlobalContexts.gc), [`.gc.user_agent`](https://objectiv.io/docs/modeling/objectiv/bach_open_taxonomy.SeriesGlobalContexts.gc#bach_open_taxonomy.SeriesGlobalContexts.gc), [`.gc.application`](https://objectiv.io/docs/modeling/objectiv/bach_open_taxonomy.SeriesGlobalContexts.gc#bach_open_taxonomy.SeriesGlobalContexts.gc)  \n",
-    "* all [methods](https://objectiv.io/docs/modeling/series/bach.SeriesJsonb.json#bach.SeriesJsonb.json) for the json(b) type can also be accessed using `.gc`\n",
+    "* all [methods](https://objectiv.io/docs/modeling/Series/bach.SeriesJsonb.json#bach.SeriesJsonb.json) for the json(b) type can also be accessed using `.gc`\n",
     "\n",
     "The full reference of global contexts is [here](https://objectiv.io/docs/taxonomy/global-contexts). An example is queried below:"
    ]

--- a/bach/docs/generate.py
+++ b/bach/docs/generate.py
@@ -59,7 +59,7 @@ patterns = [
 # list of special cases, where we have a subdir, with an introduction at toplevel
 # eg /dataframe.html and /dataframe/
 for fn in glob.glob(f'{html_dir}/*'):
-    dn = fn.replace('.html', '').lower()
+    dn = fn.replace('.html', '')
     if path.isfile(fn) and path.isdir(dn):
         patterns.extend([f'{path.basename(dn)}.*', f'{path.basename(fn).replace(".html", "")}.*'])
 

--- a/bach/docs/source/DataFrame.rst
+++ b/bach/docs/source/DataFrame.rst
@@ -73,7 +73,7 @@ Reference
 ---------
 .. autosummary::
     :template: autosummary/class_short.rst
-    :toctree: dataframe
+    :toctree: DataFrame
 
     DataFrame
 
@@ -83,7 +83,7 @@ Reference by function
 Creation
 ~~~~~~~~
 .. autosummary::
-    :toctree: dataframe
+    :toctree: DataFrame
 
     DataFrame.from_table
     DataFrame.from_model
@@ -93,7 +93,7 @@ Creation
 Value accessors
 ~~~~~~~~~~~~~~~
 .. autosummary::
-    :toctree: dataframe
+    :toctree: DataFrame
 
     DataFrame.head
     DataFrame.to_pandas
@@ -105,7 +105,7 @@ Attributes and underlying data
 Axes
 ++++
 .. autosummary::
-    :toctree: dataframe
+    :toctree: DataFrame
 
     DataFrame.index
     DataFrame.data
@@ -118,7 +118,7 @@ Axes
 Types
 +++++
 .. autosummary::
-    :toctree: dataframe
+    :toctree: DataFrame
 
     DataFrame.dtypes
     DataFrame.index_dtypes
@@ -127,7 +127,7 @@ Types
 Sql Model
 +++++++++
 .. autosummary::
-    :toctree: dataframe
+    :toctree: DataFrame
 
     DataFrame.materialize
     DataFrame.get_sample
@@ -138,7 +138,7 @@ Sql Model
 Reshaping, indexing, sorting & merging
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. autosummary::
-    :toctree: dataframe
+    :toctree: DataFrame
 
     DataFrame.sort_values
     DataFrame.rename
@@ -150,7 +150,7 @@ Reshaping, indexing, sorting & merging
 Aggregation & windowing
 ~~~~~~~~~~~~~~~~~~~~~~~
 .. autosummary::
-    :toctree: dataframe
+    :toctree: DataFrame
 
     DataFrame.agg
     DataFrame.aggregate
@@ -161,7 +161,7 @@ Aggregation & windowing
     DataFrame.rolling
     DataFrame.expanding
 
-.. _dataframe.stats:
+.. _DataFrame.stats:
 
 Computations & descriptive stats
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -169,7 +169,7 @@ Computations & descriptive stats
 All types
 +++++++++
 .. autosummary::
-    :toctree: dataframe
+    :toctree: DataFrame
 
     DataFrame.count
     DataFrame.min
@@ -181,7 +181,7 @@ All types
 Numeric
 +++++++
 .. autosummary::
-    :toctree: dataframe
+    :toctree: DataFrame
 
     DataFrame.mean
     DataFrame.sem

--- a/bach/docs/source/Objectiv.rst
+++ b/bach/docs/source/Objectiv.rst
@@ -16,4 +16,4 @@ Reference
     ObjectivStack
     SeriesGlobalContexts
     SeriesLocationStack
-    FeatureFrame
+

--- a/bach/docs/source/Objectiv.rst
+++ b/bach/docs/source/Objectiv.rst
@@ -11,7 +11,7 @@ Reference
 ---------
 .. autosummary::
     :template: autosummary/class_short.rst
-    :toctree: objectiv
+    :toctree: Objectiv
 
     ObjectivStack
     SeriesGlobalContexts

--- a/bach/docs/source/Objectiv.rst
+++ b/bach/docs/source/Objectiv.rst
@@ -13,6 +13,7 @@ Reference
     :template: autosummary/class_short.rst
     :toctree: Objectiv
 
+    ObjectivFrame
     ObjectivStack
     SeriesGlobalContexts
     SeriesLocationStack

--- a/bach/docs/source/Series.rst
+++ b/bach/docs/source/Series.rst
@@ -22,10 +22,10 @@ It should generally not be required to construct Series instances manually.
 Slicing and index access
 ~~~~~~~~~~~~~~~~~~~~~~~~
 Series support a few standard operations to get specific values:
-series[:3] will return the first 3 values of the Series. Sort order of the series is important, so use
+Series[:3] will return the first 3 values of the Series. Sort order of the Series is important, so use
 `Series.sort_values()` before slicing. Any slice with positive parameters is supported.
 
-Index lookups like series['key'] are also possible, and yield the value of the series where the index
+Index lookups like Series['key'] are also possible, and yield the value of the Series where the index
 matches 'key'.
 
 Database access
@@ -46,7 +46,7 @@ Boolean Operations
 ~~~~~~~~~~~~~~~~~~
 A special subclass, :py:class:`SeriesBoolean`, can be used to filter
 DataFrames, and these Series are easily created using comparison operations like equals (==),
-less-than (<), not(~) on two series: `boolean_series = a == b`
+less-than (<), not(~) on two Series: `boolean_Series = a == b`
 
 More complex boolean operations like `a.isin(b)` are also supported, as well as multi-compares:
 `a > b.any_value()` being True when there is a value in `b` where `a > b == True`
@@ -72,7 +72,7 @@ Series.window_* namespace.
 
 Types
 ~~~~~
-Series have a specific type that determines what kind of operations are available. All numeric series
+Series have a specific type that determines what kind of operations are available. All numeric Series
 support arithmetic operations and aggregations for example. It may or may not be possible to perform
 operations on different types. A comparison or arithmetic operation between a Int64 and Float Series
 is okay, while a comparison operation is not.
@@ -83,7 +83,7 @@ Reference
 ---------
 .. autosummary::
     :template: autosummary/class_short.rst
-    :toctree: series
+    :toctree: Series
 
     Series
     SeriesBoolean
@@ -99,7 +99,7 @@ Reference by function
 Creation / re-framing
 ~~~~~~~~~~~~~~~~~~~~~
 .. autosummary::
-    :toctree: series
+    :toctree: Series
 
     Series.from_const
     Series.to_frame
@@ -108,7 +108,7 @@ Creation / re-framing
 Value accessors
 ~~~~~~~~~~~~~~~
 .. autosummary::
-    :toctree: series
+    :toctree: Series
 
     Series.head
     Series.to_pandas
@@ -122,7 +122,7 @@ Attributes and underlying data
 Axes
 ++++
 .. autosummary::
-    :toctree: series
+    :toctree: Series
 
     Series.name
     Series.index
@@ -132,7 +132,7 @@ Axes
 Types
 +++++
 .. autosummary::
-    :toctree: series
+    :toctree: Series
 
     Series.dtype
     Series.astype
@@ -140,7 +140,7 @@ Types
 Sql Model
 +++++++++
 .. autosummary::
-    :toctree: series
+    :toctree: Series
 
     Series.engine
     Series.base_node
@@ -149,7 +149,7 @@ Sql Model
 Comparison and set operations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. autosummary::
-    :toctree: series
+    :toctree: Series
 
     Series.all_values
     Series.any_value
@@ -161,7 +161,7 @@ Comparison and set operations
 Conversion, reshaping, sorting
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. autosummary::
-    :toctree: series
+    :toctree: Series
 
     Series.sort_values
     Series.fillna
@@ -169,7 +169,7 @@ Conversion, reshaping, sorting
 Function application, aggregation & windowing
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. autosummary::
-    :toctree: series
+    :toctree: Series
 
     Series.agg
     Series.aggregate
@@ -182,7 +182,7 @@ All types
 +++++++++
 
 .. autosummary::
-    :toctree: series
+    :toctree: Series
 
     Series.count
     Series.min
@@ -194,7 +194,7 @@ All types
 Numeric
 +++++++
 .. autosummary::
-    :toctree: series
+    :toctree: Series
 
     SeriesAbstractNumeric.mean
     SeriesAbstractNumeric.sem
@@ -205,7 +205,7 @@ Numeric
 Window
 ++++++
 .. autosummary::
-    :toctree: series
+    :toctree: Series
 
     Series.window_first_value
     Series.window_lag


### PR DESCRIPTION
This PR does the following:
- rename the subdirs from dataframe/series/objectiv to DataFrame/Series/Objectiv, to reflect the .rst's they originate from

This means we remove the dataframe <->DataFrame issues, that break Windows builds, and make for confusing URL's