### PR TITLE
Sync React core version to the rest of the monorepo

### DIFF
--- a/tracker/core/react/package.json
+++ b/tracker/core/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/tracker-core-react",
-  "version": "1.0.0",
+  "version": "0.0.4",
   "description": "Core functionality for Objectiv React trackers",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",

--- a/tracker/trackers/react/package.json
+++ b/tracker/trackers/react/package.json
@@ -65,7 +65,7 @@
     "@objectiv/plugin-path-context-from-url": "^0.0.4",
     "@objectiv/queue-local-storage": "^0.0.4",
     "@objectiv/tracker-core": "~0.0.4",
-    "@objectiv/tracker-core-react": "~1.0.0",
+    "@objectiv/tracker-core-react": "~0.0.4",
     "@objectiv/transport-fetch": "^0.0.4",
     "@objectiv/transport-xhr": "^0.0.4"
   }

--- a/tracker/yarn.lock
+++ b/tracker/yarn.lock
@@ -916,7 +916,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@objectiv/tracker-core-react@workspace:core/react, @objectiv/tracker-core-react@~1.0.0":
+"@objectiv/tracker-core-react@workspace:core/react, @objectiv/tracker-core-react@~0.0.4":
   version: 0.0.0-use.local
   resolution: "@objectiv/tracker-core-react@workspace:core/react"
   dependencies:
@@ -983,7 +983,7 @@ __metadata:
     "@objectiv/queue-local-storage": ^0.0.4
     "@objectiv/testing-tools": 0.0.1
     "@objectiv/tracker-core": ~0.0.4
-    "@objectiv/tracker-core-react": ~1.0.0
+    "@objectiv/tracker-core-react": ~0.0.4
     "@objectiv/transport-fetch": ^0.0.4
     "@objectiv/transport-xhr": ^0.0.4
     "@rollup/plugin-commonjs": ^21.0.1


### PR DESCRIPTION
This PR aligns all packages in the monorepo to the same version (Tracker core was still on his prototype version number)