### PR TITLE
Finalize deprecation of old taxonomy

### DIFF
--- a/tracker/core/react/package.json
+++ b/tracker/core/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/tracker-core-react",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Core functionality for Objectiv React trackers",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -65,8 +65,8 @@
     "typescript": "^4.5.4"
   },
   "dependencies": {
-    "@objectiv/schema": "~0.0.4",
-    "@objectiv/tracker-core": "~0.0.4",
+    "@objectiv/schema": "~0.0.5",
+    "@objectiv/tracker-core": "~0.0.5",
     "fast-deep-equal": "^3.1.3"
   },
   "peerDependencies": {

--- a/tracker/core/schema/package.json
+++ b/tracker/core/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/schema",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Objectiv TypeScript implementation of the open taxonomy for analytics",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",

--- a/tracker/core/testing-tools/package.json
+++ b/tracker/core/testing-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/testing-tools",
-  "version": "0.0.1",
+  "version": "0.0.5",
   "private": true,
   "license": "Apache-2.0",
   "description": "Mocks and other testing utilities shared across Objectiv Trackers",

--- a/tracker/core/tracker/package.json
+++ b/tracker/core/tracker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/tracker-core",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Core functionality for Objectiv JavaScript trackers",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -43,8 +43,8 @@
     "npm-publish:verdaccio": "shx cp ../../verdaccio/.npmrc .npmrc && npm publish && shx rm -f .npmrc"
   },
   "devDependencies": {
-    "@objectiv/schema": "^0.0.4",
-    "@objectiv/testing-tools": "0.0.1",
+    "@objectiv/schema": "^0.0.5",
+    "@objectiv/testing-tools": "0.0.5",
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-node-resolve": "^13.1.1",
     "@types/jest": "^27.0.3",

--- a/tracker/core/utilities/package.json
+++ b/tracker/core/utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/utilities",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "private": true,
   "license": "Apache-2.0",
   "description": "Objectiv Core Utilities",

--- a/tracker/plugins/path-context-from-url/package.json
+++ b/tracker/plugins/path-context-from-url/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/plugin-path-context-from-url",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Plugin for Objectiv trackers to automatically generate and attach PathContext from URLs",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -45,7 +45,7 @@
     "npm-publish:verdaccio": "shx cp ../../verdaccio/.npmrc .npmrc && npm publish && shx rm -f .npmrc"
   },
   "devDependencies": {
-    "@objectiv/testing-tools": "0.0.1",
+    "@objectiv/testing-tools": "0.0.5",
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-node-resolve": "^13.1.1",
     "@types/jest": "^27.0.3",
@@ -66,6 +66,6 @@
     "typescript": "^4.5.4"
   },
   "peerDependencies": {
-    "@objectiv/tracker-core": "^0.0.4"
+    "@objectiv/tracker-core": "^0.0.5"
   }
 }

--- a/tracker/queues/local-storage/package.json
+++ b/tracker/queues/local-storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/queue-local-storage",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "A TrackerQueueStore based on localStorage API",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -44,7 +44,7 @@
     "npm-publish:verdaccio": "shx cp ../../verdaccio/.npmrc .npmrc && npm publish && shx rm -f .npmrc"
   },
   "devDependencies": {
-    "@objectiv/testing-tools": "0.0.1",
+    "@objectiv/testing-tools": "0.0.5",
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-node-resolve": "^13.1.1",
     "@types/jest": "^27.0.3",
@@ -61,6 +61,6 @@
     "typescript": "^4.5.4"
   },
   "dependencies": {
-    "@objectiv/tracker-core": "~0.0.4"
+    "@objectiv/tracker-core": "~0.0.5"
   }
 }

--- a/tracker/trackers/angular/package.json
+++ b/tracker/trackers/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/tracker-angular",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Objectiv Angular framework analytics tracker for the open taxonomy for analytics",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -36,14 +36,14 @@
     "npm-publish:verdaccio": "(cd dist && shx cp ../../../verdaccio/.npmrc .npmrc && npm publish && rm -f .npmrc)"
   },
   "peerDependencies": {
-    "@objectiv/tracker-browser": "^0.0.4",
+    "@objectiv/tracker-browser": "^0.0.5",
     "uuid-random": "^1.3.2"
   },
   "devDependencies": {
     "@angular/compiler": "^13.1.1",
     "@angular/compiler-cli": "^13.1.1",
     "@angular/core": "^13.1.1",
-    "@objectiv/tracker-browser": "^0.0.4",
+    "@objectiv/tracker-browser": "^0.0.5",
     "ng-packagr": "^13.1.2",
     "prettier": "^2.5.1",
     "rxjs": "^7.4.0",

--- a/tracker/trackers/browser/package.json
+++ b/tracker/trackers/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/tracker-browser",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Objectiv Web application analytics tracker for the open taxonomy for analytics",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -43,7 +43,7 @@
     "npm-publish:verdaccio": "shx cp ../../verdaccio/.npmrc .npmrc && npm publish && shx rm -f .npmrc"
   },
   "devDependencies": {
-    "@objectiv/testing-tools": "0.0.1",
+    "@objectiv/testing-tools": "0.0.5",
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-node-resolve": "^13.1.1",
     "@types/jest": "^27.0.3",
@@ -62,12 +62,12 @@
     "typescript": "^4.5.4"
   },
   "dependencies": {
-    "@objectiv/plugin-path-context-from-url": "^0.0.4",
-    "@objectiv/queue-local-storage": "^0.0.4",
-    "@objectiv/tracker-core": "^0.0.4",
+    "@objectiv/plugin-path-context-from-url": "^0.0.5",
+    "@objectiv/queue-local-storage": "^0.0.5",
+    "@objectiv/tracker-core": "^0.0.5",
     "@objectiv/transport-debug": "^0.0.4",
-    "@objectiv/transport-fetch": "^0.0.4",
-    "@objectiv/transport-xhr": "^0.0.4",
+    "@objectiv/transport-fetch": "^0.0.5",
+    "@objectiv/transport-xhr": "^0.0.5",
     "superstruct": "^0.15.3"
   },
   "peerDependencies": {

--- a/tracker/trackers/browser/package.json
+++ b/tracker/trackers/browser/package.json
@@ -65,7 +65,7 @@
     "@objectiv/plugin-path-context-from-url": "^0.0.5",
     "@objectiv/queue-local-storage": "^0.0.5",
     "@objectiv/tracker-core": "^0.0.5",
-    "@objectiv/transport-debug": "^0.0.4",
+    "@objectiv/transport-debug": "^0.0.5",
     "@objectiv/transport-fetch": "^0.0.5",
     "@objectiv/transport-xhr": "^0.0.5",
     "superstruct": "^0.15.3"

--- a/tracker/trackers/react/package.json
+++ b/tracker/trackers/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/tracker-react",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Objectiv React application analytics tracker for the open taxonomy for analytics",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -43,7 +43,7 @@
     "npm-publish:verdaccio": "shx cp ../../verdaccio/.npmrc .npmrc && npm publish && shx rm -f .npmrc"
   },
   "devDependencies": {
-    "@objectiv/testing-tools": "0.0.1",
+    "@objectiv/testing-tools": "0.0.5",
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-node-resolve": "^13.1.1",
     "@types/jest": "^27.0.3",
@@ -62,11 +62,11 @@
     "typescript": "^4.5.4"
   },
   "dependencies": {
-    "@objectiv/plugin-path-context-from-url": "^0.0.4",
-    "@objectiv/queue-local-storage": "^0.0.4",
-    "@objectiv/tracker-core": "~0.0.4",
-    "@objectiv/tracker-core-react": "~0.0.4",
-    "@objectiv/transport-fetch": "^0.0.4",
-    "@objectiv/transport-xhr": "^0.0.4"
+    "@objectiv/plugin-path-context-from-url": "^0.0.5",
+    "@objectiv/queue-local-storage": "^0.0.5",
+    "@objectiv/tracker-core": "~0.0.5",
+    "@objectiv/tracker-core-react": "~0.0.5",
+    "@objectiv/transport-fetch": "^0.0.5",
+    "@objectiv/transport-xhr": "^0.0.5"
   }
 }

--- a/tracker/transports/debug/package.json
+++ b/tracker/transports/debug/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/transport-debug",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "A TrackerTransport that logs incoming events to console.debug",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",

--- a/tracker/transports/debug/package.json
+++ b/tracker/transports/debug/package.json
@@ -45,7 +45,7 @@
     "npm-publish:verdaccio": "shx cp ../../verdaccio/.npmrc .npmrc && npm publish && shx rm -f .npmrc"
   },
   "devDependencies": {
-    "@objectiv/testing-tools": "0.0.1",
+    "@objectiv/testing-tools": "0.0.5",
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-node-resolve": "^13.1.1",
     "@types/jest": "^27.0.3",
@@ -62,6 +62,6 @@
     "typescript": "^4.5.4"
   },
   "dependencies": {
-    "@objectiv/tracker-core": "~0.0.4"
+    "@objectiv/tracker-core": "~0.0.5"
   }
 }

--- a/tracker/transports/fetch/package.json
+++ b/tracker/transports/fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/transport-fetch",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "A TrackerTransport based on Fetch API",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -44,7 +44,7 @@
     "npm-publish:verdaccio": "shx cp ../../verdaccio/.npmrc .npmrc && npm publish && shx rm -f .npmrc"
   },
   "devDependencies": {
-    "@objectiv/testing-tools": "0.0.1",
+    "@objectiv/testing-tools": "0.0.5",
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-node-resolve": "^13.1.1",
     "@types/jest": "^27.0.3",
@@ -62,6 +62,6 @@
     "typescript": "^4.5.4"
   },
   "dependencies": {
-    "@objectiv/tracker-core": "~0.0.4"
+    "@objectiv/tracker-core": "~0.0.5"
   }
 }

--- a/tracker/transports/xhr/package.json
+++ b/tracker/transports/xhr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/transport-xhr",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "A TrackerTransport based on XMLHttpRequest API",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -45,7 +45,7 @@
     "npm-publish:verdaccio": "shx cp ../../verdaccio/.npmrc .npmrc && npm publish && shx rm -f .npmrc"
   },
   "devDependencies": {
-    "@objectiv/testing-tools": "0.0.1",
+    "@objectiv/testing-tools": "0.0.5",
     "@rollup/plugin-commonjs": "^21.0.1",
     "@rollup/plugin-node-resolve": "^13.1.1",
     "@types/jest": "^27.0.3",
@@ -63,6 +63,6 @@
     "xhr-mock": "^2.5.1"
   },
   "dependencies": {
-    "@objectiv/tracker-core": "~0.0.4"
+    "@objectiv/tracker-core": "~0.0.5"
   }
 }

--- a/tracker/yarn.lock
+++ b/tracker/yarn.lock
@@ -792,11 +792,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@objectiv/plugin-path-context-from-url@^0.0.4, @objectiv/plugin-path-context-from-url@workspace:plugins/path-context-from-url":
+"@objectiv/plugin-path-context-from-url@^0.0.5, @objectiv/plugin-path-context-from-url@workspace:plugins/path-context-from-url":
   version: 0.0.0-use.local
   resolution: "@objectiv/plugin-path-context-from-url@workspace:plugins/path-context-from-url"
   dependencies:
-    "@objectiv/testing-tools": 0.0.1
+    "@objectiv/testing-tools": 0.0.5
     "@rollup/plugin-commonjs": ^21.0.1
     "@rollup/plugin-node-resolve": ^13.1.1
     "@types/jest": ^27.0.3
@@ -816,16 +816,16 @@ __metadata:
     ts-jest: ^27.1.2
     typescript: ^4.5.4
   peerDependencies:
-    "@objectiv/tracker-core": ^0.0.4
+    "@objectiv/tracker-core": ^0.0.5
   languageName: unknown
   linkType: soft
 
-"@objectiv/queue-local-storage@^0.0.4, @objectiv/queue-local-storage@workspace:queues/local-storage":
+"@objectiv/queue-local-storage@^0.0.5, @objectiv/queue-local-storage@workspace:queues/local-storage":
   version: 0.0.0-use.local
   resolution: "@objectiv/queue-local-storage@workspace:queues/local-storage"
   dependencies:
-    "@objectiv/testing-tools": 0.0.1
-    "@objectiv/tracker-core": ~0.0.4
+    "@objectiv/testing-tools": 0.0.5
+    "@objectiv/tracker-core": ~0.0.5
     "@rollup/plugin-commonjs": ^21.0.1
     "@rollup/plugin-node-resolve": ^13.1.1
     "@types/jest": ^27.0.3
@@ -843,7 +843,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@objectiv/schema@^0.0.4, @objectiv/schema@workspace:core/schema, @objectiv/schema@~0.0.4":
+"@objectiv/schema@^0.0.5, @objectiv/schema@workspace:core/schema, @objectiv/schema@~0.0.5":
   version: 0.0.0-use.local
   resolution: "@objectiv/schema@workspace:core/schema"
   dependencies:
@@ -853,7 +853,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@objectiv/testing-tools@0.0.1, @objectiv/testing-tools@workspace:core/testing-tools":
+"@objectiv/testing-tools@0.0.5, @objectiv/testing-tools@workspace:core/testing-tools":
   version: 0.0.0-use.local
   resolution: "@objectiv/testing-tools@workspace:core/testing-tools"
   dependencies:
@@ -869,7 +869,7 @@ __metadata:
     "@angular/compiler": ^13.1.1
     "@angular/compiler-cli": ^13.1.1
     "@angular/core": ^13.1.1
-    "@objectiv/tracker-browser": ^0.0.4
+    "@objectiv/tracker-browser": ^0.0.5
     ng-packagr: ^13.1.2
     prettier: ^2.5.1
     rxjs: ^7.4.0
@@ -878,22 +878,22 @@ __metadata:
     typescript: ^4.5.4
     zone.js: ^0.11.4
   peerDependencies:
-    "@objectiv/tracker-browser": ^0.0.4
+    "@objectiv/tracker-browser": ^0.0.5
     uuid-random: ^1.3.2
   languageName: unknown
   linkType: soft
 
-"@objectiv/tracker-browser@^0.0.4, @objectiv/tracker-browser@workspace:trackers/browser":
+"@objectiv/tracker-browser@^0.0.5, @objectiv/tracker-browser@workspace:trackers/browser":
   version: 0.0.0-use.local
   resolution: "@objectiv/tracker-browser@workspace:trackers/browser"
   dependencies:
-    "@objectiv/plugin-path-context-from-url": ^0.0.4
-    "@objectiv/queue-local-storage": ^0.0.4
-    "@objectiv/testing-tools": 0.0.1
-    "@objectiv/tracker-core": ^0.0.4
+    "@objectiv/plugin-path-context-from-url": ^0.0.5
+    "@objectiv/queue-local-storage": ^0.0.5
+    "@objectiv/testing-tools": 0.0.5
+    "@objectiv/tracker-core": ^0.0.5
     "@objectiv/transport-debug": ^0.0.4
-    "@objectiv/transport-fetch": ^0.0.4
-    "@objectiv/transport-xhr": ^0.0.4
+    "@objectiv/transport-fetch": ^0.0.5
+    "@objectiv/transport-xhr": ^0.0.5
     "@rollup/plugin-commonjs": ^21.0.1
     "@rollup/plugin-node-resolve": ^13.1.1
     "@types/jest": ^27.0.3
@@ -916,12 +916,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@objectiv/tracker-core-react@workspace:core/react, @objectiv/tracker-core-react@~0.0.4":
+"@objectiv/tracker-core-react@workspace:core/react, @objectiv/tracker-core-react@~0.0.5":
   version: 0.0.0-use.local
   resolution: "@objectiv/tracker-core-react@workspace:core/react"
   dependencies:
-    "@objectiv/schema": ~0.0.4
-    "@objectiv/tracker-core": ~0.0.4
+    "@objectiv/schema": ~0.0.5
+    "@objectiv/tracker-core": ~0.0.5
     "@rollup/plugin-commonjs": ^21.0.1
     "@rollup/plugin-node-resolve": ^13.1.1
     "@testing-library/react": ^12.1.2
@@ -949,12 +949,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@objectiv/tracker-core@^0.0.4, @objectiv/tracker-core@workspace:core/tracker, @objectiv/tracker-core@~0.0.4":
+"@objectiv/tracker-core@^0.0.5, @objectiv/tracker-core@workspace:core/tracker, @objectiv/tracker-core@~0.0.5":
   version: 0.0.0-use.local
   resolution: "@objectiv/tracker-core@workspace:core/tracker"
   dependencies:
-    "@objectiv/schema": ^0.0.4
-    "@objectiv/testing-tools": 0.0.1
+    "@objectiv/schema": ^0.0.5
+    "@objectiv/testing-tools": 0.0.5
     "@rollup/plugin-commonjs": ^21.0.1
     "@rollup/plugin-node-resolve": ^13.1.1
     "@types/jest": ^27.0.3
@@ -979,13 +979,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@objectiv/tracker-react@workspace:trackers/react"
   dependencies:
-    "@objectiv/plugin-path-context-from-url": ^0.0.4
-    "@objectiv/queue-local-storage": ^0.0.4
-    "@objectiv/testing-tools": 0.0.1
-    "@objectiv/tracker-core": ~0.0.4
-    "@objectiv/tracker-core-react": ~0.0.4
-    "@objectiv/transport-fetch": ^0.0.4
-    "@objectiv/transport-xhr": ^0.0.4
+    "@objectiv/plugin-path-context-from-url": ^0.0.5
+    "@objectiv/queue-local-storage": ^0.0.5
+    "@objectiv/testing-tools": 0.0.5
+    "@objectiv/tracker-core": ~0.0.5
+    "@objectiv/tracker-core-react": ~0.0.5
+    "@objectiv/transport-fetch": ^0.0.5
+    "@objectiv/transport-xhr": ^0.0.5
     "@rollup/plugin-commonjs": ^21.0.1
     "@rollup/plugin-node-resolve": ^13.1.1
     "@types/jest": ^27.0.3
@@ -1009,8 +1009,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@objectiv/transport-debug@workspace:transports/debug"
   dependencies:
-    "@objectiv/testing-tools": 0.0.1
-    "@objectiv/tracker-core": ~0.0.4
+    "@objectiv/testing-tools": 0.0.5
+    "@objectiv/tracker-core": ~0.0.5
     "@rollup/plugin-commonjs": ^21.0.1
     "@rollup/plugin-node-resolve": ^13.1.1
     "@types/jest": ^27.0.3
@@ -1028,12 +1028,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@objectiv/transport-fetch@^0.0.4, @objectiv/transport-fetch@workspace:transports/fetch":
+"@objectiv/transport-fetch@^0.0.5, @objectiv/transport-fetch@workspace:transports/fetch":
   version: 0.0.0-use.local
   resolution: "@objectiv/transport-fetch@workspace:transports/fetch"
   dependencies:
-    "@objectiv/testing-tools": 0.0.1
-    "@objectiv/tracker-core": ~0.0.4
+    "@objectiv/testing-tools": 0.0.5
+    "@objectiv/tracker-core": ~0.0.5
     "@rollup/plugin-commonjs": ^21.0.1
     "@rollup/plugin-node-resolve": ^13.1.1
     "@types/jest": ^27.0.3
@@ -1052,12 +1052,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@objectiv/transport-xhr@^0.0.4, @objectiv/transport-xhr@workspace:transports/xhr":
+"@objectiv/transport-xhr@^0.0.5, @objectiv/transport-xhr@workspace:transports/xhr":
   version: 0.0.0-use.local
   resolution: "@objectiv/transport-xhr@workspace:transports/xhr"
   dependencies:
-    "@objectiv/testing-tools": 0.0.1
-    "@objectiv/tracker-core": ~0.0.4
+    "@objectiv/testing-tools": 0.0.5
+    "@objectiv/tracker-core": ~0.0.5
     "@rollup/plugin-commonjs": ^21.0.1
     "@rollup/plugin-node-resolve": ^13.1.1
     "@types/jest": ^27.0.3

--- a/tracker/yarn.lock
+++ b/tracker/yarn.lock
@@ -891,7 +891,7 @@ __metadata:
     "@objectiv/queue-local-storage": ^0.0.5
     "@objectiv/testing-tools": 0.0.5
     "@objectiv/tracker-core": ^0.0.5
-    "@objectiv/transport-debug": ^0.0.4
+    "@objectiv/transport-debug": ^0.0.5
     "@objectiv/transport-fetch": ^0.0.5
     "@objectiv/transport-xhr": ^0.0.5
     "@rollup/plugin-commonjs": ^21.0.1
@@ -1005,7 +1005,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@objectiv/transport-debug@^0.0.4, @objectiv/transport-debug@workspace:transports/debug":
+"@objectiv/transport-debug@^0.0.5, @objectiv/transport-debug@workspace:transports/debug":
   version: 0.0.0-use.local
   resolution: "@objectiv/transport-debug@workspace:transports/debug"
   dependencies:


### PR DESCRIPTION
This Pr finalizes the latest version of the monorepo packages to 0.0.5. Version 0.0.4 was a mix of legacy packages and new ones. While version 0.0.5 is our new clean slate. This includes also internal packages that were left behind until now.