### PR TITLE
WIP: Tracker copyright year update

### DIFF
--- a/.github/workflows/tracker-tests.yml
+++ b/.github/workflows/tracker-tests.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: '16'
           check-latest: true
           cache: 'yarn'
           cache-dependency-path: tracker/yarn.lock

--- a/tracker/.yarn/plugins/@yarnpkg/plugin-workspace-tools.cjs
+++ b/tracker/.yarn/plugins/@yarnpkg/plugin-workspace-tools.cjs
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2022 Objectiv B.V.
+ */
+
 /* eslint-disable */
 //prettier-ignore
 module.exports = {

--- a/tracker/.yarn/plugins/@yarnpkg/plugin-workspace-tools.cjs
+++ b/tracker/.yarn/plugins/@yarnpkg/plugin-workspace-tools.cjs
@@ -1,7 +1,3 @@
-/*
- * Copyright 2022 Objectiv B.V.
- */
-
 /* eslint-disable */
 //prettier-ignore
 module.exports = {

--- a/tracker/core/react/jest.config.js
+++ b/tracker/core/react/jest.config.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 module.exports = {

--- a/tracker/core/react/jest.config.js
+++ b/tracker/core/react/jest.config.js
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2022 Objectiv B.V.
+ */
+
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',

--- a/tracker/core/react/rollup.config.js
+++ b/tracker/core/react/rollup.config.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import commonjs from '@rollup/plugin-commonjs';

--- a/tracker/core/react/rollup.config.js
+++ b/tracker/core/react/rollup.config.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import commonjs from '@rollup/plugin-commonjs';

--- a/tracker/core/react/src/common/LocationTree.ts
+++ b/tracker/core/react/src/common/LocationTree.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { AbstractLocationContext } from '@objectiv/schema';

--- a/tracker/core/react/src/common/LocationTree.ts
+++ b/tracker/core/react/src/common/LocationTree.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { AbstractLocationContext } from '@objectiv/schema';

--- a/tracker/core/react/src/common/factories/makeContentContext.ts
+++ b/tracker/core/react/src/common/factories/makeContentContext.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { ContentContext } from '@objectiv/schema';

--- a/tracker/core/react/src/common/factories/makeContentContext.ts
+++ b/tracker/core/react/src/common/factories/makeContentContext.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { ContentContext } from '@objectiv/schema';

--- a/tracker/core/react/src/common/factories/makeExpandableContext.ts
+++ b/tracker/core/react/src/common/factories/makeExpandableContext.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { ExpandableContext } from '@objectiv/schema';

--- a/tracker/core/react/src/common/factories/makeExpandableContext.ts
+++ b/tracker/core/react/src/common/factories/makeExpandableContext.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { ExpandableContext } from '@objectiv/schema';

--- a/tracker/core/react/src/common/factories/makeIdFromString.ts
+++ b/tracker/core/react/src/common/factories/makeIdFromString.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 /**

--- a/tracker/core/react/src/common/factories/makeIdFromString.ts
+++ b/tracker/core/react/src/common/factories/makeIdFromString.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 /**

--- a/tracker/core/react/src/common/factories/makeInputContext.ts
+++ b/tracker/core/react/src/common/factories/makeInputContext.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { InputContext } from '@objectiv/schema';

--- a/tracker/core/react/src/common/factories/makeInputContext.ts
+++ b/tracker/core/react/src/common/factories/makeInputContext.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { InputContext } from '@objectiv/schema';

--- a/tracker/core/react/src/common/factories/makeLinkContext.ts
+++ b/tracker/core/react/src/common/factories/makeLinkContext.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { LinkContext } from '@objectiv/schema';

--- a/tracker/core/react/src/common/factories/makeLinkContext.ts
+++ b/tracker/core/react/src/common/factories/makeLinkContext.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { LinkContext } from '@objectiv/schema';

--- a/tracker/core/react/src/common/factories/makeLocationContext.ts
+++ b/tracker/core/react/src/common/factories/makeLocationContext.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { AbstractLocationContext } from '@objectiv/schema';

--- a/tracker/core/react/src/common/factories/makeLocationContext.ts
+++ b/tracker/core/react/src/common/factories/makeLocationContext.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { AbstractLocationContext } from '@objectiv/schema';

--- a/tracker/core/react/src/common/factories/makeMediaPlayerContext.ts
+++ b/tracker/core/react/src/common/factories/makeMediaPlayerContext.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { MediaPlayerContext } from '@objectiv/schema';

--- a/tracker/core/react/src/common/factories/makeMediaPlayerContext.ts
+++ b/tracker/core/react/src/common/factories/makeMediaPlayerContext.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { MediaPlayerContext } from '@objectiv/schema';

--- a/tracker/core/react/src/common/factories/makeNavigationContext.ts
+++ b/tracker/core/react/src/common/factories/makeNavigationContext.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { NavigationContext } from '@objectiv/schema';

--- a/tracker/core/react/src/common/factories/makeNavigationContext.ts
+++ b/tracker/core/react/src/common/factories/makeNavigationContext.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { NavigationContext } from '@objectiv/schema';

--- a/tracker/core/react/src/common/factories/makeOverlayContext.ts
+++ b/tracker/core/react/src/common/factories/makeOverlayContext.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { OverlayContext } from '@objectiv/schema';

--- a/tracker/core/react/src/common/factories/makeOverlayContext.ts
+++ b/tracker/core/react/src/common/factories/makeOverlayContext.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { OverlayContext } from '@objectiv/schema';

--- a/tracker/core/react/src/common/factories/makePressableContext.ts
+++ b/tracker/core/react/src/common/factories/makePressableContext.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { PressableContext } from '@objectiv/schema';

--- a/tracker/core/react/src/common/factories/makePressableContext.ts
+++ b/tracker/core/react/src/common/factories/makePressableContext.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { PressableContext } from '@objectiv/schema';

--- a/tracker/core/react/src/common/factories/makeRootLocationContext.ts
+++ b/tracker/core/react/src/common/factories/makeRootLocationContext.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { RootLocationContext } from '@objectiv/schema';

--- a/tracker/core/react/src/common/factories/makeRootLocationContext.ts
+++ b/tracker/core/react/src/common/factories/makeRootLocationContext.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { RootLocationContext } from '@objectiv/schema';

--- a/tracker/core/react/src/common/factories/makeTextFromChildren.ts
+++ b/tracker/core/react/src/common/factories/makeTextFromChildren.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { ReactNode } from 'react';

--- a/tracker/core/react/src/common/factories/makeTextFromChildren.ts
+++ b/tracker/core/react/src/common/factories/makeTextFromChildren.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { ReactNode } from 'react';

--- a/tracker/core/react/src/common/factories/recursiveGetTextFromChildren.ts
+++ b/tracker/core/react/src/common/factories/recursiveGetTextFromChildren.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { isValidElement, ReactNode } from 'react';

--- a/tracker/core/react/src/common/factories/recursiveGetTextFromChildren.ts
+++ b/tracker/core/react/src/common/factories/recursiveGetTextFromChildren.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { isValidElement, ReactNode } from 'react';

--- a/tracker/core/react/src/common/providers/LocationProvider.tsx
+++ b/tracker/core/react/src/common/providers/LocationProvider.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { ReactNode, useContext } from 'react';

--- a/tracker/core/react/src/common/providers/LocationProvider.tsx
+++ b/tracker/core/react/src/common/providers/LocationProvider.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { ReactNode, useContext } from 'react';

--- a/tracker/core/react/src/common/providers/LocationProviderContext.ts
+++ b/tracker/core/react/src/common/providers/LocationProviderContext.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { createContext } from 'react';

--- a/tracker/core/react/src/common/providers/LocationProviderContext.ts
+++ b/tracker/core/react/src/common/providers/LocationProviderContext.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { createContext } from 'react';

--- a/tracker/core/react/src/common/providers/ObjectivProvider.tsx
+++ b/tracker/core/react/src/common/providers/ObjectivProvider.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { ReactNode, useContext } from 'react';

--- a/tracker/core/react/src/common/providers/ObjectivProvider.tsx
+++ b/tracker/core/react/src/common/providers/ObjectivProvider.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { ReactNode, useContext } from 'react';

--- a/tracker/core/react/src/common/providers/ObjectivProviderContext.ts
+++ b/tracker/core/react/src/common/providers/ObjectivProviderContext.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { createContext } from 'react';

--- a/tracker/core/react/src/common/providers/ObjectivProviderContext.ts
+++ b/tracker/core/react/src/common/providers/ObjectivProviderContext.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { createContext } from 'react';

--- a/tracker/core/react/src/common/providers/TrackerProvider.tsx
+++ b/tracker/core/react/src/common/providers/TrackerProvider.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { ReactNode } from 'react';

--- a/tracker/core/react/src/common/providers/TrackerProvider.tsx
+++ b/tracker/core/react/src/common/providers/TrackerProvider.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { ReactNode } from 'react';

--- a/tracker/core/react/src/common/providers/TrackerProviderContext.ts
+++ b/tracker/core/react/src/common/providers/TrackerProviderContext.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/src/common/providers/TrackerProviderContext.ts
+++ b/tracker/core/react/src/common/providers/TrackerProviderContext.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/src/common/providers/TrackingContext.ts
+++ b/tracker/core/react/src/common/providers/TrackingContext.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { LocationProviderContext } from './LocationProviderContext';

--- a/tracker/core/react/src/common/providers/TrackingContext.ts
+++ b/tracker/core/react/src/common/providers/TrackingContext.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { LocationProviderContext } from './LocationProviderContext';

--- a/tracker/core/react/src/common/providers/TrackingContextProvider.tsx
+++ b/tracker/core/react/src/common/providers/TrackingContextProvider.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { ReactNode } from 'react';

--- a/tracker/core/react/src/common/providers/TrackingContextProvider.tsx
+++ b/tracker/core/react/src/common/providers/TrackingContextProvider.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { ReactNode } from 'react';

--- a/tracker/core/react/src/eventTrackers/trackApplicationLoadedEvent.ts
+++ b/tracker/core/react/src/eventTrackers/trackApplicationLoadedEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeApplicationLoadedEvent } from '@objectiv/tracker-core';

--- a/tracker/core/react/src/eventTrackers/trackApplicationLoadedEvent.ts
+++ b/tracker/core/react/src/eventTrackers/trackApplicationLoadedEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeApplicationLoadedEvent } from '@objectiv/tracker-core';

--- a/tracker/core/react/src/eventTrackers/trackFailureEvent.ts
+++ b/tracker/core/react/src/eventTrackers/trackFailureEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeFailureEvent } from '@objectiv/tracker-core';

--- a/tracker/core/react/src/eventTrackers/trackFailureEvent.ts
+++ b/tracker/core/react/src/eventTrackers/trackFailureEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeFailureEvent } from '@objectiv/tracker-core';

--- a/tracker/core/react/src/eventTrackers/trackHiddenEvent.ts
+++ b/tracker/core/react/src/eventTrackers/trackHiddenEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeHiddenEvent } from '@objectiv/tracker-core';

--- a/tracker/core/react/src/eventTrackers/trackHiddenEvent.ts
+++ b/tracker/core/react/src/eventTrackers/trackHiddenEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeHiddenEvent } from '@objectiv/tracker-core';

--- a/tracker/core/react/src/eventTrackers/trackInputChangeEvent.ts
+++ b/tracker/core/react/src/eventTrackers/trackInputChangeEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeInputChangeEvent } from '@objectiv/tracker-core';

--- a/tracker/core/react/src/eventTrackers/trackInputChangeEvent.ts
+++ b/tracker/core/react/src/eventTrackers/trackInputChangeEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeInputChangeEvent } from '@objectiv/tracker-core';

--- a/tracker/core/react/src/eventTrackers/trackInteractiveEvent.ts
+++ b/tracker/core/react/src/eventTrackers/trackInteractiveEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeInteractiveEvent } from '@objectiv/tracker-core';

--- a/tracker/core/react/src/eventTrackers/trackInteractiveEvent.ts
+++ b/tracker/core/react/src/eventTrackers/trackInteractiveEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeInteractiveEvent } from '@objectiv/tracker-core';

--- a/tracker/core/react/src/eventTrackers/trackMediaEvent.ts
+++ b/tracker/core/react/src/eventTrackers/trackMediaEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeMediaEvent } from '@objectiv/tracker-core';

--- a/tracker/core/react/src/eventTrackers/trackMediaEvent.ts
+++ b/tracker/core/react/src/eventTrackers/trackMediaEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeMediaEvent } from '@objectiv/tracker-core';

--- a/tracker/core/react/src/eventTrackers/trackMediaLoadEvent.ts
+++ b/tracker/core/react/src/eventTrackers/trackMediaLoadEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeMediaLoadEvent } from '@objectiv/tracker-core';

--- a/tracker/core/react/src/eventTrackers/trackMediaLoadEvent.ts
+++ b/tracker/core/react/src/eventTrackers/trackMediaLoadEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeMediaLoadEvent } from '@objectiv/tracker-core';

--- a/tracker/core/react/src/eventTrackers/trackMediaPauseEvent.ts
+++ b/tracker/core/react/src/eventTrackers/trackMediaPauseEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeMediaPauseEvent } from '@objectiv/tracker-core';

--- a/tracker/core/react/src/eventTrackers/trackMediaPauseEvent.ts
+++ b/tracker/core/react/src/eventTrackers/trackMediaPauseEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeMediaPauseEvent } from '@objectiv/tracker-core';

--- a/tracker/core/react/src/eventTrackers/trackMediaStartEvent.ts
+++ b/tracker/core/react/src/eventTrackers/trackMediaStartEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeMediaStartEvent } from '@objectiv/tracker-core';

--- a/tracker/core/react/src/eventTrackers/trackMediaStartEvent.ts
+++ b/tracker/core/react/src/eventTrackers/trackMediaStartEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeMediaStartEvent } from '@objectiv/tracker-core';

--- a/tracker/core/react/src/eventTrackers/trackMediaStopEvent.ts
+++ b/tracker/core/react/src/eventTrackers/trackMediaStopEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeMediaStopEvent } from '@objectiv/tracker-core';

--- a/tracker/core/react/src/eventTrackers/trackMediaStopEvent.ts
+++ b/tracker/core/react/src/eventTrackers/trackMediaStopEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeMediaStopEvent } from '@objectiv/tracker-core';

--- a/tracker/core/react/src/eventTrackers/trackNonInteractiveEvent.ts
+++ b/tracker/core/react/src/eventTrackers/trackNonInteractiveEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeNonInteractiveEvent } from '@objectiv/tracker-core';

--- a/tracker/core/react/src/eventTrackers/trackNonInteractiveEvent.ts
+++ b/tracker/core/react/src/eventTrackers/trackNonInteractiveEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeNonInteractiveEvent } from '@objectiv/tracker-core';

--- a/tracker/core/react/src/eventTrackers/trackPressEvent.ts
+++ b/tracker/core/react/src/eventTrackers/trackPressEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makePressEvent } from '@objectiv/tracker-core';

--- a/tracker/core/react/src/eventTrackers/trackPressEvent.ts
+++ b/tracker/core/react/src/eventTrackers/trackPressEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makePressEvent } from '@objectiv/tracker-core';

--- a/tracker/core/react/src/eventTrackers/trackSuccessEvent.ts
+++ b/tracker/core/react/src/eventTrackers/trackSuccessEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeSuccessEvent } from '@objectiv/tracker-core';

--- a/tracker/core/react/src/eventTrackers/trackSuccessEvent.ts
+++ b/tracker/core/react/src/eventTrackers/trackSuccessEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeSuccessEvent } from '@objectiv/tracker-core';

--- a/tracker/core/react/src/eventTrackers/trackVisibility.ts
+++ b/tracker/core/react/src/eventTrackers/trackVisibility.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeHiddenEvent, makeVisibleEvent } from '@objectiv/tracker-core';

--- a/tracker/core/react/src/eventTrackers/trackVisibility.ts
+++ b/tracker/core/react/src/eventTrackers/trackVisibility.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeHiddenEvent, makeVisibleEvent } from '@objectiv/tracker-core';

--- a/tracker/core/react/src/eventTrackers/trackVisibleEvent.ts
+++ b/tracker/core/react/src/eventTrackers/trackVisibleEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeVisibleEvent } from '@objectiv/tracker-core';

--- a/tracker/core/react/src/eventTrackers/trackVisibleEvent.ts
+++ b/tracker/core/react/src/eventTrackers/trackVisibleEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeVisibleEvent } from '@objectiv/tracker-core';

--- a/tracker/core/react/src/hooks/consumers/useLocationStack.tsx
+++ b/tracker/core/react/src/hooks/consumers/useLocationStack.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { useContext } from 'react';

--- a/tracker/core/react/src/hooks/consumers/useLocationStack.tsx
+++ b/tracker/core/react/src/hooks/consumers/useLocationStack.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { useContext } from 'react';

--- a/tracker/core/react/src/hooks/consumers/useParentLocationContext.ts
+++ b/tracker/core/react/src/hooks/consumers/useParentLocationContext.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { useLocationStack } from './useLocationStack';

--- a/tracker/core/react/src/hooks/consumers/useParentLocationContext.ts
+++ b/tracker/core/react/src/hooks/consumers/useParentLocationContext.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { useLocationStack } from './useLocationStack';

--- a/tracker/core/react/src/hooks/consumers/useTracker.tsx
+++ b/tracker/core/react/src/hooks/consumers/useTracker.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { useContext } from 'react';

--- a/tracker/core/react/src/hooks/consumers/useTracker.tsx
+++ b/tracker/core/react/src/hooks/consumers/useTracker.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { useContext } from 'react';

--- a/tracker/core/react/src/hooks/consumers/useTrackingContext.tsx
+++ b/tracker/core/react/src/hooks/consumers/useTrackingContext.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { TrackingContext } from '../../common/providers/TrackingContext';

--- a/tracker/core/react/src/hooks/consumers/useTrackingContext.tsx
+++ b/tracker/core/react/src/hooks/consumers/useTrackingContext.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { TrackingContext } from '../../common/providers/TrackingContext';

--- a/tracker/core/react/src/hooks/eventTrackers/useApplicationLoadedEventTracker.ts
+++ b/tracker/core/react/src/hooks/eventTrackers/useApplicationLoadedEventTracker.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { trackApplicationLoadedEvent } from '../../eventTrackers/trackApplicationLoadedEvent';

--- a/tracker/core/react/src/hooks/eventTrackers/useApplicationLoadedEventTracker.ts
+++ b/tracker/core/react/src/hooks/eventTrackers/useApplicationLoadedEventTracker.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { trackApplicationLoadedEvent } from '../../eventTrackers/trackApplicationLoadedEvent';

--- a/tracker/core/react/src/hooks/eventTrackers/useFailureEventTracker.ts
+++ b/tracker/core/react/src/hooks/eventTrackers/useFailureEventTracker.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { trackFailureEvent } from '../../eventTrackers/trackFailureEvent';

--- a/tracker/core/react/src/hooks/eventTrackers/useFailureEventTracker.ts
+++ b/tracker/core/react/src/hooks/eventTrackers/useFailureEventTracker.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { trackFailureEvent } from '../../eventTrackers/trackFailureEvent';

--- a/tracker/core/react/src/hooks/eventTrackers/useHiddenEventTracker.ts
+++ b/tracker/core/react/src/hooks/eventTrackers/useHiddenEventTracker.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { trackHiddenEvent } from '../../eventTrackers/trackHiddenEvent';

--- a/tracker/core/react/src/hooks/eventTrackers/useHiddenEventTracker.ts
+++ b/tracker/core/react/src/hooks/eventTrackers/useHiddenEventTracker.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { trackHiddenEvent } from '../../eventTrackers/trackHiddenEvent';

--- a/tracker/core/react/src/hooks/eventTrackers/useInputChangeEventTracker.ts
+++ b/tracker/core/react/src/hooks/eventTrackers/useInputChangeEventTracker.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { trackInputChangeEvent } from '../../eventTrackers/trackInputChangeEvent';

--- a/tracker/core/react/src/hooks/eventTrackers/useInputChangeEventTracker.ts
+++ b/tracker/core/react/src/hooks/eventTrackers/useInputChangeEventTracker.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { trackInputChangeEvent } from '../../eventTrackers/trackInputChangeEvent';

--- a/tracker/core/react/src/hooks/eventTrackers/useInteractiveEventTracker.ts
+++ b/tracker/core/react/src/hooks/eventTrackers/useInteractiveEventTracker.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { trackInteractiveEvent } from '../../eventTrackers/trackInteractiveEvent';

--- a/tracker/core/react/src/hooks/eventTrackers/useInteractiveEventTracker.ts
+++ b/tracker/core/react/src/hooks/eventTrackers/useInteractiveEventTracker.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { trackInteractiveEvent } from '../../eventTrackers/trackInteractiveEvent';

--- a/tracker/core/react/src/hooks/eventTrackers/useMediaEventTracker.ts
+++ b/tracker/core/react/src/hooks/eventTrackers/useMediaEventTracker.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { trackMediaEvent } from '../../eventTrackers/trackMediaEvent';

--- a/tracker/core/react/src/hooks/eventTrackers/useMediaEventTracker.ts
+++ b/tracker/core/react/src/hooks/eventTrackers/useMediaEventTracker.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { trackMediaEvent } from '../../eventTrackers/trackMediaEvent';

--- a/tracker/core/react/src/hooks/eventTrackers/useMediaLoadEventTracker.ts
+++ b/tracker/core/react/src/hooks/eventTrackers/useMediaLoadEventTracker.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { trackMediaLoadEvent } from '../../eventTrackers/trackMediaLoadEvent';

--- a/tracker/core/react/src/hooks/eventTrackers/useMediaLoadEventTracker.ts
+++ b/tracker/core/react/src/hooks/eventTrackers/useMediaLoadEventTracker.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { trackMediaLoadEvent } from '../../eventTrackers/trackMediaLoadEvent';

--- a/tracker/core/react/src/hooks/eventTrackers/useMediaPauseEventTracker.ts
+++ b/tracker/core/react/src/hooks/eventTrackers/useMediaPauseEventTracker.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { trackMediaPauseEvent } from '../../eventTrackers/trackMediaPauseEvent';

--- a/tracker/core/react/src/hooks/eventTrackers/useMediaPauseEventTracker.ts
+++ b/tracker/core/react/src/hooks/eventTrackers/useMediaPauseEventTracker.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { trackMediaPauseEvent } from '../../eventTrackers/trackMediaPauseEvent';

--- a/tracker/core/react/src/hooks/eventTrackers/useMediaStartEventTracker.ts
+++ b/tracker/core/react/src/hooks/eventTrackers/useMediaStartEventTracker.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { trackMediaStartEvent } from '../../eventTrackers/trackMediaStartEvent';

--- a/tracker/core/react/src/hooks/eventTrackers/useMediaStartEventTracker.ts
+++ b/tracker/core/react/src/hooks/eventTrackers/useMediaStartEventTracker.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { trackMediaStartEvent } from '../../eventTrackers/trackMediaStartEvent';

--- a/tracker/core/react/src/hooks/eventTrackers/useMediaStopEventTracker.ts
+++ b/tracker/core/react/src/hooks/eventTrackers/useMediaStopEventTracker.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { trackMediaStopEvent } from '../../eventTrackers/trackMediaStopEvent';

--- a/tracker/core/react/src/hooks/eventTrackers/useMediaStopEventTracker.ts
+++ b/tracker/core/react/src/hooks/eventTrackers/useMediaStopEventTracker.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { trackMediaStopEvent } from '../../eventTrackers/trackMediaStopEvent';

--- a/tracker/core/react/src/hooks/eventTrackers/useNonInteractiveEventTracker.ts
+++ b/tracker/core/react/src/hooks/eventTrackers/useNonInteractiveEventTracker.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { trackNonInteractiveEvent } from '../../eventTrackers/trackNonInteractiveEvent';

--- a/tracker/core/react/src/hooks/eventTrackers/useNonInteractiveEventTracker.ts
+++ b/tracker/core/react/src/hooks/eventTrackers/useNonInteractiveEventTracker.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { trackNonInteractiveEvent } from '../../eventTrackers/trackNonInteractiveEvent';

--- a/tracker/core/react/src/hooks/eventTrackers/usePressEventTracker.ts
+++ b/tracker/core/react/src/hooks/eventTrackers/usePressEventTracker.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { trackPressEvent } from '../../eventTrackers/trackPressEvent';

--- a/tracker/core/react/src/hooks/eventTrackers/usePressEventTracker.ts
+++ b/tracker/core/react/src/hooks/eventTrackers/usePressEventTracker.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { trackPressEvent } from '../../eventTrackers/trackPressEvent';

--- a/tracker/core/react/src/hooks/eventTrackers/useSuccessEventTracker.ts
+++ b/tracker/core/react/src/hooks/eventTrackers/useSuccessEventTracker.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { trackSuccessEvent } from '../../eventTrackers/trackSuccessEvent';

--- a/tracker/core/react/src/hooks/eventTrackers/useSuccessEventTracker.ts
+++ b/tracker/core/react/src/hooks/eventTrackers/useSuccessEventTracker.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { trackSuccessEvent } from '../../eventTrackers/trackSuccessEvent';

--- a/tracker/core/react/src/hooks/eventTrackers/useVisibilityTracker.ts
+++ b/tracker/core/react/src/hooks/eventTrackers/useVisibilityTracker.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { trackVisibility } from '../../eventTrackers/trackVisibility';

--- a/tracker/core/react/src/hooks/eventTrackers/useVisibilityTracker.ts
+++ b/tracker/core/react/src/hooks/eventTrackers/useVisibilityTracker.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { trackVisibility } from '../../eventTrackers/trackVisibility';

--- a/tracker/core/react/src/hooks/eventTrackers/useVisibleEventTracker.ts
+++ b/tracker/core/react/src/hooks/eventTrackers/useVisibleEventTracker.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { trackVisibleEvent } from '../../eventTrackers/trackVisibleEvent';

--- a/tracker/core/react/src/hooks/eventTrackers/useVisibleEventTracker.ts
+++ b/tracker/core/react/src/hooks/eventTrackers/useVisibleEventTracker.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { trackVisibleEvent } from '../../eventTrackers/trackVisibleEvent';

--- a/tracker/core/react/src/hooks/useOnChange.ts
+++ b/tracker/core/react/src/hooks/useOnChange.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { useEffect, useRef } from 'react';

--- a/tracker/core/react/src/hooks/useOnChange.ts
+++ b/tracker/core/react/src/hooks/useOnChange.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { useEffect, useRef } from 'react';

--- a/tracker/core/react/src/hooks/useOnMount.ts
+++ b/tracker/core/react/src/hooks/useOnMount.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { EffectCallback, useEffect } from 'react';

--- a/tracker/core/react/src/hooks/useOnMount.ts
+++ b/tracker/core/react/src/hooks/useOnMount.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { EffectCallback, useEffect } from 'react';

--- a/tracker/core/react/src/hooks/useOnToggle.ts
+++ b/tracker/core/react/src/hooks/useOnToggle.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { useEffect, useRef } from 'react';

--- a/tracker/core/react/src/hooks/useOnToggle.ts
+++ b/tracker/core/react/src/hooks/useOnToggle.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { useEffect, useRef } from 'react';

--- a/tracker/core/react/src/hooks/useOnUnmount.ts
+++ b/tracker/core/react/src/hooks/useOnUnmount.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { useEffect, useRef } from 'react';

--- a/tracker/core/react/src/hooks/useOnUnmount.ts
+++ b/tracker/core/react/src/hooks/useOnUnmount.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { useEffect, useRef } from 'react';

--- a/tracker/core/react/src/hooks/useTrackOnChange.ts
+++ b/tracker/core/react/src/hooks/useTrackOnChange.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { TrackerEventConfig } from '@objectiv/tracker-core';

--- a/tracker/core/react/src/hooks/useTrackOnChange.ts
+++ b/tracker/core/react/src/hooks/useTrackOnChange.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { TrackerEventConfig } from '@objectiv/tracker-core';

--- a/tracker/core/react/src/hooks/useTrackOnMount.ts
+++ b/tracker/core/react/src/hooks/useTrackOnMount.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { TrackerEventConfig } from '@objectiv/tracker-core';

--- a/tracker/core/react/src/hooks/useTrackOnMount.ts
+++ b/tracker/core/react/src/hooks/useTrackOnMount.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { TrackerEventConfig } from '@objectiv/tracker-core';

--- a/tracker/core/react/src/hooks/useTrackOnToggle.ts
+++ b/tracker/core/react/src/hooks/useTrackOnToggle.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { TrackerEventConfig } from '@objectiv/tracker-core';

--- a/tracker/core/react/src/hooks/useTrackOnToggle.ts
+++ b/tracker/core/react/src/hooks/useTrackOnToggle.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { TrackerEventConfig } from '@objectiv/tracker-core';

--- a/tracker/core/react/src/hooks/useTrackOnUnmount.ts
+++ b/tracker/core/react/src/hooks/useTrackOnUnmount.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { TrackerEventConfig } from '@objectiv/tracker-core';

--- a/tracker/core/react/src/hooks/useTrackOnUnmount.ts
+++ b/tracker/core/react/src/hooks/useTrackOnUnmount.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { TrackerEventConfig } from '@objectiv/tracker-core';

--- a/tracker/core/react/src/index.ts
+++ b/tracker/core/react/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 export * from './common/factories/makeContentContext';

--- a/tracker/core/react/src/index.ts
+++ b/tracker/core/react/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 export * from './common/factories/makeContentContext';

--- a/tracker/core/react/src/locationWrappers/ContentContextWrapper.tsx
+++ b/tracker/core/react/src/locationWrappers/ContentContextWrapper.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeContentContext } from '../common/factories/makeContentContext';

--- a/tracker/core/react/src/locationWrappers/ContentContextWrapper.tsx
+++ b/tracker/core/react/src/locationWrappers/ContentContextWrapper.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeContentContext } from '../common/factories/makeContentContext';

--- a/tracker/core/react/src/locationWrappers/ExpandableContextWrapper.tsx
+++ b/tracker/core/react/src/locationWrappers/ExpandableContextWrapper.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeExpandableContext } from '../common/factories/makeExpandableContext';

--- a/tracker/core/react/src/locationWrappers/ExpandableContextWrapper.tsx
+++ b/tracker/core/react/src/locationWrappers/ExpandableContextWrapper.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeExpandableContext } from '../common/factories/makeExpandableContext';

--- a/tracker/core/react/src/locationWrappers/InputContextWrapper.tsx
+++ b/tracker/core/react/src/locationWrappers/InputContextWrapper.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeInputContext } from '../common/factories/makeInputContext';

--- a/tracker/core/react/src/locationWrappers/InputContextWrapper.tsx
+++ b/tracker/core/react/src/locationWrappers/InputContextWrapper.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeInputContext } from '../common/factories/makeInputContext';

--- a/tracker/core/react/src/locationWrappers/LinkContextWrapper.tsx
+++ b/tracker/core/react/src/locationWrappers/LinkContextWrapper.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeLinkContext } from '../common/factories/makeLinkContext';

--- a/tracker/core/react/src/locationWrappers/LinkContextWrapper.tsx
+++ b/tracker/core/react/src/locationWrappers/LinkContextWrapper.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeLinkContext } from '../common/factories/makeLinkContext';

--- a/tracker/core/react/src/locationWrappers/LocationContextWrapper.tsx
+++ b/tracker/core/react/src/locationWrappers/LocationContextWrapper.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { AbstractLocationContext } from '@objectiv/schema';

--- a/tracker/core/react/src/locationWrappers/LocationContextWrapper.tsx
+++ b/tracker/core/react/src/locationWrappers/LocationContextWrapper.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { AbstractLocationContext } from '@objectiv/schema';

--- a/tracker/core/react/src/locationWrappers/MediaPlayerContextWrapper.tsx
+++ b/tracker/core/react/src/locationWrappers/MediaPlayerContextWrapper.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeMediaPlayerContext } from '../common/factories/makeMediaPlayerContext';

--- a/tracker/core/react/src/locationWrappers/MediaPlayerContextWrapper.tsx
+++ b/tracker/core/react/src/locationWrappers/MediaPlayerContextWrapper.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeMediaPlayerContext } from '../common/factories/makeMediaPlayerContext';

--- a/tracker/core/react/src/locationWrappers/NavigationContextWrapper.tsx
+++ b/tracker/core/react/src/locationWrappers/NavigationContextWrapper.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeNavigationContext } from '../common/factories/makeNavigationContext';

--- a/tracker/core/react/src/locationWrappers/NavigationContextWrapper.tsx
+++ b/tracker/core/react/src/locationWrappers/NavigationContextWrapper.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeNavigationContext } from '../common/factories/makeNavigationContext';

--- a/tracker/core/react/src/locationWrappers/OverlayContextWrapper.tsx
+++ b/tracker/core/react/src/locationWrappers/OverlayContextWrapper.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeOverlayContext } from '../common/factories/makeOverlayContext';

--- a/tracker/core/react/src/locationWrappers/OverlayContextWrapper.tsx
+++ b/tracker/core/react/src/locationWrappers/OverlayContextWrapper.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeOverlayContext } from '../common/factories/makeOverlayContext';

--- a/tracker/core/react/src/locationWrappers/PressableContextWrapper.tsx
+++ b/tracker/core/react/src/locationWrappers/PressableContextWrapper.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makePressableContext } from '../common/factories/makePressableContext';

--- a/tracker/core/react/src/locationWrappers/PressableContextWrapper.tsx
+++ b/tracker/core/react/src/locationWrappers/PressableContextWrapper.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makePressableContext } from '../common/factories/makePressableContext';

--- a/tracker/core/react/src/locationWrappers/RootLocationContextWrapper.tsx
+++ b/tracker/core/react/src/locationWrappers/RootLocationContextWrapper.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeRootLocationContext } from '../common/factories/makeRootLocationContext';

--- a/tracker/core/react/src/locationWrappers/RootLocationContextWrapper.tsx
+++ b/tracker/core/react/src/locationWrappers/RootLocationContextWrapper.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeRootLocationContext } from '../common/factories/makeRootLocationContext';

--- a/tracker/core/react/src/types.ts
+++ b/tracker/core/react/src/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { AbstractLocationContext } from '@objectiv/schema';

--- a/tracker/core/react/src/types.ts
+++ b/tracker/core/react/src/types.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { AbstractLocationContext } from '@objectiv/schema';

--- a/tracker/core/react/tests/ApplicationLoadedEvent.test.tsx
+++ b/tracker/core/react/tests/ApplicationLoadedEvent.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeApplicationLoadedEvent, Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/ApplicationLoadedEvent.test.tsx
+++ b/tracker/core/react/tests/ApplicationLoadedEvent.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeApplicationLoadedEvent, Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/ExpandableContextWrapper.test.tsx
+++ b/tracker/core/react/tests/ExpandableContextWrapper.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/ExpandableContextWrapper.test.tsx
+++ b/tracker/core/react/tests/ExpandableContextWrapper.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/FailureEvent.test.tsx
+++ b/tracker/core/react/tests/FailureEvent.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeFailureEvent, Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/FailureEvent.test.tsx
+++ b/tracker/core/react/tests/FailureEvent.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeFailureEvent, Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/HiddenEvent.test.tsx
+++ b/tracker/core/react/tests/HiddenEvent.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeHiddenEvent, Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/HiddenEvent.test.tsx
+++ b/tracker/core/react/tests/HiddenEvent.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeHiddenEvent, Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/InputChangeEvent.test.tsx
+++ b/tracker/core/react/tests/InputChangeEvent.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeInputChangeEvent, Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/InputChangeEvent.test.tsx
+++ b/tracker/core/react/tests/InputChangeEvent.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeInputChangeEvent, Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/InputContextWrapper.test.tsx
+++ b/tracker/core/react/tests/InputContextWrapper.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/InputContextWrapper.test.tsx
+++ b/tracker/core/react/tests/InputContextWrapper.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/InteractiveEvent.test.tsx
+++ b/tracker/core/react/tests/InteractiveEvent.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeInteractiveEvent, Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/InteractiveEvent.test.tsx
+++ b/tracker/core/react/tests/InteractiveEvent.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeInteractiveEvent, Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/LinkContextWrapper.test.tsx
+++ b/tracker/core/react/tests/LinkContextWrapper.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/LinkContextWrapper.test.tsx
+++ b/tracker/core/react/tests/LinkContextWrapper.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/LocationContextWrapper.test.tsx
+++ b/tracker/core/react/tests/LocationContextWrapper.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/LocationContextWrapper.test.tsx
+++ b/tracker/core/react/tests/LocationContextWrapper.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/LocationTree.test.ts
+++ b/tracker/core/react/tests/LocationTree.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { LocationTree, makeContentContext } from '../src';

--- a/tracker/core/react/tests/LocationTree.test.ts
+++ b/tracker/core/react/tests/LocationTree.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { LocationTree, makeContentContext } from '../src';

--- a/tracker/core/react/tests/MediaEvent.test.tsx
+++ b/tracker/core/react/tests/MediaEvent.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeMediaEvent, Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/MediaEvent.test.tsx
+++ b/tracker/core/react/tests/MediaEvent.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeMediaEvent, Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/MediaLoadEvent.test.tsx
+++ b/tracker/core/react/tests/MediaLoadEvent.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeMediaLoadEvent, Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/MediaLoadEvent.test.tsx
+++ b/tracker/core/react/tests/MediaLoadEvent.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeMediaLoadEvent, Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/MediaPauseEvent.test.tsx
+++ b/tracker/core/react/tests/MediaPauseEvent.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeMediaPauseEvent, Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/MediaPauseEvent.test.tsx
+++ b/tracker/core/react/tests/MediaPauseEvent.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeMediaPauseEvent, Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/MediaPlayerContextWrapper.test.tsx
+++ b/tracker/core/react/tests/MediaPlayerContextWrapper.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/MediaPlayerContextWrapper.test.tsx
+++ b/tracker/core/react/tests/MediaPlayerContextWrapper.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/MediaStartEvent.test.tsx
+++ b/tracker/core/react/tests/MediaStartEvent.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeMediaStartEvent, Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/MediaStartEvent.test.tsx
+++ b/tracker/core/react/tests/MediaStartEvent.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeMediaStartEvent, Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/MediaStopEvent.test.tsx
+++ b/tracker/core/react/tests/MediaStopEvent.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeMediaStopEvent, Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/MediaStopEvent.test.tsx
+++ b/tracker/core/react/tests/MediaStopEvent.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeMediaStopEvent, Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/NavigationContextWrapper.test.tsx
+++ b/tracker/core/react/tests/NavigationContextWrapper.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/NavigationContextWrapper.test.tsx
+++ b/tracker/core/react/tests/NavigationContextWrapper.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/NonInteractiveEvent.test.tsx
+++ b/tracker/core/react/tests/NonInteractiveEvent.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeNonInteractiveEvent, Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/NonInteractiveEvent.test.tsx
+++ b/tracker/core/react/tests/NonInteractiveEvent.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeNonInteractiveEvent, Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/ObjectivProvider.test.tsx
+++ b/tracker/core/react/tests/ObjectivProvider.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeApplicationLoadedEvent, Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/ObjectivProvider.test.tsx
+++ b/tracker/core/react/tests/ObjectivProvider.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeApplicationLoadedEvent, Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/OverlayContextWrapper.test.tsx
+++ b/tracker/core/react/tests/OverlayContextWrapper.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/OverlayContextWrapper.test.tsx
+++ b/tracker/core/react/tests/OverlayContextWrapper.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/PressEvent.test.tsx
+++ b/tracker/core/react/tests/PressEvent.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makePressEvent, Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/PressEvent.test.tsx
+++ b/tracker/core/react/tests/PressEvent.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makePressEvent, Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/PressableContextWrapper.test.tsx
+++ b/tracker/core/react/tests/PressableContextWrapper.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/PressableContextWrapper.test.tsx
+++ b/tracker/core/react/tests/PressableContextWrapper.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/RootLocationContextWrapper.test.tsx
+++ b/tracker/core/react/tests/RootLocationContextWrapper.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/RootLocationContextWrapper.test.tsx
+++ b/tracker/core/react/tests/RootLocationContextWrapper.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/SectionContextWrapper.test.tsx
+++ b/tracker/core/react/tests/SectionContextWrapper.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/SectionContextWrapper.test.tsx
+++ b/tracker/core/react/tests/SectionContextWrapper.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/SuccessEvent.test.tsx
+++ b/tracker/core/react/tests/SuccessEvent.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeSuccessEvent, Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/SuccessEvent.test.tsx
+++ b/tracker/core/react/tests/SuccessEvent.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeSuccessEvent, Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/TrackerProvider.test.tsx
+++ b/tracker/core/react/tests/TrackerProvider.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/TrackerProvider.test.tsx
+++ b/tracker/core/react/tests/TrackerProvider.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/TrackingContextProvider.test.tsx
+++ b/tracker/core/react/tests/TrackingContextProvider.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/TrackingContextProvider.test.tsx
+++ b/tracker/core/react/tests/TrackingContextProvider.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/Visibility.test.tsx
+++ b/tracker/core/react/tests/Visibility.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeHiddenEvent, makeVisibleEvent, Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/Visibility.test.tsx
+++ b/tracker/core/react/tests/Visibility.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeHiddenEvent, makeVisibleEvent, Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/VisibleEvent.test.tsx
+++ b/tracker/core/react/tests/VisibleEvent.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeVisibleEvent, Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/VisibleEvent.test.tsx
+++ b/tracker/core/react/tests/VisibleEvent.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeVisibleEvent, Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/makeIdFromString.test.ts
+++ b/tracker/core/react/tests/makeIdFromString.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeIdFromString } from '../src';

--- a/tracker/core/react/tests/makeIdFromString.test.ts
+++ b/tracker/core/react/tests/makeIdFromString.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeIdFromString } from '../src';

--- a/tracker/core/react/tests/makeTextFromChildren.test.tsx
+++ b/tracker/core/react/tests/makeTextFromChildren.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { ReactNode } from 'react';

--- a/tracker/core/react/tests/makeTextFromChildren.test.tsx
+++ b/tracker/core/react/tests/makeTextFromChildren.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { ReactNode } from 'react';

--- a/tracker/core/react/tests/useOnChange.test.ts
+++ b/tracker/core/react/tests/useOnChange.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { renderHook } from '@testing-library/react-hooks';

--- a/tracker/core/react/tests/useOnChange.test.ts
+++ b/tracker/core/react/tests/useOnChange.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { renderHook } from '@testing-library/react-hooks';

--- a/tracker/core/react/tests/useOnMount.test.ts
+++ b/tracker/core/react/tests/useOnMount.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { renderHook } from '@testing-library/react-hooks';

--- a/tracker/core/react/tests/useOnMount.test.ts
+++ b/tracker/core/react/tests/useOnMount.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { renderHook } from '@testing-library/react-hooks';

--- a/tracker/core/react/tests/useOnToggle.test.ts
+++ b/tracker/core/react/tests/useOnToggle.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { renderHook } from '@testing-library/react-hooks';

--- a/tracker/core/react/tests/useOnToggle.test.ts
+++ b/tracker/core/react/tests/useOnToggle.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { renderHook } from '@testing-library/react-hooks';

--- a/tracker/core/react/tests/useOnUnmount.test.ts
+++ b/tracker/core/react/tests/useOnUnmount.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { renderHook } from '@testing-library/react-hooks';

--- a/tracker/core/react/tests/useOnUnmount.test.ts
+++ b/tracker/core/react/tests/useOnUnmount.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { renderHook } from '@testing-library/react-hooks';

--- a/tracker/core/react/tests/useTrackOnChange.test.tsx
+++ b/tracker/core/react/tests/useTrackOnChange.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/useTrackOnChange.test.tsx
+++ b/tracker/core/react/tests/useTrackOnChange.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/useTrackOnMount.test.tsx
+++ b/tracker/core/react/tests/useTrackOnMount.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeVisibleEvent, Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/useTrackOnMount.test.tsx
+++ b/tracker/core/react/tests/useTrackOnMount.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeVisibleEvent, Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/useTrackOnToggle.test.tsx
+++ b/tracker/core/react/tests/useTrackOnToggle.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeHiddenEvent, makeVisibleEvent, Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/useTrackOnToggle.test.tsx
+++ b/tracker/core/react/tests/useTrackOnToggle.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeHiddenEvent, makeVisibleEvent, Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/useTrackOnUnmount.test.tsx
+++ b/tracker/core/react/tests/useTrackOnUnmount.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeHiddenEvent, Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/react/tests/useTrackOnUnmount.test.tsx
+++ b/tracker/core/react/tests/useTrackOnUnmount.test.tsx
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeHiddenEvent, Tracker } from '@objectiv/tracker-core';

--- a/tracker/core/schema/src/abstracts.d.ts
+++ b/tracker/core/schema/src/abstracts.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 /**

--- a/tracker/core/schema/src/abstracts.d.ts
+++ b/tracker/core/schema/src/abstracts.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 /**

--- a/tracker/core/schema/src/events.d.ts
+++ b/tracker/core/schema/src/events.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { AbstractInteractiveEvent, AbstractNonInteractiveEvent, AbstractMediaEvent } from './abstracts';

--- a/tracker/core/schema/src/events.d.ts
+++ b/tracker/core/schema/src/events.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { AbstractInteractiveEvent, AbstractNonInteractiveEvent, AbstractMediaEvent } from './abstracts';

--- a/tracker/core/schema/src/global_contexts.d.ts
+++ b/tracker/core/schema/src/global_contexts.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { AbstractGlobalContext } from './abstracts';

--- a/tracker/core/schema/src/global_contexts.d.ts
+++ b/tracker/core/schema/src/global_contexts.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { AbstractGlobalContext } from './abstracts';

--- a/tracker/core/schema/src/index.d.ts
+++ b/tracker/core/schema/src/index.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 export * from './abstracts';

--- a/tracker/core/schema/src/index.d.ts
+++ b/tracker/core/schema/src/index.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 export * from './abstracts';

--- a/tracker/core/schema/src/location_contexts.d.ts
+++ b/tracker/core/schema/src/location_contexts.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { AbstractLocationContext, AbstractPressableContext } from './abstracts';

--- a/tracker/core/schema/src/location_contexts.d.ts
+++ b/tracker/core/schema/src/location_contexts.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { AbstractLocationContext, AbstractPressableContext } from './abstracts';

--- a/tracker/core/schema/src/static.d.ts
+++ b/tracker/core/schema/src/static.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { AbstractGlobalContext, AbstractLocationContext } from './abstracts';

--- a/tracker/core/schema/src/static.d.ts
+++ b/tracker/core/schema/src/static.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { AbstractGlobalContext, AbstractLocationContext } from './abstracts';

--- a/tracker/core/testing-tools/src/ConfigurableMockTransport.ts
+++ b/tracker/core/testing-tools/src/ConfigurableMockTransport.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { TrackerConsole, TrackerTransportConfig, TrackerTransportInterface } from '@objectiv/tracker-core';

--- a/tracker/core/testing-tools/src/ConfigurableMockTransport.ts
+++ b/tracker/core/testing-tools/src/ConfigurableMockTransport.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { TrackerConsole, TrackerTransportConfig, TrackerTransportInterface } from '@objectiv/tracker-core';

--- a/tracker/core/testing-tools/src/LogTransport.ts
+++ b/tracker/core/testing-tools/src/LogTransport.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { TrackerConsole, TrackerTransportConfig, TrackerTransportInterface } from '@objectiv/tracker-core';

--- a/tracker/core/testing-tools/src/LogTransport.ts
+++ b/tracker/core/testing-tools/src/LogTransport.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { TrackerConsole, TrackerTransportConfig, TrackerTransportInterface } from '@objectiv/tracker-core';

--- a/tracker/core/testing-tools/src/SpyTransport.ts
+++ b/tracker/core/testing-tools/src/SpyTransport.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { TrackerConsole, TrackerTransportConfig, TrackerTransportInterface } from '@objectiv/tracker-core';

--- a/tracker/core/testing-tools/src/SpyTransport.ts
+++ b/tracker/core/testing-tools/src/SpyTransport.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { TrackerConsole, TrackerTransportConfig, TrackerTransportInterface } from '@objectiv/tracker-core';

--- a/tracker/core/testing-tools/src/UnusableTransport.ts
+++ b/tracker/core/testing-tools/src/UnusableTransport.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { TrackerConsole, TrackerTransportConfig } from '@objectiv/tracker-core';

--- a/tracker/core/testing-tools/src/UnusableTransport.ts
+++ b/tracker/core/testing-tools/src/UnusableTransport.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { TrackerConsole, TrackerTransportConfig } from '@objectiv/tracker-core';

--- a/tracker/core/testing-tools/src/index.ts
+++ b/tracker/core/testing-tools/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 export * from './ConfigurableMockTransport';

--- a/tracker/core/testing-tools/src/index.ts
+++ b/tracker/core/testing-tools/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 export * from './ConfigurableMockTransport';

--- a/tracker/core/testing-tools/src/localStorageMock.ts
+++ b/tracker/core/testing-tools/src/localStorageMock.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 export const localStorageMock = (function () {

--- a/tracker/core/testing-tools/src/localStorageMock.ts
+++ b/tracker/core/testing-tools/src/localStorageMock.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 export const localStorageMock = (function () {

--- a/tracker/core/testing-tools/src/matchUUID.ts
+++ b/tracker/core/testing-tools/src/matchUUID.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 const UUIDV4_REGEX = /^[0-9A-F]{8}-[0-9A-F]{4}-[4][0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i;

--- a/tracker/core/testing-tools/src/matchUUID.ts
+++ b/tracker/core/testing-tools/src/matchUUID.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 const UUIDV4_REGEX = /^[0-9A-F]{8}-[0-9A-F]{4}-[4][0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i;

--- a/tracker/core/testing-tools/src/mockConsole.ts
+++ b/tracker/core/testing-tools/src/mockConsole.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { TrackerConsole } from '@objectiv/tracker-core';

--- a/tracker/core/testing-tools/src/mockConsole.ts
+++ b/tracker/core/testing-tools/src/mockConsole.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { TrackerConsole } from '@objectiv/tracker-core';

--- a/tracker/core/tracker/jest.config.js
+++ b/tracker/core/tracker/jest.config.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 module.exports = {

--- a/tracker/core/tracker/jest.config.js
+++ b/tracker/core/tracker/jest.config.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 module.exports = {

--- a/tracker/core/tracker/rollup.config.js
+++ b/tracker/core/tracker/rollup.config.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import commonjs from '@rollup/plugin-commonjs';

--- a/tracker/core/tracker/rollup.config.js
+++ b/tracker/core/tracker/rollup.config.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import commonjs from '@rollup/plugin-commonjs';

--- a/tracker/core/tracker/src/ApplicationContextPlugin.ts
+++ b/tracker/core/tracker/src/ApplicationContextPlugin.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { ApplicationContext } from '@objectiv/schema';

--- a/tracker/core/tracker/src/ApplicationContextPlugin.ts
+++ b/tracker/core/tracker/src/ApplicationContextPlugin.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { ApplicationContext } from '@objectiv/schema';

--- a/tracker/core/tracker/src/Context.ts
+++ b/tracker/core/tracker/src/Context.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { AbstractGlobalContext, AbstractLocationContext } from '@objectiv/schema';

--- a/tracker/core/tracker/src/Context.ts
+++ b/tracker/core/tracker/src/Context.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { AbstractGlobalContext, AbstractLocationContext } from '@objectiv/schema';

--- a/tracker/core/tracker/src/ContextFactories.ts
+++ b/tracker/core/tracker/src/ContextFactories.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import {

--- a/tracker/core/tracker/src/ContextFactories.ts
+++ b/tracker/core/tracker/src/ContextFactories.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import {

--- a/tracker/core/tracker/src/EventFactories.ts
+++ b/tracker/core/tracker/src/EventFactories.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import {

--- a/tracker/core/tracker/src/EventFactories.ts
+++ b/tracker/core/tracker/src/EventFactories.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import {

--- a/tracker/core/tracker/src/Tracker.ts
+++ b/tracker/core/tracker/src/Tracker.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { AbstractGlobalContext, AbstractLocationContext, Contexts } from '@objectiv/schema';

--- a/tracker/core/tracker/src/Tracker.ts
+++ b/tracker/core/tracker/src/Tracker.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { AbstractGlobalContext, AbstractLocationContext, Contexts } from '@objectiv/schema';

--- a/tracker/core/tracker/src/TrackerConsole.ts
+++ b/tracker/core/tracker/src/TrackerConsole.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 /**

--- a/tracker/core/tracker/src/TrackerConsole.ts
+++ b/tracker/core/tracker/src/TrackerConsole.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 /**

--- a/tracker/core/tracker/src/TrackerElementLocations.ts
+++ b/tracker/core/tracker/src/TrackerElementLocations.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { LocationStack } from './Context';

--- a/tracker/core/tracker/src/TrackerElementLocations.ts
+++ b/tracker/core/tracker/src/TrackerElementLocations.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { LocationStack } from './Context';

--- a/tracker/core/tracker/src/TrackerEvent.ts
+++ b/tracker/core/tracker/src/TrackerEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { AbstractEvent, AbstractGlobalContext, AbstractLocationContext, Contexts } from '@objectiv/schema';

--- a/tracker/core/tracker/src/TrackerEvent.ts
+++ b/tracker/core/tracker/src/TrackerEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { AbstractEvent, AbstractGlobalContext, AbstractLocationContext, Contexts } from '@objectiv/schema';

--- a/tracker/core/tracker/src/TrackerPluginInterface.ts
+++ b/tracker/core/tracker/src/TrackerPluginInterface.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { TrackerConsole } from './TrackerConsole';

--- a/tracker/core/tracker/src/TrackerPluginInterface.ts
+++ b/tracker/core/tracker/src/TrackerPluginInterface.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { TrackerConsole } from './TrackerConsole';

--- a/tracker/core/tracker/src/TrackerPluginLifecycleInterface.ts
+++ b/tracker/core/tracker/src/TrackerPluginLifecycleInterface.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { ContextsConfig } from './Context';

--- a/tracker/core/tracker/src/TrackerPluginLifecycleInterface.ts
+++ b/tracker/core/tracker/src/TrackerPluginLifecycleInterface.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { ContextsConfig } from './Context';

--- a/tracker/core/tracker/src/TrackerPlugins.ts
+++ b/tracker/core/tracker/src/TrackerPlugins.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { ContextsConfig } from './Context';

--- a/tracker/core/tracker/src/TrackerPlugins.ts
+++ b/tracker/core/tracker/src/TrackerPlugins.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { ContextsConfig } from './Context';

--- a/tracker/core/tracker/src/TrackerQueue.ts
+++ b/tracker/core/tracker/src/TrackerQueue.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { isNonEmptyArray, NonEmptyArray } from './helpers';

--- a/tracker/core/tracker/src/TrackerQueue.ts
+++ b/tracker/core/tracker/src/TrackerQueue.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { isNonEmptyArray, NonEmptyArray } from './helpers';

--- a/tracker/core/tracker/src/TrackerQueueInterface.ts
+++ b/tracker/core/tracker/src/TrackerQueueInterface.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { NonEmptyArray } from './helpers';

--- a/tracker/core/tracker/src/TrackerQueueInterface.ts
+++ b/tracker/core/tracker/src/TrackerQueueInterface.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { NonEmptyArray } from './helpers';

--- a/tracker/core/tracker/src/TrackerQueueMemoryStore.ts
+++ b/tracker/core/tracker/src/TrackerQueueMemoryStore.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { NonEmptyArray } from './helpers';

--- a/tracker/core/tracker/src/TrackerQueueMemoryStore.ts
+++ b/tracker/core/tracker/src/TrackerQueueMemoryStore.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { NonEmptyArray } from './helpers';

--- a/tracker/core/tracker/src/TrackerQueueStoreInterface.ts
+++ b/tracker/core/tracker/src/TrackerQueueStoreInterface.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { NonEmptyArray } from './helpers';

--- a/tracker/core/tracker/src/TrackerQueueStoreInterface.ts
+++ b/tracker/core/tracker/src/TrackerQueueStoreInterface.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { NonEmptyArray } from './helpers';

--- a/tracker/core/tracker/src/TrackerRepository.ts
+++ b/tracker/core/tracker/src/TrackerRepository.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { Tracker } from './Tracker';

--- a/tracker/core/tracker/src/TrackerRepository.ts
+++ b/tracker/core/tracker/src/TrackerRepository.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { Tracker } from './Tracker';

--- a/tracker/core/tracker/src/TrackerRepositoryInterface.ts
+++ b/tracker/core/tracker/src/TrackerRepositoryInterface.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { Tracker } from './Tracker';

--- a/tracker/core/tracker/src/TrackerRepositoryInterface.ts
+++ b/tracker/core/tracker/src/TrackerRepositoryInterface.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { Tracker } from './Tracker';

--- a/tracker/core/tracker/src/TrackerTransportGroup.ts
+++ b/tracker/core/tracker/src/TrackerTransportGroup.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { NonEmptyArray } from './helpers';

--- a/tracker/core/tracker/src/TrackerTransportGroup.ts
+++ b/tracker/core/tracker/src/TrackerTransportGroup.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { NonEmptyArray } from './helpers';

--- a/tracker/core/tracker/src/TrackerTransportInterface.ts
+++ b/tracker/core/tracker/src/TrackerTransportInterface.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import ExtendableError from 'es6-error';

--- a/tracker/core/tracker/src/TrackerTransportInterface.ts
+++ b/tracker/core/tracker/src/TrackerTransportInterface.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import ExtendableError from 'es6-error';

--- a/tracker/core/tracker/src/TrackerTransportRetry.ts
+++ b/tracker/core/tracker/src/TrackerTransportRetry.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { NonEmptyArray } from './helpers';

--- a/tracker/core/tracker/src/TrackerTransportRetry.ts
+++ b/tracker/core/tracker/src/TrackerTransportRetry.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { NonEmptyArray } from './helpers';

--- a/tracker/core/tracker/src/TrackerTransportRetryAttempt.ts
+++ b/tracker/core/tracker/src/TrackerTransportRetryAttempt.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { NonEmptyArray } from './helpers';

--- a/tracker/core/tracker/src/TrackerTransportRetryAttempt.ts
+++ b/tracker/core/tracker/src/TrackerTransportRetryAttempt.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { NonEmptyArray } from './helpers';

--- a/tracker/core/tracker/src/TrackerTransportSwitch.ts
+++ b/tracker/core/tracker/src/TrackerTransportSwitch.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { NonEmptyArray } from './helpers';

--- a/tracker/core/tracker/src/TrackerTransportSwitch.ts
+++ b/tracker/core/tracker/src/TrackerTransportSwitch.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { NonEmptyArray } from './helpers';

--- a/tracker/core/tracker/src/cleanObjectFromInternalProperties.ts
+++ b/tracker/core/tracker/src/cleanObjectFromInternalProperties.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { DiscriminatingPropertyPrefix } from '@objectiv/schema';

--- a/tracker/core/tracker/src/cleanObjectFromInternalProperties.ts
+++ b/tracker/core/tracker/src/cleanObjectFromInternalProperties.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { DiscriminatingPropertyPrefix } from '@objectiv/schema';

--- a/tracker/core/tracker/src/helpers.ts
+++ b/tracker/core/tracker/src/helpers.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import uuid from 'uuid-random';

--- a/tracker/core/tracker/src/helpers.ts
+++ b/tracker/core/tracker/src/helpers.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import uuid from 'uuid-random';

--- a/tracker/core/tracker/src/index.ts
+++ b/tracker/core/tracker/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 export * from './ApplicationContextPlugin';

--- a/tracker/core/tracker/src/index.ts
+++ b/tracker/core/tracker/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 export * from './ApplicationContextPlugin';

--- a/tracker/core/tracker/tests/ApplicationContextPlugin.test.ts
+++ b/tracker/core/tracker/tests/ApplicationContextPlugin.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { ApplicationContextPlugin, ContextsConfig, Tracker, TrackerConfig, TrackerEvent, TrackerPlugins } from '../src';

--- a/tracker/core/tracker/tests/ApplicationContextPlugin.test.ts
+++ b/tracker/core/tracker/tests/ApplicationContextPlugin.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { ApplicationContextPlugin, ContextsConfig, Tracker, TrackerConfig, TrackerEvent, TrackerPlugins } from '../src';

--- a/tracker/core/tracker/tests/ContextFactories.test.ts
+++ b/tracker/core/tracker/tests/ContextFactories.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import {

--- a/tracker/core/tracker/tests/ContextFactories.test.ts
+++ b/tracker/core/tracker/tests/ContextFactories.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import {

--- a/tracker/core/tracker/tests/EventFactories.test.ts
+++ b/tracker/core/tracker/tests/EventFactories.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import {

--- a/tracker/core/tracker/tests/EventFactories.test.ts
+++ b/tracker/core/tracker/tests/EventFactories.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import {

--- a/tracker/core/tracker/tests/Tracker.test.ts
+++ b/tracker/core/tracker/tests/Tracker.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { LogTransport, mockConsole, UnusableTransport } from '@objectiv/testing-tools';

--- a/tracker/core/tracker/tests/Tracker.test.ts
+++ b/tracker/core/tracker/tests/Tracker.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { LogTransport, mockConsole, UnusableTransport } from '@objectiv/testing-tools';

--- a/tracker/core/tracker/tests/TrackerConsole.test.ts
+++ b/tracker/core/tracker/tests/TrackerConsole.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { NoopConsole } from '../src';

--- a/tracker/core/tracker/tests/TrackerConsole.test.ts
+++ b/tracker/core/tracker/tests/TrackerConsole.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { NoopConsole } from '../src';

--- a/tracker/core/tracker/tests/TrackerElementLocations.test.ts
+++ b/tracker/core/tracker/tests/TrackerElementLocations.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import {

--- a/tracker/core/tracker/tests/TrackerElementLocations.test.ts
+++ b/tracker/core/tracker/tests/TrackerElementLocations.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import {

--- a/tracker/core/tracker/tests/TrackerEvent.test.ts
+++ b/tracker/core/tracker/tests/TrackerEvent.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import MockDate from 'mockdate';

--- a/tracker/core/tracker/tests/TrackerEvent.test.ts
+++ b/tracker/core/tracker/tests/TrackerEvent.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import MockDate from 'mockdate';

--- a/tracker/core/tracker/tests/TrackerPlugin.test.ts
+++ b/tracker/core/tracker/tests/TrackerPlugin.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { TrackerEvent, TrackerPluginInterface, TrackerPlugins, TrackerPluginsConfiguration } from '../src';

--- a/tracker/core/tracker/tests/TrackerPlugin.test.ts
+++ b/tracker/core/tracker/tests/TrackerPlugin.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { TrackerEvent, TrackerPluginInterface, TrackerPlugins, TrackerPluginsConfiguration } from '../src';

--- a/tracker/core/tracker/tests/TrackerQueue.test.ts
+++ b/tracker/core/tracker/tests/TrackerQueue.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { mockConsole } from '@objectiv/testing-tools';

--- a/tracker/core/tracker/tests/TrackerQueue.test.ts
+++ b/tracker/core/tracker/tests/TrackerQueue.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { mockConsole } from '@objectiv/testing-tools';

--- a/tracker/core/tracker/tests/TrackerRepository.test.ts
+++ b/tracker/core/tracker/tests/TrackerRepository.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { mockConsole } from '@objectiv/testing-tools';

--- a/tracker/core/tracker/tests/TrackerRepository.test.ts
+++ b/tracker/core/tracker/tests/TrackerRepository.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { mockConsole } from '@objectiv/testing-tools';

--- a/tracker/core/tracker/tests/TrackerTransport.test.ts
+++ b/tracker/core/tracker/tests/TrackerTransport.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { ConfigurableMockTransport, LogTransport, mockConsole, UnusableTransport } from '@objectiv/testing-tools';

--- a/tracker/core/tracker/tests/TrackerTransport.test.ts
+++ b/tracker/core/tracker/tests/TrackerTransport.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { ConfigurableMockTransport, LogTransport, mockConsole, UnusableTransport } from '@objectiv/testing-tools';

--- a/tracker/core/tracker/tests/helpers.test.ts
+++ b/tracker/core/tracker/tests/helpers.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { waitForPromise } from '../src';

--- a/tracker/core/tracker/tests/helpers.test.ts
+++ b/tracker/core/tracker/tests/helpers.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { waitForPromise } from '../src';

--- a/tracker/core/utilities/src/generator.js
+++ b/tracker/core/utilities/src/generator.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 // noinspection UnnecessaryLocalVariableJS

--- a/tracker/core/utilities/src/generator.js
+++ b/tracker/core/utilities/src/generator.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 // noinspection UnnecessaryLocalVariableJS
@@ -21,7 +21,7 @@ const fs = require('fs');
 const JSON5 = require('json5');
 
 const COPYRIGHT = `/*
- * Copyright ${new Date().getFullYear()} Objectiv B.V.
+ * Copyright 2021-${new Date().getFullYear()} Objectiv B.V.
  */
  \n
 `;

--- a/tracker/plugins/path-context-from-url/jest.config.js
+++ b/tracker/plugins/path-context-from-url/jest.config.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 module.exports = {

--- a/tracker/plugins/path-context-from-url/jest.config.js
+++ b/tracker/plugins/path-context-from-url/jest.config.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 module.exports = {

--- a/tracker/plugins/path-context-from-url/rollup.config.js
+++ b/tracker/plugins/path-context-from-url/rollup.config.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import commonjs from '@rollup/plugin-commonjs';

--- a/tracker/plugins/path-context-from-url/rollup.config.js
+++ b/tracker/plugins/path-context-from-url/rollup.config.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import commonjs from '@rollup/plugin-commonjs';

--- a/tracker/plugins/path-context-from-url/src/PathContextFromURLPlugin.ts
+++ b/tracker/plugins/path-context-from-url/src/PathContextFromURLPlugin.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import {

--- a/tracker/plugins/path-context-from-url/src/PathContextFromURLPlugin.ts
+++ b/tracker/plugins/path-context-from-url/src/PathContextFromURLPlugin.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import {

--- a/tracker/plugins/path-context-from-url/src/index.ts
+++ b/tracker/plugins/path-context-from-url/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 export * from './PathContextFromURLPlugin';

--- a/tracker/plugins/path-context-from-url/src/index.ts
+++ b/tracker/plugins/path-context-from-url/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 export * from './PathContextFromURLPlugin';

--- a/tracker/plugins/path-context-from-url/tests/PathContextFromURL.node.test.ts
+++ b/tracker/plugins/path-context-from-url/tests/PathContextFromURL.node.test.ts
@@ -1,6 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
- * @jest-environment node
+ * Copyright 2022 Objectiv B.V.
  */
 import { PathContextFromURLPlugin } from '../src';
 

--- a/tracker/plugins/path-context-from-url/tests/PathContextFromURL.node.test.ts
+++ b/tracker/plugins/path-context-from-url/tests/PathContextFromURL.node.test.ts
@@ -1,5 +1,6 @@
 /*
  * Copyright 2022 Objectiv B.V.
+ * @jest-environment node
  */
 import { PathContextFromURLPlugin } from '../src';
 

--- a/tracker/plugins/path-context-from-url/tests/PathContextFromURL.node.test.ts
+++ b/tracker/plugins/path-context-from-url/tests/PathContextFromURL.node.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  * @jest-environment node
  */
 import { PathContextFromURLPlugin } from '../src';

--- a/tracker/plugins/path-context-from-url/tests/PathContextFromURL.test.ts
+++ b/tracker/plugins/path-context-from-url/tests/PathContextFromURL.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { ContextsConfig, Tracker, TrackerEvent, TrackerPlugins } from '@objectiv/tracker-core';

--- a/tracker/plugins/path-context-from-url/tests/PathContextFromURL.test.ts
+++ b/tracker/plugins/path-context-from-url/tests/PathContextFromURL.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { ContextsConfig, Tracker, TrackerEvent, TrackerPlugins } from '@objectiv/tracker-core';

--- a/tracker/plugins/path-context-from-url/tests/global.d.ts
+++ b/tracker/plugins/path-context-from-url/tests/global.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import 'jest-extended';

--- a/tracker/plugins/path-context-from-url/tests/global.d.ts
+++ b/tracker/plugins/path-context-from-url/tests/global.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import 'jest-extended';

--- a/tracker/plugins/path-context-from-url/tests/mocks/MockConsole.ts
+++ b/tracker/plugins/path-context-from-url/tests/mocks/MockConsole.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { TrackerConsole } from '@objectiv/tracker-core';

--- a/tracker/plugins/path-context-from-url/tests/mocks/MockConsole.ts
+++ b/tracker/plugins/path-context-from-url/tests/mocks/MockConsole.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { TrackerConsole } from '@objectiv/tracker-core';

--- a/tracker/plugins/path-context-from-url/tests/mocks/SpyTransport.ts
+++ b/tracker/plugins/path-context-from-url/tests/mocks/SpyTransport.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { TrackerConsole, TrackerTransportConfig, TrackerTransportInterface } from '@objectiv/tracker-core';

--- a/tracker/plugins/path-context-from-url/tests/mocks/SpyTransport.ts
+++ b/tracker/plugins/path-context-from-url/tests/mocks/SpyTransport.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { TrackerConsole, TrackerTransportConfig, TrackerTransportInterface } from '@objectiv/tracker-core';

--- a/tracker/queues/local-storage/jest.config.js
+++ b/tracker/queues/local-storage/jest.config.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 module.exports = {

--- a/tracker/queues/local-storage/jest.config.js
+++ b/tracker/queues/local-storage/jest.config.js
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2022 Objectiv B.V.
+ */
+
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',

--- a/tracker/queues/local-storage/rollup.config.js
+++ b/tracker/queues/local-storage/rollup.config.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import commonjs from '@rollup/plugin-commonjs';

--- a/tracker/queues/local-storage/rollup.config.js
+++ b/tracker/queues/local-storage/rollup.config.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import commonjs from '@rollup/plugin-commonjs';

--- a/tracker/queues/local-storage/src/LocalStorageQueueStore.ts
+++ b/tracker/queues/local-storage/src/LocalStorageQueueStore.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import {

--- a/tracker/queues/local-storage/src/LocalStorageQueueStore.ts
+++ b/tracker/queues/local-storage/src/LocalStorageQueueStore.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import {

--- a/tracker/queues/local-storage/src/index.ts
+++ b/tracker/queues/local-storage/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 export * from './LocalStorageQueueStore';

--- a/tracker/queues/local-storage/src/index.ts
+++ b/tracker/queues/local-storage/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 export * from './LocalStorageQueueStore';

--- a/tracker/queues/local-storage/tests/LocalStorageQueueStore.test.ts
+++ b/tracker/queues/local-storage/tests/LocalStorageQueueStore.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { localStorageMock, mockConsole } from '@objectiv/testing-tools';

--- a/tracker/queues/local-storage/tests/LocalStorageQueueStore.test.ts
+++ b/tracker/queues/local-storage/tests/LocalStorageQueueStore.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { localStorageMock, mockConsole } from '@objectiv/testing-tools';

--- a/tracker/queues/local-storage/tests/withoutDOM.test.ts
+++ b/tracker/queues/local-storage/tests/withoutDOM.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  * @jest-environment node
  */
 

--- a/tracker/queues/local-storage/tests/withoutDOM.test.ts
+++ b/tracker/queues/local-storage/tests/withoutDOM.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  * @jest-environment node
  */
 

--- a/tracker/trackers/angular/src/index.ts
+++ b/tracker/trackers/angular/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 export * from './objectiv-tracker.directive';

--- a/tracker/trackers/angular/src/index.ts
+++ b/tracker/trackers/angular/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 export * from './objectiv-tracker.directive';

--- a/tracker/trackers/angular/src/objectiv-tracker.directive.ts
+++ b/tracker/trackers/angular/src/objectiv-tracker.directive.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { Directive, ElementRef, Input } from '@angular/core';

--- a/tracker/trackers/angular/src/objectiv-tracker.directive.ts
+++ b/tracker/trackers/angular/src/objectiv-tracker.directive.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { Directive, ElementRef, Input } from '@angular/core';

--- a/tracker/trackers/angular/src/objectiv-tracker.initializer.ts
+++ b/tracker/trackers/angular/src/objectiv-tracker.initializer.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { APP_INITIALIZER, Provider } from '@angular/core';

--- a/tracker/trackers/angular/src/objectiv-tracker.initializer.ts
+++ b/tracker/trackers/angular/src/objectiv-tracker.initializer.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { APP_INITIALIZER, Provider } from '@angular/core';

--- a/tracker/trackers/angular/src/objectiv-tracker.module.ts
+++ b/tracker/trackers/angular/src/objectiv-tracker.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { ModuleWithProviders, NgModule } from '@angular/core';

--- a/tracker/trackers/angular/src/objectiv-tracker.module.ts
+++ b/tracker/trackers/angular/src/objectiv-tracker.module.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { ModuleWithProviders, NgModule } from '@angular/core';

--- a/tracker/trackers/angular/src/objectiv-tracker.token.ts
+++ b/tracker/trackers/angular/src/objectiv-tracker.token.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { InjectionToken } from '@angular/core';

--- a/tracker/trackers/angular/src/objectiv-tracker.token.ts
+++ b/tracker/trackers/angular/src/objectiv-tracker.token.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { InjectionToken } from '@angular/core';

--- a/tracker/trackers/browser/jest.config.js
+++ b/tracker/trackers/browser/jest.config.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 module.exports = {

--- a/tracker/trackers/browser/jest.config.js
+++ b/tracker/trackers/browser/jest.config.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 module.exports = {

--- a/tracker/trackers/browser/rollup.config.js
+++ b/tracker/trackers/browser/rollup.config.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import commonjs from '@rollup/plugin-commonjs';

--- a/tracker/trackers/browser/rollup.config.js
+++ b/tracker/trackers/browser/rollup.config.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import commonjs from '@rollup/plugin-commonjs';

--- a/tracker/trackers/browser/src/BrowserTracker.ts
+++ b/tracker/trackers/browser/src/BrowserTracker.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { ContextsConfig, Tracker, TrackerConfig, TrackerPlugins } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/BrowserTracker.ts
+++ b/tracker/trackers/browser/src/BrowserTracker.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { ContextsConfig, Tracker, TrackerConfig, TrackerPlugins } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/common/compareTrackerConfigs.ts
+++ b/tracker/trackers/browser/src/common/compareTrackerConfigs.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { TrackerConfig } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/common/compareTrackerConfigs.ts
+++ b/tracker/trackers/browser/src/common/compareTrackerConfigs.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { TrackerConfig } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/common/factories/makeDefaultPluginsList.ts
+++ b/tracker/trackers/browser/src/common/factories/makeDefaultPluginsList.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { PathContextFromURLPlugin } from '@objectiv/plugin-path-context-from-url';

--- a/tracker/trackers/browser/src/common/factories/makeDefaultPluginsList.ts
+++ b/tracker/trackers/browser/src/common/factories/makeDefaultPluginsList.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { PathContextFromURLPlugin } from '@objectiv/plugin-path-context-from-url';

--- a/tracker/trackers/browser/src/common/factories/makeDefaultQueue.ts
+++ b/tracker/trackers/browser/src/common/factories/makeDefaultQueue.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { LocalStorageQueueStore } from '@objectiv/queue-local-storage';

--- a/tracker/trackers/browser/src/common/factories/makeDefaultQueue.ts
+++ b/tracker/trackers/browser/src/common/factories/makeDefaultQueue.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { LocalStorageQueueStore } from '@objectiv/queue-local-storage';

--- a/tracker/trackers/browser/src/common/factories/makeDefaultTransport.ts
+++ b/tracker/trackers/browser/src/common/factories/makeDefaultTransport.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { TrackerTransportInterface, TrackerTransportRetry, TrackerTransportSwitch } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/common/factories/makeDefaultTransport.ts
+++ b/tracker/trackers/browser/src/common/factories/makeDefaultTransport.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { TrackerTransportInterface, TrackerTransportRetry, TrackerTransportSwitch } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/common/findParentTaggedElements.ts
+++ b/tracker/trackers/browser/src/common/findParentTaggedElements.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { TaggableElement } from '../definitions/TaggableElement';

--- a/tracker/trackers/browser/src/common/findParentTaggedElements.ts
+++ b/tracker/trackers/browser/src/common/findParentTaggedElements.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { TaggableElement } from '../definitions/TaggableElement';

--- a/tracker/trackers/browser/src/common/getElementLocationStack.ts
+++ b/tracker/trackers/browser/src/common/getElementLocationStack.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { LocationStack } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/common/getElementLocationStack.ts
+++ b/tracker/trackers/browser/src/common/getElementLocationStack.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { LocationStack } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/common/getLocationHref.ts
+++ b/tracker/trackers/browser/src/common/getLocationHref.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 /**

--- a/tracker/trackers/browser/src/common/getLocationHref.ts
+++ b/tracker/trackers/browser/src/common/getLocationHref.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 /**

--- a/tracker/trackers/browser/src/common/guards/isParentTaggedElement.ts
+++ b/tracker/trackers/browser/src/common/guards/isParentTaggedElement.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { GuardableElement } from '../../definitions/GuardableElement';

--- a/tracker/trackers/browser/src/common/guards/isParentTaggedElement.ts
+++ b/tracker/trackers/browser/src/common/guards/isParentTaggedElement.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { GuardableElement } from '../../definitions/GuardableElement';

--- a/tracker/trackers/browser/src/common/guards/isTagChildrenElement.ts
+++ b/tracker/trackers/browser/src/common/guards/isTagChildrenElement.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { GuardableElement } from '../../definitions/GuardableElement';

--- a/tracker/trackers/browser/src/common/guards/isTagChildrenElement.ts
+++ b/tracker/trackers/browser/src/common/guards/isTagChildrenElement.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { GuardableElement } from '../../definitions/GuardableElement';

--- a/tracker/trackers/browser/src/common/guards/isTaggableElement.ts
+++ b/tracker/trackers/browser/src/common/guards/isTaggableElement.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { GuardableElement } from '../../definitions/GuardableElement';

--- a/tracker/trackers/browser/src/common/guards/isTaggableElement.ts
+++ b/tracker/trackers/browser/src/common/guards/isTaggableElement.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { GuardableElement } from '../../definitions/GuardableElement';

--- a/tracker/trackers/browser/src/common/guards/isTaggedElement.ts
+++ b/tracker/trackers/browser/src/common/guards/isTaggedElement.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { GuardableElement } from '../../definitions/GuardableElement';

--- a/tracker/trackers/browser/src/common/guards/isTaggedElement.ts
+++ b/tracker/trackers/browser/src/common/guards/isTaggedElement.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { GuardableElement } from '../../definitions/GuardableElement';

--- a/tracker/trackers/browser/src/common/objectivWindowInterface.ts
+++ b/tracker/trackers/browser/src/common/objectivWindowInterface.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { TrackerRepository } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/common/objectivWindowInterface.ts
+++ b/tracker/trackers/browser/src/common/objectivWindowInterface.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { TrackerRepository } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/common/parsers/parseJson.ts
+++ b/tracker/trackers/browser/src/common/parsers/parseJson.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { coerce, create, string, Struct } from 'superstruct';

--- a/tracker/trackers/browser/src/common/parsers/parseJson.ts
+++ b/tracker/trackers/browser/src/common/parsers/parseJson.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { coerce, create, string, Struct } from 'superstruct';

--- a/tracker/trackers/browser/src/common/parsers/parseLocationContext.ts
+++ b/tracker/trackers/browser/src/common/parsers/parseLocationContext.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { AnyLocationContext } from '../../definitions/LocationContext';

--- a/tracker/trackers/browser/src/common/parsers/parseLocationContext.ts
+++ b/tracker/trackers/browser/src/common/parsers/parseLocationContext.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { AnyLocationContext } from '../../definitions/LocationContext';

--- a/tracker/trackers/browser/src/common/parsers/parseTagChildren.ts
+++ b/tracker/trackers/browser/src/common/parsers/parseTagChildren.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { array, create } from 'superstruct';

--- a/tracker/trackers/browser/src/common/parsers/parseTagChildren.ts
+++ b/tracker/trackers/browser/src/common/parsers/parseTagChildren.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { array, create } from 'superstruct';

--- a/tracker/trackers/browser/src/common/parsers/parseTrackClicks.ts
+++ b/tracker/trackers/browser/src/common/parsers/parseTrackClicks.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { TrackClicksAttribute } from '../../definitions/TrackClicksAttribute';

--- a/tracker/trackers/browser/src/common/parsers/parseTrackClicks.ts
+++ b/tracker/trackers/browser/src/common/parsers/parseTrackClicks.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { TrackClicksAttribute } from '../../definitions/TrackClicksAttribute';

--- a/tracker/trackers/browser/src/common/parsers/parseTrackVisibility.ts
+++ b/tracker/trackers/browser/src/common/parsers/parseTrackVisibility.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { TrackVisibilityAttribute } from '../../definitions/TrackVisibilityAttribute';

--- a/tracker/trackers/browser/src/common/parsers/parseTrackVisibility.ts
+++ b/tracker/trackers/browser/src/common/parsers/parseTrackVisibility.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { TrackVisibilityAttribute } from '../../definitions/TrackVisibilityAttribute';

--- a/tracker/trackers/browser/src/common/parsers/parseValidate.ts
+++ b/tracker/trackers/browser/src/common/parsers/parseValidate.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { ValidateAttribute } from '../../definitions/ValidateAttribute';

--- a/tracker/trackers/browser/src/common/parsers/parseValidate.ts
+++ b/tracker/trackers/browser/src/common/parsers/parseValidate.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { ValidateAttribute } from '../../definitions/ValidateAttribute';

--- a/tracker/trackers/browser/src/common/runIfValueIsNotUndefined.ts
+++ b/tracker/trackers/browser/src/common/runIfValueIsNotUndefined.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 /**

--- a/tracker/trackers/browser/src/common/runIfValueIsNotUndefined.ts
+++ b/tracker/trackers/browser/src/common/runIfValueIsNotUndefined.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 /**

--- a/tracker/trackers/browser/src/common/stringifiers/stringifyJson.ts
+++ b/tracker/trackers/browser/src/common/stringifiers/stringifyJson.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { coerce, create, string, Struct } from 'superstruct';

--- a/tracker/trackers/browser/src/common/stringifiers/stringifyJson.ts
+++ b/tracker/trackers/browser/src/common/stringifiers/stringifyJson.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { coerce, create, string, Struct } from 'superstruct';

--- a/tracker/trackers/browser/src/common/stringifiers/stringifyLocationContext.ts
+++ b/tracker/trackers/browser/src/common/stringifiers/stringifyLocationContext.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { AnyLocationContext } from '../../definitions/LocationContext';

--- a/tracker/trackers/browser/src/common/stringifiers/stringifyLocationContext.ts
+++ b/tracker/trackers/browser/src/common/stringifiers/stringifyLocationContext.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { AnyLocationContext } from '../../definitions/LocationContext';

--- a/tracker/trackers/browser/src/common/stringifiers/stringifyTagChildren.ts
+++ b/tracker/trackers/browser/src/common/stringifiers/stringifyTagChildren.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { assert, create, string } from 'superstruct';

--- a/tracker/trackers/browser/src/common/stringifiers/stringifyTagChildren.ts
+++ b/tracker/trackers/browser/src/common/stringifiers/stringifyTagChildren.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { assert, create, string } from 'superstruct';

--- a/tracker/trackers/browser/src/common/stringifiers/stringifyTrackClicks.ts
+++ b/tracker/trackers/browser/src/common/stringifiers/stringifyTrackClicks.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { TrackClicksAttribute } from '../../definitions/TrackClicksAttribute';

--- a/tracker/trackers/browser/src/common/stringifiers/stringifyTrackClicks.ts
+++ b/tracker/trackers/browser/src/common/stringifiers/stringifyTrackClicks.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { TrackClicksAttribute } from '../../definitions/TrackClicksAttribute';

--- a/tracker/trackers/browser/src/common/stringifiers/stringifyTrackVisibility.ts
+++ b/tracker/trackers/browser/src/common/stringifiers/stringifyTrackVisibility.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { TrackVisibilityAttribute } from '../../definitions/TrackVisibilityAttribute';

--- a/tracker/trackers/browser/src/common/stringifiers/stringifyTrackVisibility.ts
+++ b/tracker/trackers/browser/src/common/stringifiers/stringifyTrackVisibility.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { TrackVisibilityAttribute } from '../../definitions/TrackVisibilityAttribute';

--- a/tracker/trackers/browser/src/common/stringifiers/stringifyValidate.ts
+++ b/tracker/trackers/browser/src/common/stringifiers/stringifyValidate.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { ValidateAttribute } from '../../definitions/ValidateAttribute';

--- a/tracker/trackers/browser/src/common/stringifiers/stringifyValidate.ts
+++ b/tracker/trackers/browser/src/common/stringifiers/stringifyValidate.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { ValidateAttribute } from '../../definitions/ValidateAttribute';

--- a/tracker/trackers/browser/src/common/trackerErrorHandler.ts
+++ b/tracker/trackers/browser/src/common/trackerErrorHandler.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { TrackerErrorHandlerCallback } from '../definitions/TrackerErrorHandlerCallback';

--- a/tracker/trackers/browser/src/common/trackerErrorHandler.ts
+++ b/tracker/trackers/browser/src/common/trackerErrorHandler.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { TrackerErrorHandlerCallback } from '../definitions/TrackerErrorHandlerCallback';

--- a/tracker/trackers/browser/src/common/windowExists.ts
+++ b/tracker/trackers/browser/src/common/windowExists.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 /**

--- a/tracker/trackers/browser/src/common/windowExists.ts
+++ b/tracker/trackers/browser/src/common/windowExists.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 /**

--- a/tracker/trackers/browser/src/definitions/BrowserTrackerConfig.ts
+++ b/tracker/trackers/browser/src/definitions/BrowserTrackerConfig.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { TrackerConfig } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/definitions/BrowserTrackerConfig.ts
+++ b/tracker/trackers/browser/src/definitions/BrowserTrackerConfig.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { TrackerConfig } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/definitions/ChildrenTaggingQueries.ts
+++ b/tracker/trackers/browser/src/definitions/ChildrenTaggingQueries.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { array, Infer } from 'superstruct';

--- a/tracker/trackers/browser/src/definitions/ChildrenTaggingQueries.ts
+++ b/tracker/trackers/browser/src/definitions/ChildrenTaggingQueries.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { array, Infer } from 'superstruct';

--- a/tracker/trackers/browser/src/definitions/ChildrenTaggingQuery.ts
+++ b/tracker/trackers/browser/src/definitions/ChildrenTaggingQuery.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { Infer, object, optional, string } from 'superstruct';

--- a/tracker/trackers/browser/src/definitions/ChildrenTaggingQuery.ts
+++ b/tracker/trackers/browser/src/definitions/ChildrenTaggingQuery.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { Infer, object, optional, string } from 'superstruct';

--- a/tracker/trackers/browser/src/definitions/FlushQueueOptions.ts
+++ b/tracker/trackers/browser/src/definitions/FlushQueueOptions.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { Infer, literal, union } from 'superstruct';

--- a/tracker/trackers/browser/src/definitions/FlushQueueOptions.ts
+++ b/tracker/trackers/browser/src/definitions/FlushQueueOptions.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { Infer, literal, union } from 'superstruct';

--- a/tracker/trackers/browser/src/definitions/GuardableElement.ts
+++ b/tracker/trackers/browser/src/definitions/GuardableElement.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 /**

--- a/tracker/trackers/browser/src/definitions/GuardableElement.ts
+++ b/tracker/trackers/browser/src/definitions/GuardableElement.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 /**

--- a/tracker/trackers/browser/src/definitions/InteractiveEventTrackerParameters.ts
+++ b/tracker/trackers/browser/src/definitions/InteractiveEventTrackerParameters.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { GlobalContexts, LocationStack } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/definitions/InteractiveEventTrackerParameters.ts
+++ b/tracker/trackers/browser/src/definitions/InteractiveEventTrackerParameters.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { GlobalContexts, LocationStack } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/definitions/LocationContext.ts
+++ b/tracker/trackers/browser/src/definitions/LocationContext.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { assign, Infer, literal, object, string, union } from 'superstruct';

--- a/tracker/trackers/browser/src/definitions/LocationContext.ts
+++ b/tracker/trackers/browser/src/definitions/LocationContext.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { assign, Infer, literal, object, string, union } from 'superstruct';

--- a/tracker/trackers/browser/src/definitions/LocationTaggerParameters.ts
+++ b/tracker/trackers/browser/src/definitions/LocationTaggerParameters.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { assign, object, pick, string } from 'superstruct';

--- a/tracker/trackers/browser/src/definitions/LocationTaggerParameters.ts
+++ b/tracker/trackers/browser/src/definitions/LocationTaggerParameters.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { assign, object, pick, string } from 'superstruct';

--- a/tracker/trackers/browser/src/definitions/NonInteractiveEventTrackerParameters.ts
+++ b/tracker/trackers/browser/src/definitions/NonInteractiveEventTrackerParameters.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { InteractiveEventTrackerParameters } from './InteractiveEventTrackerParameters';

--- a/tracker/trackers/browser/src/definitions/NonInteractiveEventTrackerParameters.ts
+++ b/tracker/trackers/browser/src/definitions/NonInteractiveEventTrackerParameters.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { InteractiveEventTrackerParameters } from './InteractiveEventTrackerParameters';

--- a/tracker/trackers/browser/src/definitions/ParentTaggedElement.ts
+++ b/tracker/trackers/browser/src/definitions/ParentTaggedElement.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { TaggableElement } from './TaggableElement';

--- a/tracker/trackers/browser/src/definitions/ParentTaggedElement.ts
+++ b/tracker/trackers/browser/src/definitions/ParentTaggedElement.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { TaggableElement } from './TaggableElement';

--- a/tracker/trackers/browser/src/definitions/TagChildrenAttributes.ts
+++ b/tracker/trackers/browser/src/definitions/TagChildrenAttributes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { Infer, object, string } from 'superstruct';

--- a/tracker/trackers/browser/src/definitions/TagChildrenAttributes.ts
+++ b/tracker/trackers/browser/src/definitions/TagChildrenAttributes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { Infer, object, string } from 'superstruct';

--- a/tracker/trackers/browser/src/definitions/TagChildrenElement.ts
+++ b/tracker/trackers/browser/src/definitions/TagChildrenElement.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { TagChildrenAttributes } from './TagChildrenAttributes';

--- a/tracker/trackers/browser/src/definitions/TagChildrenElement.ts
+++ b/tracker/trackers/browser/src/definitions/TagChildrenElement.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { TagChildrenAttributes } from './TagChildrenAttributes';

--- a/tracker/trackers/browser/src/definitions/TagChildrenReturnValue.ts
+++ b/tracker/trackers/browser/src/definitions/TagChildrenReturnValue.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { Infer, optional } from 'superstruct';

--- a/tracker/trackers/browser/src/definitions/TagChildrenReturnValue.ts
+++ b/tracker/trackers/browser/src/definitions/TagChildrenReturnValue.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { Infer, optional } from 'superstruct';

--- a/tracker/trackers/browser/src/definitions/TagLinkParameters.ts
+++ b/tracker/trackers/browser/src/definitions/TagLinkParameters.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { assign, object, string } from 'superstruct';

--- a/tracker/trackers/browser/src/definitions/TagLinkParameters.ts
+++ b/tracker/trackers/browser/src/definitions/TagLinkParameters.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { assign, object, string } from 'superstruct';

--- a/tracker/trackers/browser/src/definitions/TagLocationAttributes.ts
+++ b/tracker/trackers/browser/src/definitions/TagLocationAttributes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { Infer, object, optional, string } from 'superstruct';

--- a/tracker/trackers/browser/src/definitions/TagLocationAttributes.ts
+++ b/tracker/trackers/browser/src/definitions/TagLocationAttributes.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { Infer, object, optional, string } from 'superstruct';

--- a/tracker/trackers/browser/src/definitions/TagLocationOptions.ts
+++ b/tracker/trackers/browser/src/definitions/TagLocationOptions.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { boolean, object, optional } from 'superstruct';

--- a/tracker/trackers/browser/src/definitions/TagLocationOptions.ts
+++ b/tracker/trackers/browser/src/definitions/TagLocationOptions.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { boolean, object, optional } from 'superstruct';

--- a/tracker/trackers/browser/src/definitions/TagLocationParameters.ts
+++ b/tracker/trackers/browser/src/definitions/TagLocationParameters.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { func, object, optional } from 'superstruct';

--- a/tracker/trackers/browser/src/definitions/TagLocationParameters.ts
+++ b/tracker/trackers/browser/src/definitions/TagLocationParameters.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { func, object, optional } from 'superstruct';

--- a/tracker/trackers/browser/src/definitions/TagLocationReturnValue.ts
+++ b/tracker/trackers/browser/src/definitions/TagLocationReturnValue.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { Infer, optional } from 'superstruct';

--- a/tracker/trackers/browser/src/definitions/TagLocationReturnValue.ts
+++ b/tracker/trackers/browser/src/definitions/TagLocationReturnValue.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { Infer, optional } from 'superstruct';

--- a/tracker/trackers/browser/src/definitions/TaggableElement.ts
+++ b/tracker/trackers/browser/src/definitions/TaggableElement.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 /**

--- a/tracker/trackers/browser/src/definitions/TaggableElement.ts
+++ b/tracker/trackers/browser/src/definitions/TaggableElement.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 /**

--- a/tracker/trackers/browser/src/definitions/TaggedElement.ts
+++ b/tracker/trackers/browser/src/definitions/TaggedElement.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { TaggableElement } from './TaggableElement';

--- a/tracker/trackers/browser/src/definitions/TaggedElement.ts
+++ b/tracker/trackers/browser/src/definitions/TaggedElement.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { TaggableElement } from './TaggableElement';

--- a/tracker/trackers/browser/src/definitions/TaggingAttribute.ts
+++ b/tracker/trackers/browser/src/definitions/TaggingAttribute.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 /**

--- a/tracker/trackers/browser/src/definitions/TaggingAttribute.ts
+++ b/tracker/trackers/browser/src/definitions/TaggingAttribute.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 /**

--- a/tracker/trackers/browser/src/definitions/TrackClicksAttribute.ts
+++ b/tracker/trackers/browser/src/definitions/TrackClicksAttribute.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { boolean, Infer, literal, object, union } from 'superstruct';

--- a/tracker/trackers/browser/src/definitions/TrackClicksAttribute.ts
+++ b/tracker/trackers/browser/src/definitions/TrackClicksAttribute.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { boolean, Infer, literal, object, union } from 'superstruct';

--- a/tracker/trackers/browser/src/definitions/TrackClicksOptions.ts
+++ b/tracker/trackers/browser/src/definitions/TrackClicksOptions.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { Infer, literal, object, optional, union } from 'superstruct';

--- a/tracker/trackers/browser/src/definitions/TrackClicksOptions.ts
+++ b/tracker/trackers/browser/src/definitions/TrackClicksOptions.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { Infer, literal, object, optional, union } from 'superstruct';

--- a/tracker/trackers/browser/src/definitions/TrackFailureEventParameters.ts
+++ b/tracker/trackers/browser/src/definitions/TrackFailureEventParameters.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { NonInteractiveEventTrackerParameters } from './NonInteractiveEventTrackerParameters';

--- a/tracker/trackers/browser/src/definitions/TrackFailureEventParameters.ts
+++ b/tracker/trackers/browser/src/definitions/TrackFailureEventParameters.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { NonInteractiveEventTrackerParameters } from './NonInteractiveEventTrackerParameters';

--- a/tracker/trackers/browser/src/definitions/TrackSuccessEventParameters.ts
+++ b/tracker/trackers/browser/src/definitions/TrackSuccessEventParameters.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { NonInteractiveEventTrackerParameters } from './NonInteractiveEventTrackerParameters';

--- a/tracker/trackers/browser/src/definitions/TrackSuccessEventParameters.ts
+++ b/tracker/trackers/browser/src/definitions/TrackSuccessEventParameters.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { NonInteractiveEventTrackerParameters } from './NonInteractiveEventTrackerParameters';

--- a/tracker/trackers/browser/src/definitions/TrackVisibilityAttribute.ts
+++ b/tracker/trackers/browser/src/definitions/TrackVisibilityAttribute.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { boolean, Infer, literal, object, union } from 'superstruct';

--- a/tracker/trackers/browser/src/definitions/TrackVisibilityAttribute.ts
+++ b/tracker/trackers/browser/src/definitions/TrackVisibilityAttribute.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { boolean, Infer, literal, object, union } from 'superstruct';

--- a/tracker/trackers/browser/src/definitions/TrackedElement.ts
+++ b/tracker/trackers/browser/src/definitions/TrackedElement.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { TaggableElement } from './TaggableElement';

--- a/tracker/trackers/browser/src/definitions/TrackedElement.ts
+++ b/tracker/trackers/browser/src/definitions/TrackedElement.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { TaggableElement } from './TaggableElement';

--- a/tracker/trackers/browser/src/definitions/TrackerErrorHandlerCallback.ts
+++ b/tracker/trackers/browser/src/definitions/TrackerErrorHandlerCallback.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 /**

--- a/tracker/trackers/browser/src/definitions/TrackerErrorHandlerCallback.ts
+++ b/tracker/trackers/browser/src/definitions/TrackerErrorHandlerCallback.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 /**

--- a/tracker/trackers/browser/src/definitions/Uuid.ts
+++ b/tracker/trackers/browser/src/definitions/Uuid.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { define } from 'superstruct';

--- a/tracker/trackers/browser/src/definitions/Uuid.ts
+++ b/tracker/trackers/browser/src/definitions/Uuid.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { define } from 'superstruct';

--- a/tracker/trackers/browser/src/definitions/ValidChildrenTaggingQuery.ts
+++ b/tracker/trackers/browser/src/definitions/ValidChildrenTaggingQuery.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { Infer, object, string } from 'superstruct';

--- a/tracker/trackers/browser/src/definitions/ValidChildrenTaggingQuery.ts
+++ b/tracker/trackers/browser/src/definitions/ValidChildrenTaggingQuery.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { Infer, object, string } from 'superstruct';

--- a/tracker/trackers/browser/src/definitions/ValidateAttribute.ts
+++ b/tracker/trackers/browser/src/definitions/ValidateAttribute.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { boolean, defaulted, Infer, object } from 'superstruct';

--- a/tracker/trackers/browser/src/definitions/ValidateAttribute.ts
+++ b/tracker/trackers/browser/src/definitions/ValidateAttribute.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { boolean, defaulted, Infer, object } from 'superstruct';

--- a/tracker/trackers/browser/src/definitions/WaitForQueueOptions.ts
+++ b/tracker/trackers/browser/src/definitions/WaitForQueueOptions.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { Infer, number, object, optional, union } from 'superstruct';

--- a/tracker/trackers/browser/src/definitions/WaitForQueueOptions.ts
+++ b/tracker/trackers/browser/src/definitions/WaitForQueueOptions.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { Infer, number, object, optional, union } from 'superstruct';

--- a/tracker/trackers/browser/src/definitions/WaitUntilTrackedOptions.ts
+++ b/tracker/trackers/browser/src/definitions/WaitUntilTrackedOptions.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { Infer, number, object, optional } from 'superstruct';

--- a/tracker/trackers/browser/src/definitions/WaitUntilTrackedOptions.ts
+++ b/tracker/trackers/browser/src/definitions/WaitUntilTrackedOptions.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { Infer, number, object, optional } from 'superstruct';

--- a/tracker/trackers/browser/src/eventTrackers/trackApplicationLoadedEvent.ts
+++ b/tracker/trackers/browser/src/eventTrackers/trackApplicationLoadedEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeApplicationLoadedEvent } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/eventTrackers/trackApplicationLoadedEvent.ts
+++ b/tracker/trackers/browser/src/eventTrackers/trackApplicationLoadedEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeApplicationLoadedEvent } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/eventTrackers/trackEvent.ts
+++ b/tracker/trackers/browser/src/eventTrackers/trackEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { LocationStack, TrackerEvent, UntrackedEvent } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/eventTrackers/trackEvent.ts
+++ b/tracker/trackers/browser/src/eventTrackers/trackEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { LocationStack, TrackerEvent, UntrackedEvent } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/eventTrackers/trackFailureEvent.ts
+++ b/tracker/trackers/browser/src/eventTrackers/trackFailureEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeFailureEvent } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/eventTrackers/trackFailureEvent.ts
+++ b/tracker/trackers/browser/src/eventTrackers/trackFailureEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeFailureEvent } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/eventTrackers/trackHiddenEvent.ts
+++ b/tracker/trackers/browser/src/eventTrackers/trackHiddenEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeHiddenEvent } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/eventTrackers/trackHiddenEvent.ts
+++ b/tracker/trackers/browser/src/eventTrackers/trackHiddenEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeHiddenEvent } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/eventTrackers/trackInputChangeEvent.ts
+++ b/tracker/trackers/browser/src/eventTrackers/trackInputChangeEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeInputChangeEvent } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/eventTrackers/trackInputChangeEvent.ts
+++ b/tracker/trackers/browser/src/eventTrackers/trackInputChangeEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeInputChangeEvent } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/eventTrackers/trackInteractiveEvent.ts
+++ b/tracker/trackers/browser/src/eventTrackers/trackInteractiveEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeInteractiveEvent } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/eventTrackers/trackInteractiveEvent.ts
+++ b/tracker/trackers/browser/src/eventTrackers/trackInteractiveEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeInteractiveEvent } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/eventTrackers/trackMediaEvent.ts
+++ b/tracker/trackers/browser/src/eventTrackers/trackMediaEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeMediaEvent } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/eventTrackers/trackMediaEvent.ts
+++ b/tracker/trackers/browser/src/eventTrackers/trackMediaEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeMediaEvent } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/eventTrackers/trackMediaLoadEvent.ts
+++ b/tracker/trackers/browser/src/eventTrackers/trackMediaLoadEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeMediaLoadEvent } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/eventTrackers/trackMediaLoadEvent.ts
+++ b/tracker/trackers/browser/src/eventTrackers/trackMediaLoadEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeMediaLoadEvent } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/eventTrackers/trackMediaPauseEvent.ts
+++ b/tracker/trackers/browser/src/eventTrackers/trackMediaPauseEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeMediaPauseEvent } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/eventTrackers/trackMediaPauseEvent.ts
+++ b/tracker/trackers/browser/src/eventTrackers/trackMediaPauseEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeMediaPauseEvent } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/eventTrackers/trackMediaStartEvent.ts
+++ b/tracker/trackers/browser/src/eventTrackers/trackMediaStartEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeMediaStartEvent } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/eventTrackers/trackMediaStartEvent.ts
+++ b/tracker/trackers/browser/src/eventTrackers/trackMediaStartEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeMediaStartEvent } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/eventTrackers/trackMediaStopEvent.ts
+++ b/tracker/trackers/browser/src/eventTrackers/trackMediaStopEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeMediaStopEvent } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/eventTrackers/trackMediaStopEvent.ts
+++ b/tracker/trackers/browser/src/eventTrackers/trackMediaStopEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeMediaStopEvent } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/eventTrackers/trackNonInteractiveEvent.ts
+++ b/tracker/trackers/browser/src/eventTrackers/trackNonInteractiveEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeNonInteractiveEvent } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/eventTrackers/trackNonInteractiveEvent.ts
+++ b/tracker/trackers/browser/src/eventTrackers/trackNonInteractiveEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeNonInteractiveEvent } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/eventTrackers/trackPressEvent.ts
+++ b/tracker/trackers/browser/src/eventTrackers/trackPressEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makePressEvent } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/eventTrackers/trackPressEvent.ts
+++ b/tracker/trackers/browser/src/eventTrackers/trackPressEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makePressEvent } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/eventTrackers/trackSuccessEvent.ts
+++ b/tracker/trackers/browser/src/eventTrackers/trackSuccessEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeSuccessEvent } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/eventTrackers/trackSuccessEvent.ts
+++ b/tracker/trackers/browser/src/eventTrackers/trackSuccessEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeSuccessEvent } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/eventTrackers/trackVisibility.ts
+++ b/tracker/trackers/browser/src/eventTrackers/trackVisibility.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeHiddenEvent, makeVisibleEvent } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/eventTrackers/trackVisibility.ts
+++ b/tracker/trackers/browser/src/eventTrackers/trackVisibility.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeHiddenEvent, makeVisibleEvent } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/eventTrackers/trackVisibleEvent.ts
+++ b/tracker/trackers/browser/src/eventTrackers/trackVisibleEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeVisibleEvent } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/eventTrackers/trackVisibleEvent.ts
+++ b/tracker/trackers/browser/src/eventTrackers/trackVisibleEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeVisibleEvent } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/getOrMakeTracker.ts
+++ b/tracker/trackers/browser/src/getOrMakeTracker.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { BrowserTracker } from './BrowserTracker';

--- a/tracker/trackers/browser/src/getOrMakeTracker.ts
+++ b/tracker/trackers/browser/src/getOrMakeTracker.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { BrowserTracker } from './BrowserTracker';

--- a/tracker/trackers/browser/src/getTracker.ts
+++ b/tracker/trackers/browser/src/getTracker.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { BrowserTracker } from './BrowserTracker';

--- a/tracker/trackers/browser/src/getTracker.ts
+++ b/tracker/trackers/browser/src/getTracker.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { BrowserTracker } from './BrowserTracker';

--- a/tracker/trackers/browser/src/getTrackerRepository.ts
+++ b/tracker/trackers/browser/src/getTrackerRepository.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { TrackerRepository } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/getTrackerRepository.ts
+++ b/tracker/trackers/browser/src/getTrackerRepository.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { TrackerRepository } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/index.ts
+++ b/tracker/trackers/browser/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 export * from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/index.ts
+++ b/tracker/trackers/browser/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 export * from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/locationTaggers/tagChild.ts
+++ b/tracker/trackers/browser/src/locationTaggers/tagChild.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { ChildrenTaggingQuery } from '../definitions/ChildrenTaggingQuery';

--- a/tracker/trackers/browser/src/locationTaggers/tagChild.ts
+++ b/tracker/trackers/browser/src/locationTaggers/tagChild.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { ChildrenTaggingQuery } from '../definitions/ChildrenTaggingQuery';

--- a/tracker/trackers/browser/src/locationTaggers/tagChildren.ts
+++ b/tracker/trackers/browser/src/locationTaggers/tagChildren.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { assert, validate } from 'superstruct';

--- a/tracker/trackers/browser/src/locationTaggers/tagChildren.ts
+++ b/tracker/trackers/browser/src/locationTaggers/tagChildren.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { assert, validate } from 'superstruct';

--- a/tracker/trackers/browser/src/locationTaggers/tagContent.ts
+++ b/tracker/trackers/browser/src/locationTaggers/tagContent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeContentContext } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/locationTaggers/tagContent.ts
+++ b/tracker/trackers/browser/src/locationTaggers/tagContent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeContentContext } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/locationTaggers/tagExpandable.ts
+++ b/tracker/trackers/browser/src/locationTaggers/tagExpandable.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeExpandableContext } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/locationTaggers/tagExpandable.ts
+++ b/tracker/trackers/browser/src/locationTaggers/tagExpandable.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeExpandableContext } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/locationTaggers/tagInput.ts
+++ b/tracker/trackers/browser/src/locationTaggers/tagInput.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeInputContext } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/locationTaggers/tagInput.ts
+++ b/tracker/trackers/browser/src/locationTaggers/tagInput.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeInputContext } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/locationTaggers/tagLink.ts
+++ b/tracker/trackers/browser/src/locationTaggers/tagLink.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeLinkContext } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/locationTaggers/tagLink.ts
+++ b/tracker/trackers/browser/src/locationTaggers/tagLink.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeLinkContext } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/locationTaggers/tagLocation.ts
+++ b/tracker/trackers/browser/src/locationTaggers/tagLocation.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { generateUUID, getObjectKeys } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/locationTaggers/tagLocation.ts
+++ b/tracker/trackers/browser/src/locationTaggers/tagLocation.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { generateUUID, getObjectKeys } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/locationTaggers/tagMediaPlayer.ts
+++ b/tracker/trackers/browser/src/locationTaggers/tagMediaPlayer.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeMediaPlayerContext } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/locationTaggers/tagMediaPlayer.ts
+++ b/tracker/trackers/browser/src/locationTaggers/tagMediaPlayer.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeMediaPlayerContext } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/locationTaggers/tagNavigation.ts
+++ b/tracker/trackers/browser/src/locationTaggers/tagNavigation.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeNavigationContext } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/locationTaggers/tagNavigation.ts
+++ b/tracker/trackers/browser/src/locationTaggers/tagNavigation.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeNavigationContext } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/locationTaggers/tagOverlay.ts
+++ b/tracker/trackers/browser/src/locationTaggers/tagOverlay.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeOverlayContext } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/locationTaggers/tagOverlay.ts
+++ b/tracker/trackers/browser/src/locationTaggers/tagOverlay.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeOverlayContext } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/locationTaggers/tagPressable.ts
+++ b/tracker/trackers/browser/src/locationTaggers/tagPressable.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makePressableContext } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/locationTaggers/tagPressable.ts
+++ b/tracker/trackers/browser/src/locationTaggers/tagPressable.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makePressableContext } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/locationTaggers/tagRootLocation.ts
+++ b/tracker/trackers/browser/src/locationTaggers/tagRootLocation.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeRootLocationContext } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/locationTaggers/tagRootLocation.ts
+++ b/tracker/trackers/browser/src/locationTaggers/tagRootLocation.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeRootLocationContext } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/makeTracker.ts
+++ b/tracker/trackers/browser/src/makeTracker.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { BrowserTracker } from './BrowserTracker';

--- a/tracker/trackers/browser/src/makeTracker.ts
+++ b/tracker/trackers/browser/src/makeTracker.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { BrowserTracker } from './BrowserTracker';

--- a/tracker/trackers/browser/src/mutationObserver/AutoTrackingState.ts
+++ b/tracker/trackers/browser/src/mutationObserver/AutoTrackingState.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { getLocationHref } from '../common/getLocationHref';

--- a/tracker/trackers/browser/src/mutationObserver/AutoTrackingState.ts
+++ b/tracker/trackers/browser/src/mutationObserver/AutoTrackingState.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { getLocationHref } from '../common/getLocationHref';

--- a/tracker/trackers/browser/src/mutationObserver/makeBlurEventHandler.ts
+++ b/tracker/trackers/browser/src/mutationObserver/makeBlurEventHandler.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { BrowserTracker } from '../BrowserTracker';

--- a/tracker/trackers/browser/src/mutationObserver/makeBlurEventHandler.ts
+++ b/tracker/trackers/browser/src/mutationObserver/makeBlurEventHandler.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { BrowserTracker } from '../BrowserTracker';

--- a/tracker/trackers/browser/src/mutationObserver/makeClickEventHandler.ts
+++ b/tracker/trackers/browser/src/mutationObserver/makeClickEventHandler.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { BrowserTracker } from '../BrowserTracker';

--- a/tracker/trackers/browser/src/mutationObserver/makeClickEventHandler.ts
+++ b/tracker/trackers/browser/src/mutationObserver/makeClickEventHandler.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { BrowserTracker } from '../BrowserTracker';

--- a/tracker/trackers/browser/src/mutationObserver/makeMutationCallback.ts
+++ b/tracker/trackers/browser/src/mutationObserver/makeMutationCallback.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { TrackerConsole, TrackerElementLocations } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/mutationObserver/makeMutationCallback.ts
+++ b/tracker/trackers/browser/src/mutationObserver/makeMutationCallback.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { TrackerConsole, TrackerElementLocations } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/mutationObserver/processTagChildrenElement.ts
+++ b/tracker/trackers/browser/src/mutationObserver/processTagChildrenElement.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { getObjectKeys } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/mutationObserver/processTagChildrenElement.ts
+++ b/tracker/trackers/browser/src/mutationObserver/processTagChildrenElement.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { getObjectKeys } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/mutationObserver/trackNewElement.ts
+++ b/tracker/trackers/browser/src/mutationObserver/trackNewElement.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { getLocationPath, TrackerConsole, TrackerElementLocations } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/mutationObserver/trackNewElement.ts
+++ b/tracker/trackers/browser/src/mutationObserver/trackNewElement.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { getLocationPath, TrackerConsole, TrackerElementLocations } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/mutationObserver/trackNewElements.ts
+++ b/tracker/trackers/browser/src/mutationObserver/trackNewElements.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { TrackerConsole } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/mutationObserver/trackNewElements.ts
+++ b/tracker/trackers/browser/src/mutationObserver/trackNewElements.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { TrackerConsole } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/mutationObserver/trackRemovedElement.ts
+++ b/tracker/trackers/browser/src/mutationObserver/trackRemovedElement.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { TrackerElementLocations } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/mutationObserver/trackRemovedElement.ts
+++ b/tracker/trackers/browser/src/mutationObserver/trackRemovedElement.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { TrackerElementLocations } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/src/mutationObserver/trackRemovedElements.ts
+++ b/tracker/trackers/browser/src/mutationObserver/trackRemovedElements.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { BrowserTracker } from '../BrowserTracker';

--- a/tracker/trackers/browser/src/mutationObserver/trackRemovedElements.ts
+++ b/tracker/trackers/browser/src/mutationObserver/trackRemovedElements.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { BrowserTracker } from '../BrowserTracker';

--- a/tracker/trackers/browser/src/mutationObserver/trackVisibilityHiddenEvent.ts
+++ b/tracker/trackers/browser/src/mutationObserver/trackVisibilityHiddenEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { BrowserTracker } from '../BrowserTracker';

--- a/tracker/trackers/browser/src/mutationObserver/trackVisibilityHiddenEvent.ts
+++ b/tracker/trackers/browser/src/mutationObserver/trackVisibilityHiddenEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { BrowserTracker } from '../BrowserTracker';

--- a/tracker/trackers/browser/src/mutationObserver/trackVisibilityVisibleEvent.ts
+++ b/tracker/trackers/browser/src/mutationObserver/trackVisibilityVisibleEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { BrowserTracker } from '../BrowserTracker';

--- a/tracker/trackers/browser/src/mutationObserver/trackVisibilityVisibleEvent.ts
+++ b/tracker/trackers/browser/src/mutationObserver/trackVisibilityVisibleEvent.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { BrowserTracker } from '../BrowserTracker';

--- a/tracker/trackers/browser/src/setDefaultTracker.ts
+++ b/tracker/trackers/browser/src/setDefaultTracker.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { FlushQueueOptions } from './definitions/FlushQueueOptions';

--- a/tracker/trackers/browser/src/setDefaultTracker.ts
+++ b/tracker/trackers/browser/src/setDefaultTracker.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { FlushQueueOptions } from './definitions/FlushQueueOptions';

--- a/tracker/trackers/browser/src/startAutoTracking.ts
+++ b/tracker/trackers/browser/src/startAutoTracking.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { trackerErrorHandler } from './common/trackerErrorHandler';

--- a/tracker/trackers/browser/src/startAutoTracking.ts
+++ b/tracker/trackers/browser/src/startAutoTracking.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { trackerErrorHandler } from './common/trackerErrorHandler';

--- a/tracker/trackers/browser/src/stopAutoTracking.ts
+++ b/tracker/trackers/browser/src/stopAutoTracking.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { trackerErrorHandler } from './common/trackerErrorHandler';

--- a/tracker/trackers/browser/src/stopAutoTracking.ts
+++ b/tracker/trackers/browser/src/stopAutoTracking.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { trackerErrorHandler } from './common/trackerErrorHandler';

--- a/tracker/trackers/browser/tests/BrowserTracker.test.ts
+++ b/tracker/trackers/browser/tests/BrowserTracker.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { mockConsole } from '@objectiv/testing-tools';

--- a/tracker/trackers/browser/tests/BrowserTracker.test.ts
+++ b/tracker/trackers/browser/tests/BrowserTracker.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { mockConsole } from '@objectiv/testing-tools';

--- a/tracker/trackers/browser/tests/findTaggedParentElements.test.ts
+++ b/tracker/trackers/browser/tests/findTaggedParentElements.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { findParentTaggedElements, isParentTaggedElement, isTaggedElement, TaggingAttribute } from '../src';

--- a/tracker/trackers/browser/tests/findTaggedParentElements.test.ts
+++ b/tracker/trackers/browser/tests/findTaggedParentElements.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { findParentTaggedElements, isParentTaggedElement, isTaggedElement, TaggingAttribute } from '../src';

--- a/tracker/trackers/browser/tests/getElementLocationStack.test.ts
+++ b/tracker/trackers/browser/tests/getElementLocationStack.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { PathContextFromURLPlugin } from '@objectiv/plugin-path-context-from-url';

--- a/tracker/trackers/browser/tests/getElementLocationStack.test.ts
+++ b/tracker/trackers/browser/tests/getElementLocationStack.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { PathContextFromURLPlugin } from '@objectiv/plugin-path-context-from-url';

--- a/tracker/trackers/browser/tests/globals.test.ts
+++ b/tracker/trackers/browser/tests/globals.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { BrowserTracker, getOrMakeTracker, getTracker, makeTracker, setDefaultTracker } from '../src/';

--- a/tracker/trackers/browser/tests/globals.test.ts
+++ b/tracker/trackers/browser/tests/globals.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { BrowserTracker, getOrMakeTracker, getTracker, makeTracker, setDefaultTracker } from '../src/';

--- a/tracker/trackers/browser/tests/guards.test.ts
+++ b/tracker/trackers/browser/tests/guards.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import {

--- a/tracker/trackers/browser/tests/guards.test.ts
+++ b/tracker/trackers/browser/tests/guards.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import {

--- a/tracker/trackers/browser/tests/makeBlurEventHandler.test.ts
+++ b/tracker/trackers/browser/tests/makeBlurEventHandler.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { matchUUID } from '@objectiv/testing-tools';

--- a/tracker/trackers/browser/tests/makeBlurEventHandler.test.ts
+++ b/tracker/trackers/browser/tests/makeBlurEventHandler.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { matchUUID } from '@objectiv/testing-tools';

--- a/tracker/trackers/browser/tests/makeClickEventHandler.test.ts
+++ b/tracker/trackers/browser/tests/makeClickEventHandler.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { matchUUID } from '@objectiv/testing-tools';

--- a/tracker/trackers/browser/tests/makeClickEventHandler.test.ts
+++ b/tracker/trackers/browser/tests/makeClickEventHandler.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { matchUUID } from '@objectiv/testing-tools';

--- a/tracker/trackers/browser/tests/mocks/makeTaggedElement.ts
+++ b/tracker/trackers/browser/tests/mocks/makeTaggedElement.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makePressableContext, makeInputContext, makeContentContext } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/tests/mocks/makeTaggedElement.ts
+++ b/tracker/trackers/browser/tests/mocks/makeTaggedElement.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makePressableContext, makeInputContext, makeContentContext } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/tests/processTagChildrenElement.test.ts
+++ b/tracker/trackers/browser/tests/processTagChildrenElement.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makePressableContext } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/tests/processTagChildrenElement.test.ts
+++ b/tracker/trackers/browser/tests/processTagChildrenElement.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makePressableContext } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/tests/startAutoTracking.test.ts
+++ b/tracker/trackers/browser/tests/startAutoTracking.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { matchUUID } from '@objectiv/testing-tools';

--- a/tracker/trackers/browser/tests/startAutoTracking.test.ts
+++ b/tracker/trackers/browser/tests/startAutoTracking.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { matchUUID } from '@objectiv/testing-tools';

--- a/tracker/trackers/browser/tests/structs.test.ts
+++ b/tracker/trackers/browser/tests/structs.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { makeContentContext } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/tests/structs.test.ts
+++ b/tracker/trackers/browser/tests/structs.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { makeContentContext } from '@objectiv/tracker-core';

--- a/tracker/trackers/browser/tests/tagChildren.test.ts
+++ b/tracker/trackers/browser/tests/tagChildren.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { StructError } from 'superstruct';

--- a/tracker/trackers/browser/tests/tagChildren.test.ts
+++ b/tracker/trackers/browser/tests/tagChildren.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { StructError } from 'superstruct';

--- a/tracker/trackers/browser/tests/tagLocation.test.ts
+++ b/tracker/trackers/browser/tests/tagLocation.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { matchUUID, mockConsole } from '@objectiv/testing-tools';

--- a/tracker/trackers/browser/tests/tagLocation.test.ts
+++ b/tracker/trackers/browser/tests/tagLocation.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { matchUUID, mockConsole } from '@objectiv/testing-tools';

--- a/tracker/trackers/browser/tests/tagLocationHelpers.test.ts
+++ b/tracker/trackers/browser/tests/tagLocationHelpers.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { matchUUID } from '@objectiv/testing-tools';

--- a/tracker/trackers/browser/tests/tagLocationHelpers.test.ts
+++ b/tracker/trackers/browser/tests/tagLocationHelpers.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { matchUUID } from '@objectiv/testing-tools';

--- a/tracker/trackers/browser/tests/trackEvent.test.ts
+++ b/tracker/trackers/browser/tests/trackEvent.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { matchUUID } from '@objectiv/testing-tools';

--- a/tracker/trackers/browser/tests/trackEvent.test.ts
+++ b/tracker/trackers/browser/tests/trackEvent.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { matchUUID } from '@objectiv/testing-tools';

--- a/tracker/trackers/browser/tests/trackNewElement.test.ts
+++ b/tracker/trackers/browser/tests/trackNewElement.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { matchUUID, mockConsole } from '@objectiv/testing-tools';

--- a/tracker/trackers/browser/tests/trackNewElement.test.ts
+++ b/tracker/trackers/browser/tests/trackNewElement.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { matchUUID, mockConsole } from '@objectiv/testing-tools';

--- a/tracker/trackers/browser/tests/trackNewElements.test.ts
+++ b/tracker/trackers/browser/tests/trackNewElements.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { matchUUID } from '@objectiv/testing-tools';

--- a/tracker/trackers/browser/tests/trackNewElements.test.ts
+++ b/tracker/trackers/browser/tests/trackNewElements.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { matchUUID } from '@objectiv/testing-tools';

--- a/tracker/trackers/browser/tests/trackRemovedElements.test.ts
+++ b/tracker/trackers/browser/tests/trackRemovedElements.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { matchUUID } from '@objectiv/testing-tools';

--- a/tracker/trackers/browser/tests/trackRemovedElements.test.ts
+++ b/tracker/trackers/browser/tests/trackRemovedElements.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { matchUUID } from '@objectiv/testing-tools';

--- a/tracker/trackers/browser/tests/trackVisibilityHiddenEvent.test.ts
+++ b/tracker/trackers/browser/tests/trackVisibilityHiddenEvent.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { matchUUID } from '@objectiv/testing-tools';

--- a/tracker/trackers/browser/tests/trackVisibilityHiddenEvent.test.ts
+++ b/tracker/trackers/browser/tests/trackVisibilityHiddenEvent.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { matchUUID } from '@objectiv/testing-tools';

--- a/tracker/trackers/browser/tests/trackVisibilityVisibleEvent.test.ts
+++ b/tracker/trackers/browser/tests/trackVisibilityVisibleEvent.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { matchUUID } from '@objectiv/testing-tools';

--- a/tracker/trackers/browser/tests/trackVisibilityVisibleEvent.test.ts
+++ b/tracker/trackers/browser/tests/trackVisibilityVisibleEvent.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { matchUUID } from '@objectiv/testing-tools';

--- a/tracker/trackers/browser/tests/withoutDOM.test.ts
+++ b/tracker/trackers/browser/tests/withoutDOM.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  * @jest-environment node
  */
 

--- a/tracker/trackers/browser/tests/withoutDOM.test.ts
+++ b/tracker/trackers/browser/tests/withoutDOM.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  * @jest-environment node
  */
 

--- a/tracker/trackers/react/jest.config.js
+++ b/tracker/trackers/react/jest.config.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 module.exports = {

--- a/tracker/trackers/react/jest.config.js
+++ b/tracker/trackers/react/jest.config.js
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2022 Objectiv B.V.
+ */
+
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',

--- a/tracker/trackers/react/rollup.config.js
+++ b/tracker/trackers/react/rollup.config.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import commonjs from '@rollup/plugin-commonjs';

--- a/tracker/trackers/react/rollup.config.js
+++ b/tracker/trackers/react/rollup.config.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import commonjs from '@rollup/plugin-commonjs';

--- a/tracker/trackers/react/src/ReactTracker.ts
+++ b/tracker/trackers/react/src/ReactTracker.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { ContextsConfig, Tracker, TrackerConfig, TrackerPlugins } from '@objectiv/tracker-core';

--- a/tracker/trackers/react/src/ReactTracker.ts
+++ b/tracker/trackers/react/src/ReactTracker.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { ContextsConfig, Tracker, TrackerConfig, TrackerPlugins } from '@objectiv/tracker-core';

--- a/tracker/trackers/react/src/common/factories/makeDefaultPluginsList.ts
+++ b/tracker/trackers/react/src/common/factories/makeDefaultPluginsList.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { PathContextFromURLPlugin } from '@objectiv/plugin-path-context-from-url';

--- a/tracker/trackers/react/src/common/factories/makeDefaultPluginsList.ts
+++ b/tracker/trackers/react/src/common/factories/makeDefaultPluginsList.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { PathContextFromURLPlugin } from '@objectiv/plugin-path-context-from-url';

--- a/tracker/trackers/react/src/common/factories/makeDefaultQueue.ts
+++ b/tracker/trackers/react/src/common/factories/makeDefaultQueue.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { LocalStorageQueueStore } from '@objectiv/queue-local-storage';

--- a/tracker/trackers/react/src/common/factories/makeDefaultQueue.ts
+++ b/tracker/trackers/react/src/common/factories/makeDefaultQueue.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { LocalStorageQueueStore } from '@objectiv/queue-local-storage';

--- a/tracker/trackers/react/src/common/factories/makeDefaultTransport.ts
+++ b/tracker/trackers/react/src/common/factories/makeDefaultTransport.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { TrackerTransportInterface, TrackerTransportRetry, TrackerTransportSwitch } from '@objectiv/tracker-core';

--- a/tracker/trackers/react/src/common/factories/makeDefaultTransport.ts
+++ b/tracker/trackers/react/src/common/factories/makeDefaultTransport.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { TrackerTransportInterface, TrackerTransportRetry, TrackerTransportSwitch } from '@objectiv/tracker-core';

--- a/tracker/trackers/react/src/index.ts
+++ b/tracker/trackers/react/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 export * from '@objectiv/tracker-core-react';

--- a/tracker/trackers/react/src/index.ts
+++ b/tracker/trackers/react/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 export * from '@objectiv/tracker-core-react';

--- a/tracker/trackers/react/tests/ReactTracker.test.ts
+++ b/tracker/trackers/react/tests/ReactTracker.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { mockConsole } from '@objectiv/testing-tools';

--- a/tracker/trackers/react/tests/ReactTracker.test.ts
+++ b/tracker/trackers/react/tests/ReactTracker.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { mockConsole } from '@objectiv/testing-tools';

--- a/tracker/transports/debug/jest.config.js
+++ b/tracker/transports/debug/jest.config.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 module.exports = {

--- a/tracker/transports/debug/jest.config.js
+++ b/tracker/transports/debug/jest.config.js
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2022 Objectiv B.V.
+ */
+
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',

--- a/tracker/transports/debug/rollup.config.js
+++ b/tracker/transports/debug/rollup.config.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import commonjs from '@rollup/plugin-commonjs';

--- a/tracker/transports/debug/rollup.config.js
+++ b/tracker/transports/debug/rollup.config.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import commonjs from '@rollup/plugin-commonjs';

--- a/tracker/transports/debug/src/DebugTransport.ts
+++ b/tracker/transports/debug/src/DebugTransport.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import {

--- a/tracker/transports/debug/src/DebugTransport.ts
+++ b/tracker/transports/debug/src/DebugTransport.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import {

--- a/tracker/transports/debug/src/index.ts
+++ b/tracker/transports/debug/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 export * from './DebugTransport';

--- a/tracker/transports/debug/src/index.ts
+++ b/tracker/transports/debug/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 export * from './DebugTransport';

--- a/tracker/transports/debug/tests/DebugTransport.test.ts
+++ b/tracker/transports/debug/tests/DebugTransport.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { mockConsole } from '@objectiv/testing-tools';

--- a/tracker/transports/debug/tests/DebugTransport.test.ts
+++ b/tracker/transports/debug/tests/DebugTransport.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { mockConsole } from '@objectiv/testing-tools';

--- a/tracker/transports/fetch/jest.config.js
+++ b/tracker/transports/fetch/jest.config.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 module.exports = {

--- a/tracker/transports/fetch/jest.config.js
+++ b/tracker/transports/fetch/jest.config.js
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2022 Objectiv B.V.
+ */
+
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',

--- a/tracker/transports/fetch/rollup.config.js
+++ b/tracker/transports/fetch/rollup.config.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import commonjs from '@rollup/plugin-commonjs';

--- a/tracker/transports/fetch/rollup.config.js
+++ b/tracker/transports/fetch/rollup.config.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import commonjs from '@rollup/plugin-commonjs';

--- a/tracker/transports/fetch/src/FetchTransport.ts
+++ b/tracker/transports/fetch/src/FetchTransport.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import {

--- a/tracker/transports/fetch/src/FetchTransport.ts
+++ b/tracker/transports/fetch/src/FetchTransport.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import {

--- a/tracker/transports/fetch/src/defaultFetchFunction.ts
+++ b/tracker/transports/fetch/src/defaultFetchFunction.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { TrackerConsole, TrackerEvent, TransportSendError } from '@objectiv/tracker-core';

--- a/tracker/transports/fetch/src/defaultFetchFunction.ts
+++ b/tracker/transports/fetch/src/defaultFetchFunction.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { TrackerConsole, TrackerEvent, TransportSendError } from '@objectiv/tracker-core';

--- a/tracker/transports/fetch/src/defaultFetchOptions.ts
+++ b/tracker/transports/fetch/src/defaultFetchOptions.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 /**

--- a/tracker/transports/fetch/src/defaultFetchOptions.ts
+++ b/tracker/transports/fetch/src/defaultFetchOptions.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 /**

--- a/tracker/transports/fetch/src/index.ts
+++ b/tracker/transports/fetch/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 export * from './defaultFetchFunction';

--- a/tracker/transports/fetch/src/index.ts
+++ b/tracker/transports/fetch/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 export * from './defaultFetchFunction';

--- a/tracker/transports/fetch/tests/FetchTransport.test.ts
+++ b/tracker/transports/fetch/tests/FetchTransport.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { mockConsole } from '@objectiv/testing-tools';

--- a/tracker/transports/fetch/tests/FetchTransport.test.ts
+++ b/tracker/transports/fetch/tests/FetchTransport.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { mockConsole } from '@objectiv/testing-tools';

--- a/tracker/transports/xhr/jest.config.js
+++ b/tracker/transports/xhr/jest.config.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 module.exports = {

--- a/tracker/transports/xhr/jest.config.js
+++ b/tracker/transports/xhr/jest.config.js
@@ -1,3 +1,7 @@
+/*
+ * Copyright 2022 Objectiv B.V.
+ */
+
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',

--- a/tracker/transports/xhr/rollup.config.js
+++ b/tracker/transports/xhr/rollup.config.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import commonjs from '@rollup/plugin-commonjs';

--- a/tracker/transports/xhr/rollup.config.js
+++ b/tracker/transports/xhr/rollup.config.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import commonjs from '@rollup/plugin-commonjs';

--- a/tracker/transports/xhr/src/XHRTransport.ts
+++ b/tracker/transports/xhr/src/XHRTransport.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import {

--- a/tracker/transports/xhr/src/XHRTransport.ts
+++ b/tracker/transports/xhr/src/XHRTransport.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import {

--- a/tracker/transports/xhr/src/defaultXHRFunction.ts
+++ b/tracker/transports/xhr/src/defaultXHRFunction.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { TrackerConsole, TrackerEvent, TransportSendError } from '@objectiv/tracker-core';

--- a/tracker/transports/xhr/src/defaultXHRFunction.ts
+++ b/tracker/transports/xhr/src/defaultXHRFunction.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { TrackerConsole, TrackerEvent, TransportSendError } from '@objectiv/tracker-core';

--- a/tracker/transports/xhr/src/index.ts
+++ b/tracker/transports/xhr/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 export * from './defaultXHRFunction';

--- a/tracker/transports/xhr/src/index.ts
+++ b/tracker/transports/xhr/src/index.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 export * from './defaultXHRFunction';

--- a/tracker/transports/xhr/tests/XHRTransport.test.ts
+++ b/tracker/transports/xhr/tests/XHRTransport.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 Objectiv B.V.
+ * Copyright 2021-2022 Objectiv B.V.
  */
 
 import { mockConsole } from '@objectiv/testing-tools';

--- a/tracker/transports/xhr/tests/XHRTransport.test.ts
+++ b/tracker/transports/xhr/tests/XHRTransport.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { mockConsole } from '@objectiv/testing-tools';


### PR DESCRIPTION
This updates the copyright everywhere in the Tracker monorepo. 

Waiting for a confirmation on the format to use. Year vs PreviousYear-Year.