### PR TITLE
Fix arm64 docker images

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -103,7 +103,7 @@ services:
 
   objectiv_metabase:
     container_name: objectiv_metabase
-    image: objectiv/metabase
+    image: ${OBJECTIV_CONTAINER_URL-objectiv}/metabase:${OBJECTIV_CONTAINER_TAG-latest}
     ports:
       - "127.0.0.1:3000:3000"
     networks:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -103,7 +103,7 @@ services:
 
   objectiv_metabase:
     container_name: objectiv_metabase
-    image: metabase/metabase
+    image: objectiv/metabase
     ports:
       - "127.0.0.1:3000:3000"
     networks:


### PR DESCRIPTION
We use our own metabase container, as the ones provided by metabase only support amd64. 
See https://github.com/objectiv/objectiv-demo/pull/45/files for the `Dockerfile`.