### PR TITLE
React Tracker: Fix and enable validation

### DIFF
--- a/tracker/trackers/browser/src/BrowserTracker.ts
+++ b/tracker/trackers/browser/src/BrowserTracker.ts
@@ -55,7 +55,7 @@ export class BrowserTracker extends Tracker {
     }
 
     // If node is in `development` mode and console has not been configured, automatically use the browser's console
-    if (!config.console && process.env.NODE_ENV?.startsWith('dev')) {
+    if (config.console === undefined && process.env.NODE_ENV?.startsWith('dev')) {
       config.console = console;
     }
 

--- a/tracker/trackers/react/src/ReactTracker.ts
+++ b/tracker/trackers/react/src/ReactTracker.ts
@@ -6,6 +6,7 @@ import { ContextsConfig, Tracker, TrackerConfig, TrackerPlugins } from '@objecti
 import { makeDefaultPluginsList } from './common/factories/makeDefaultPluginsList';
 import { makeDefaultQueue } from './common/factories/makeDefaultQueue';
 import { makeDefaultTransport } from './common/factories/makeDefaultTransport';
+import { isDevMode } from './common/isDevMode';
 
 /**
  * React Tracker can be configured in an easier way, as opposed to the core tracker.
@@ -73,7 +74,7 @@ export class ReactTracker extends Tracker {
     }
 
     // If node is in `development` on web and console has not been configured, automatically use the browser's console
-    if (!config.console && process.env.NODE_ENV?.startsWith('dev') && typeof window !== 'undefined') {
+    if (!config.console && isDevMode()) {
       config.console = console;
     }
 

--- a/tracker/trackers/react/src/ReactTracker.ts
+++ b/tracker/trackers/react/src/ReactTracker.ts
@@ -74,7 +74,7 @@ export class ReactTracker extends Tracker {
     }
 
     // If node is in `development` on web and console has not been configured, automatically use the browser's console
-    if (!config.console && isDevMode()) {
+    if (config.console === undefined && isDevMode()) {
       config.console = console;
     }
 

--- a/tracker/trackers/react/src/common/LocationTree.ts
+++ b/tracker/trackers/react/src/common/LocationTree.ts
@@ -162,6 +162,8 @@ export const LocationTree = {
 
     if (locationPathsSize === locationPaths.size) {
       LocationTree.error(locationId, `Location collision detected: ${locationPath}`);
+      // No point in continuing to validate this node children, exit early
+      return;
     }
 
     // Rerun validation for each child

--- a/tracker/trackers/react/src/common/factories/makeIdFromString.ts
+++ b/tracker/trackers/react/src/common/factories/makeIdFromString.ts
@@ -6,8 +6,8 @@
  * Converts the given text to a standardized format to be used as identifier for Location Contexts.
  * This may be used, among others, to infer a valid identifier from the title / label of a Button.
  */
-export const makeIdFromString = (sourceString: string): string => {
-  let id;
+export const makeIdFromString = (sourceString: string): string | null => {
+  let id = '';
 
   if (typeof sourceString === 'string') {
     id = sourceString
@@ -17,7 +17,7 @@ export const makeIdFromString = (sourceString: string): string => {
       .trim()
       // Replace spaces with dashes
       .replace(/[\s]+/g, '-')
-      // Remove non alphanumeric characters except dashes and underscores
+      // Remove non-alphanumeric characters except dashes and underscores
       .replace(/[^a-zA-Z0-9_-]+/g, '')
       // Get rid of duplicated dashes
       .replace(/-+/g, '-')
@@ -26,12 +26,12 @@ export const makeIdFromString = (sourceString: string): string => {
       // Get rid of leading or trailing underscores and dashes
       .replace(/^([-_])*|([-_])*$/g, '')
       // Truncate to 64 chars
-      .substr(0, 64);
+      .slice(0, 64);
   }
 
-  // Throw if we did not manage to generate a valid id
-  if (!id) {
-    throw new Error('Could not generated a valid id. Please provide one manually.');
+  // Catch empty strings and return null
+  if (!id || !id.length) {
+    return null;
   }
 
   // Return processed id

--- a/tracker/trackers/react/src/common/factories/makeTitleFromChildren.ts
+++ b/tracker/trackers/react/src/common/factories/makeTitleFromChildren.ts
@@ -7,17 +7,10 @@ import { recursiveGetTextFromChildrenNode } from './recursiveGetTextFromChildren
 
 /**
  * Retrieve text from given ReactNode children.
- * The resulting text may be may be used, among others, to infer a valid text and identifier for a Button.
+ * The resulting text may be used, among others, to infer a valid text and identifier for a Button.
  *
  * @see makeIdFromString
  */
 export const makeTitleFromChildren = (children: ReactNode): string => {
-  const text = recursiveGetTextFromChildrenNode(children);
-
-  // Throw if we did not manage to get any text
-  if (!text) {
-    throw new Error('Could not infer a title from children nodes. Please provide one manually.');
-  }
-
-  return text.trim();
+  return recursiveGetTextFromChildrenNode(children)?.trim() ?? '';
 };

--- a/tracker/trackers/react/src/common/isDevMode.ts
+++ b/tracker/trackers/react/src/common/isDevMode.ts
@@ -1,0 +1,9 @@
+/*
+ * Copyright 2021-2022 Objectiv B.V.
+ */
+
+/**
+ * Helper function to determine if we are in development mode.
+ * Determines whether Node environment is development and if we are in a browser by checking the window object.
+ */
+export const isDevMode = () => process.env.NODE_ENV?.startsWith('dev') && typeof window !== 'undefined';

--- a/tracker/trackers/react/src/common/providers/ObjectivProvider.tsx
+++ b/tracker/trackers/react/src/common/providers/ObjectivProvider.tsx
@@ -5,6 +5,7 @@
 import React, { ReactNode, useContext } from 'react';
 import { trackApplicationLoadedEvent } from '../../eventTrackers/trackApplicationLoadedEvent';
 import { useOnMount } from '../../hooks/useOnMount';
+import { useOnUnmount } from '../../hooks/useOnUnmount';
 import { LocationTree } from '../LocationTree';
 import { ObjectivProviderContext } from './ObjectivProviderContext';
 import { TrackerProviderContext } from './TrackerProviderContext';
@@ -59,6 +60,10 @@ export const ObjectivProvider = ({ children, tracker, options }: ObjectivProvide
     if (trackApplicationLoaded) {
       trackApplicationLoadedEvent({ tracker });
     }
+    LocationTree.clear();
+  });
+
+  useOnUnmount(() => {
     LocationTree.clear();
   });
 

--- a/tracker/trackers/react/src/common/providers/ObjectivProvider.tsx
+++ b/tracker/trackers/react/src/common/providers/ObjectivProvider.tsx
@@ -5,8 +5,6 @@
 import React, { ReactNode, useContext } from 'react';
 import { trackApplicationLoadedEvent } from '../../eventTrackers/trackApplicationLoadedEvent';
 import { useOnMount } from '../../hooks/useOnMount';
-import { useOnUnmount } from '../../hooks/useOnUnmount';
-import { LocationTree } from '../LocationTree';
 import { ObjectivProviderContext } from './ObjectivProviderContext';
 import { TrackerProviderContext } from './TrackerProviderContext';
 import { TrackingContext } from './TrackingContext';
@@ -60,11 +58,6 @@ export const ObjectivProvider = ({ children, tracker, options }: ObjectivProvide
     if (trackApplicationLoaded) {
       trackApplicationLoadedEvent({ tracker });
     }
-    LocationTree.clear();
-  });
-
-  useOnUnmount(() => {
-    LocationTree.clear();
   });
 
   return (

--- a/tracker/trackers/react/src/common/providers/TrackerProvider.tsx
+++ b/tracker/trackers/react/src/common/providers/TrackerProvider.tsx
@@ -3,6 +3,7 @@
  */
 
 import React, { ReactNode } from 'react';
+import { LocationTree } from '../LocationTree';
 import { TrackerProviderContext } from './TrackerProviderContext';
 
 /**
@@ -24,8 +25,12 @@ export type TrackerProviderProps = TrackerProviderContext & {
  * @see LocationStackProvider
  * @see ObjectivProvider
  */
-export const TrackerProvider = ({ children, tracker }: TrackerProviderProps) => (
-  <TrackerProviderContext.Provider value={{ tracker }}>
-    {typeof children === 'function' ? children({ tracker }) : children}
-  </TrackerProviderContext.Provider>
-);
+export const TrackerProvider = ({ children, tracker }: TrackerProviderProps) => {
+  LocationTree.initialize(tracker);
+
+  return (
+    <TrackerProviderContext.Provider value={{ tracker }}>
+      {typeof children === 'function' ? children({ tracker }) : children}
+    </TrackerProviderContext.Provider>
+  );
+};

--- a/tracker/trackers/react/src/common/providers/TrackerProvider.tsx
+++ b/tracker/trackers/react/src/common/providers/TrackerProvider.tsx
@@ -3,6 +3,7 @@
  */
 
 import React, { ReactNode } from 'react';
+import { isDevMode } from '../isDevMode';
 import { LocationTree } from '../LocationTree';
 import { TrackerProviderContext } from './TrackerProviderContext';
 
@@ -26,7 +27,9 @@ export type TrackerProviderProps = TrackerProviderContext & {
  * @see ObjectivProvider
  */
 export const TrackerProvider = ({ children, tracker }: TrackerProviderProps) => {
-  LocationTree.initialize(tracker);
+  if (isDevMode()) {
+    LocationTree.initialize(tracker);
+  }
 
   return (
     <TrackerProviderContext.Provider value={{ tracker }}>

--- a/tracker/trackers/react/src/hooks/useOnChange.ts
+++ b/tracker/trackers/react/src/hooks/useOnChange.ts
@@ -9,7 +9,7 @@ import { OnChangeEffectCallback } from '../types';
 /**
  * A side effect that monitors the given `state` and runs the given `effect` when it changes.
  */
-export const useOnChange = <T>(state: T, effect: OnChangeEffectCallback) => {
+export const useOnChange = <T>(state: T, effect: OnChangeEffectCallback<T>) => {
   let previousStateRef = useRef<T>(state);
   let latestEffectRef = useRef(effect);
 

--- a/tracker/trackers/react/src/index.ts
+++ b/tracker/trackers/react/src/index.ts
@@ -29,6 +29,7 @@ export * from './common/providers/TrackingContext';
 export * from './common/providers/TrackingContextProvider';
 
 export * from './common/executeOnce';
+export * from './common/isDevMode';
 export * from './common/LocationTree';
 export * from './common/trackPressEventHandler';
 

--- a/tracker/trackers/react/src/locationWrappers/LocationContextWrapper.tsx
+++ b/tracker/trackers/react/src/locationWrappers/LocationContextWrapper.tsx
@@ -4,6 +4,7 @@
 
 import { AbstractLocationContext } from '@objectiv/schema';
 import React, { ReactNode } from 'react';
+import { isDevMode } from '../common/isDevMode';
 import { LocationTree } from '../common/LocationTree';
 import { LocationProvider } from '../common/providers/LocationProvider';
 import { TrackingContext } from '../common/providers/TrackingContext';
@@ -38,16 +39,22 @@ export const LocationContextWrapper = ({ children, locationContext }: LocationCo
   const parentLocationContext = useParentLocationContext();
 
   useOnMount(() => {
-    LocationTree.add(locationContext, parentLocationContext);
+    if (isDevMode()) {
+      LocationTree.add(locationContext, parentLocationContext);
+    }
   });
 
   useOnUnmount(() => {
-    LocationTree.remove(locationContext);
+    if (isDevMode()) {
+      LocationTree.remove(locationContext);
+    }
   });
 
   useOnChange<LocationContext<AbstractLocationContext>>(locationContext, (previousLocationContext) => {
-    LocationTree.remove(previousLocationContext);
-    LocationTree.add(locationContext, parentLocationContext);
+    if (isDevMode()) {
+      LocationTree.remove(previousLocationContext);
+      LocationTree.add(locationContext, parentLocationContext);
+    }
   });
 
   return (

--- a/tracker/trackers/react/src/locationWrappers/LocationContextWrapper.tsx
+++ b/tracker/trackers/react/src/locationWrappers/LocationContextWrapper.tsx
@@ -4,9 +4,14 @@
 
 import { AbstractLocationContext } from '@objectiv/schema';
 import React, { ReactNode } from 'react';
+import { LocationTree } from '../common/LocationTree';
 import { LocationProvider } from '../common/providers/LocationProvider';
 import { TrackingContext } from '../common/providers/TrackingContext';
+import { useParentLocationContext } from '../hooks/consumers/useParentLocationContext';
 import { useTracker } from '../hooks/consumers/useTracker';
+import { useOnChange } from '../hooks/useOnChange';
+import { useOnMount } from '../hooks/useOnMount';
+import { useOnUnmount } from '../hooks/useOnUnmount';
 import { LocationContext } from '../types';
 
 /**
@@ -30,9 +35,20 @@ export type LocationContextWrapperProps = {
  */
 export const LocationContextWrapper = ({ children, locationContext }: LocationContextWrapperProps) => {
   const tracker = useTracker();
+  const parentLocationContext = useParentLocationContext();
 
-  // TODO: Add new LocationEntry to LocationTree as well (LocationTree is not ready for production yet)
-  //LocationTree.add(locationContext, useParentLocationContext());
+  useOnMount(() => {
+    LocationTree.add(locationContext, parentLocationContext);
+  });
+
+  useOnUnmount(() => {
+    LocationTree.remove(locationContext);
+  });
+
+  useOnChange<LocationContext<AbstractLocationContext>>(locationContext, (previousLocationContext) => {
+    LocationTree.remove(previousLocationContext);
+    LocationTree.add(locationContext, parentLocationContext);
+  });
 
   return (
     <LocationProvider locationStack={[locationContext]}>

--- a/tracker/trackers/react/src/types.ts
+++ b/tracker/trackers/react/src/types.ts
@@ -24,7 +24,7 @@ export type LocationStack = LocationContext<AbstractLocationContext>[];
 /**
  * A custom generic EffectCallback that receives the monitored `previousState` and `state` values
  */
-export type OnChangeEffectCallback = <T>(previousState: T, state: T) => void;
+export type OnChangeEffectCallback<T> = (previousState: T, state: T) => void;
 
 /**
  * A custom EffectCallback that receives the monitored `previousState` and `state` boolean values

--- a/tracker/trackers/react/tests/LocationTree.test.ts
+++ b/tracker/trackers/react/tests/LocationTree.test.ts
@@ -204,16 +204,50 @@ describe('LocationTree', () => {
     const section1 = makeContentContext({ id: '1' });
     const section2 = makeContentContext({ id: 'oops' });
     const section3 = makeContentContext({ id: 'oops' });
+    const section4 = makeContentContext({ id: 'oops' });
 
     LocationTree.add(rootSection, null);
     LocationTree.add(section1, rootSection);
     LocationTree.add(section2, rootSection);
     LocationTree.add(section3, rootSection);
+    LocationTree.add(section4, rootSection);
 
-    expect(console.error).toHaveBeenCalledTimes(1);
+    expect(console.error).toHaveBeenCalledTimes(2);
     expect(console.error).toHaveBeenNthCalledWith(
       1,
       '｢objectiv｣ Location collision detected: Content:root / Content:oops'
+    );
+    expect(console.error).toHaveBeenNthCalledWith(
+      2,
+      '｢objectiv｣ Location collision detected: Content:root / Content:oops'
+    );
+  });
+
+  it('should not console.error collisions in children of already colliding nodes', () => {
+    const rootSection = makeContentContext({ id: 'root' });
+    const section1 = makeContentContext({ id: '1' });
+    const section2 = makeContentContext({ id: 'oops' });
+    const section3 = makeContentContext({ id: 'oops' });
+    const section4 = makeContentContext({ id: '1' });
+    const section5 = makeContentContext({ id: 'oops' });
+    const section6 = makeContentContext({ id: 'oops' });
+
+    LocationTree.add(rootSection, null);
+    LocationTree.add(section1, rootSection);
+    LocationTree.add(section2, rootSection);
+    LocationTree.add(section3, rootSection);
+    LocationTree.add(section4, rootSection);
+    LocationTree.add(section5, section4);
+    LocationTree.add(section6, section4);
+
+    expect(console.error).toHaveBeenCalledTimes(2);
+    expect(console.error).toHaveBeenNthCalledWith(
+      1,
+      '｢objectiv｣ Location collision detected: Content:root / Content:oops'
+    );
+    expect(console.error).toHaveBeenNthCalledWith(
+      2,
+      '｢objectiv｣ Location collision detected: Content:root / Content:1'
     );
   });
 

--- a/tracker/trackers/react/tests/LocationTree.test.ts
+++ b/tracker/trackers/react/tests/LocationTree.test.ts
@@ -2,7 +2,15 @@
  * Copyright 2021-2022 Objectiv B.V.
  */
 
-import { LocationTree, makeContentContext } from '../src';
+import {
+  locationNodes,
+  LocationTree,
+  makeContentContext,
+  makeLinkContext,
+  makeNavigationContext,
+  makePressableContext,
+  makeRootLocationContext,
+} from '../src';
 
 describe('LocationTree', () => {
   beforeEach(() => {
@@ -23,39 +31,186 @@ describe('LocationTree', () => {
     expect(console.log).not.toHaveBeenCalled();
   });
 
-  it('should not log anything (falsy input)', () => {
-    // @ts-ignore
-    LocationTree.log(0);
+  it('should add nodes', () => {
+    const root = makeRootLocationContext({ id: 'root' });
+    const nav = makeNavigationContext({ id: 'nav' });
+    const button = makePressableContext({ id: 'button' });
+    const footer = makeNavigationContext({ id: 'footer' });
 
-    expect(console.log).not.toHaveBeenCalled();
+    expect(locationNodes).toHaveLength(0);
+
+    LocationTree.add(root, null);
+    LocationTree.add(nav, root);
+    LocationTree.add(button, nav);
+    LocationTree.add(footer, root);
+
+    expect(locationNodes).toHaveLength(4);
+    expect(locationNodes).toStrictEqual([
+      expect.objectContaining({
+        __location_id: root.__location_id,
+        _type: 'RootLocationContext',
+        id: 'root',
+        parentLocationId: null,
+      }),
+      expect.objectContaining({
+        _type: 'NavigationContext',
+        id: 'nav',
+        parentLocationId: root.__location_id,
+      }),
+      expect.objectContaining({
+        _type: 'PressableContext',
+        id: 'button',
+        parentLocationId: nav.__location_id,
+      }),
+      expect.objectContaining({
+        _type: 'NavigationContext',
+        id: 'footer',
+        parentLocationId: root.__location_id,
+      }),
+    ]);
   });
 
-  it('should throw if the given parentLocation does not exist', () => {
-    // We create two Locations, but we do not add them to the LocationTree, thus parent retrieval will fail
-    const location = makeContentContext({ id: 'root' });
-    const parentLocation = makeContentContext({ id: 'parent' });
+  it('should remove nodes', () => {
+    const root = makeRootLocationContext({ id: 'root' });
+    const nav = makeNavigationContext({ id: 'nav' });
+    const button = makePressableContext({ id: 'button' });
+    const footer = makeNavigationContext({ id: 'footer' });
 
-    expect(() => LocationTree.add(location, parentLocation)).toThrow('Parent LocationNode not found.');
+    expect(locationNodes).toHaveLength(0);
+
+    LocationTree.add(root, null);
+    LocationTree.add(nav, root);
+    LocationTree.add(button, nav);
+    LocationTree.add(footer, root);
+
+    expect(locationNodes).toHaveLength(4);
+
+    LocationTree.remove(button);
+
+    expect(locationNodes).toHaveLength(3);
+    expect(locationNodes).toStrictEqual([
+      expect.objectContaining({
+        __location_id: root.__location_id,
+        _type: 'RootLocationContext',
+        id: 'root',
+        parentLocationId: null,
+      }),
+      expect.objectContaining({
+        _type: 'NavigationContext',
+        id: 'nav',
+        parentLocationId: root.__location_id,
+      }),
+      expect.objectContaining({
+        _type: 'NavigationContext',
+        id: 'footer',
+        parentLocationId: root.__location_id,
+      }),
+    ]);
   });
 
-  it('should console.error collisions once', () => {
+  it('should remove branches', () => {
+    const root = makeRootLocationContext({ id: 'root' });
+    const nav = makeNavigationContext({ id: 'nav' });
+    const button = makePressableContext({ id: 'button' });
+    const footer = makeNavigationContext({ id: 'footer' });
+
+    expect(locationNodes).toHaveLength(0);
+
+    LocationTree.add(root, null);
+    LocationTree.add(nav, root);
+    LocationTree.add(button, nav);
+    LocationTree.add(footer, root);
+
+    expect(locationNodes).toHaveLength(4);
+
+    LocationTree.remove(nav);
+
+    expect(locationNodes).toHaveLength(2);
+    expect(locationNodes).toStrictEqual([
+      expect.objectContaining({
+        __location_id: root.__location_id,
+        _type: 'RootLocationContext',
+        id: 'root',
+        parentLocationId: null,
+      }),
+      expect.objectContaining({
+        _type: 'NavigationContext',
+        id: 'footer',
+        parentLocationId: root.__location_id,
+      }),
+    ]);
+  });
+
+  it('should remove orphan nodes and branches', () => {
+    const root = makeRootLocationContext({ id: 'root' });
+    const nav = makeNavigationContext({ id: 'nav' });
+    const button = makePressableContext({ id: 'button' });
+    const main = makeContentContext({ id: 'main' });
+    const hero = makeContentContext({ id: 'hero' });
+    const link1 = makeLinkContext({ id: 'link', href: '/link1' });
+    const link2 = makeLinkContext({ id: 'link', href: '/link2' });
+    const footer = makeNavigationContext({ id: 'footer' });
+
+    expect(locationNodes).toHaveLength(0);
+
+    LocationTree.add(root, null);
+    LocationTree.add(nav, root);
+    LocationTree.add(button, nav);
+    LocationTree.add(main, root);
+    LocationTree.add(hero, main);
+    LocationTree.add(link1, hero);
+    LocationTree.add(footer, root);
+    LocationTree.add(link2, footer);
+
+    expect(locationNodes).toHaveLength(8);
+
+    LocationTree.remove(footer);
+    LocationTree.remove(main);
+
+    expect(locationNodes).toHaveLength(3);
+    expect(locationNodes).toStrictEqual([
+      expect.objectContaining({
+        __location_id: root.__location_id,
+        _type: 'RootLocationContext',
+        id: 'root',
+        parentLocationId: null,
+      }),
+      expect.objectContaining({
+        _type: 'NavigationContext',
+        id: 'nav',
+        parentLocationId: root.__location_id,
+      }),
+      expect.objectContaining({
+        _type: 'PressableContext',
+        id: 'button',
+        parentLocationId: nav.__location_id,
+      }),
+    ]);
+  });
+
+  it('should console.error collisions', () => {
     const rootSection = makeContentContext({ id: 'root' });
     const section1 = makeContentContext({ id: '1' });
     const section2 = makeContentContext({ id: 'oops' });
     const section3 = makeContentContext({ id: 'oops' });
     const section4 = makeContentContext({ id: 'oops' });
+    const anotherRoot = makeContentContext({ id: 'root' });
+    const section5 = makeContentContext({ id: 'oops' });
 
-    LocationTree.add(rootSection);
+    LocationTree.add(rootSection, null);
     LocationTree.add(section1, rootSection);
     LocationTree.add(section2, rootSection);
     LocationTree.add(section3, rootSection);
     LocationTree.add(section4, rootSection);
+    LocationTree.add(anotherRoot, null);
+    LocationTree.add(section5, anotherRoot);
 
-    expect(console.error).toHaveBeenCalledTimes(1);
+    expect(console.error).toHaveBeenCalledTimes(2);
     expect(console.error).toHaveBeenNthCalledWith(
       1,
       '｢objectiv｣ Location collision detected: Content:root / Content:oops'
     );
+    expect(console.error).toHaveBeenNthCalledWith(2, '｢objectiv｣ Location collision detected: Content:root');
   });
 
   it('should log the Location tree', () => {
@@ -66,26 +221,32 @@ describe('LocationTree', () => {
     const section2b = makeContentContext({ id: '2b' });
     const section3 = makeContentContext({ id: '3' });
     const section3a = makeContentContext({ id: '3a' });
+    const footer = makeContentContext({ id: 'footer' });
+    const section4 = makeContentContext({ id: '4' });
 
-    LocationTree.add(rootSection);
+    LocationTree.add(rootSection, null);
     LocationTree.add(section1, rootSection);
     LocationTree.add(section2, rootSection);
     LocationTree.add(section2a, section2);
     LocationTree.add(section2b, section2);
     LocationTree.add(section3, rootSection);
     LocationTree.add(section3a, section3);
+    LocationTree.add(footer, null);
+    LocationTree.add(section4, footer);
 
     jest.spyOn(console, 'log').mockImplementation(() => {});
 
     LocationTree.log();
 
-    expect(console.log).toHaveBeenCalledTimes(7);
-    expect(console.log).toHaveBeenNthCalledWith(1, '  ContentContext:root');
-    expect(console.log).toHaveBeenNthCalledWith(2, '    ContentContext:1');
-    expect(console.log).toHaveBeenNthCalledWith(3, '    ContentContext:2');
-    expect(console.log).toHaveBeenNthCalledWith(4, '      ContentContext:2a');
-    expect(console.log).toHaveBeenNthCalledWith(5, '      ContentContext:2b');
-    expect(console.log).toHaveBeenNthCalledWith(6, '    ContentContext:3');
-    expect(console.log).toHaveBeenNthCalledWith(7, '      ContentContext:3a');
+    expect(console.log).toHaveBeenCalledTimes(9);
+    expect(console.log).toHaveBeenNthCalledWith(1, 'ContentContext:root');
+    expect(console.log).toHaveBeenNthCalledWith(2, '  ContentContext:1');
+    expect(console.log).toHaveBeenNthCalledWith(3, '  ContentContext:2');
+    expect(console.log).toHaveBeenNthCalledWith(4, '    ContentContext:2a');
+    expect(console.log).toHaveBeenNthCalledWith(5, '    ContentContext:2b');
+    expect(console.log).toHaveBeenNthCalledWith(6, '  ContentContext:3');
+    expect(console.log).toHaveBeenNthCalledWith(7, '    ContentContext:3a');
+    expect(console.log).toHaveBeenNthCalledWith(8, 'ContentContext:footer');
+    expect(console.log).toHaveBeenNthCalledWith(9, '  ContentContext:4');
   });
 });

--- a/tracker/trackers/react/tests/LocationTree.test.ts
+++ b/tracker/trackers/react/tests/LocationTree.test.ts
@@ -31,6 +31,17 @@ describe('LocationTree', () => {
     expect(console.log).not.toHaveBeenCalled();
   });
 
+  it('should console.error multiple roots', () => {
+    const root1 = makeContentContext({ id: 'root1' });
+    const root2 = makeContentContext({ id: 'root2' });
+
+    LocationTree.add(root1, null);
+    LocationTree.add(root2, null);
+
+    expect(console.error).toHaveBeenCalledTimes(1);
+    expect(console.error).toHaveBeenCalledWith(`｢objectiv｣ Multiple root locations detected: ${root2.id}`);
+  });
+
   it('should add nodes', () => {
     const root = makeRootLocationContext({ id: 'root' });
     const nav = makeNavigationContext({ id: 'nav' });
@@ -193,24 +204,17 @@ describe('LocationTree', () => {
     const section1 = makeContentContext({ id: '1' });
     const section2 = makeContentContext({ id: 'oops' });
     const section3 = makeContentContext({ id: 'oops' });
-    const section4 = makeContentContext({ id: 'oops' });
-    const anotherRoot = makeContentContext({ id: 'root' });
-    const section5 = makeContentContext({ id: 'oops' });
 
     LocationTree.add(rootSection, null);
     LocationTree.add(section1, rootSection);
     LocationTree.add(section2, rootSection);
     LocationTree.add(section3, rootSection);
-    LocationTree.add(section4, rootSection);
-    LocationTree.add(anotherRoot, null);
-    LocationTree.add(section5, anotherRoot);
 
-    expect(console.error).toHaveBeenCalledTimes(2);
+    expect(console.error).toHaveBeenCalledTimes(1);
     expect(console.error).toHaveBeenNthCalledWith(
       1,
       '｢objectiv｣ Location collision detected: Content:root / Content:oops'
     );
-    expect(console.error).toHaveBeenNthCalledWith(2, '｢objectiv｣ Location collision detected: Content:root');
   });
 
   it('should log the Location tree', () => {
@@ -231,7 +235,7 @@ describe('LocationTree', () => {
     LocationTree.add(section2b, section2);
     LocationTree.add(section3, rootSection);
     LocationTree.add(section3a, section3);
-    LocationTree.add(footer, null);
+    LocationTree.add(footer, rootSection);
     LocationTree.add(section4, footer);
 
     jest.spyOn(console, 'log').mockImplementation(() => {});
@@ -246,7 +250,7 @@ describe('LocationTree', () => {
     expect(console.log).toHaveBeenNthCalledWith(5, '    ContentContext:2b');
     expect(console.log).toHaveBeenNthCalledWith(6, '  ContentContext:3');
     expect(console.log).toHaveBeenNthCalledWith(7, '    ContentContext:3a');
-    expect(console.log).toHaveBeenNthCalledWith(8, 'ContentContext:footer');
-    expect(console.log).toHaveBeenNthCalledWith(9, '  ContentContext:4');
+    expect(console.log).toHaveBeenNthCalledWith(8, '  ContentContext:footer');
+    expect(console.log).toHaveBeenNthCalledWith(9, '    ContentContext:4');
   });
 });

--- a/tracker/trackers/react/tests/SSR.test.tsx
+++ b/tracker/trackers/react/tests/SSR.test.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2021-2022 Objectiv B.V.
+ */
+
+import { mockConsole, SpyTransport } from '@objectiv/testing-tools';
+import { render } from '@testing-library/react';
+import React from 'react';
+import { isDevMode, LocationTree, ObjectivProvider, ReactTracker, TrackedMain } from '../src';
+
+describe('Browser / SSR', () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    jest.spyOn(LocationTree, 'initialize');
+    jest.spyOn(LocationTree, 'add');
+    jest.spyOn(LocationTree, 'remove');
+    process.env = { ...OLD_ENV };
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterAll(() => {
+    jest.resetAllMocks();
+    process.env = OLD_ENV;
+  });
+
+  it('LocationTree: should not be invoked', () => {
+    process.env.NODE_ENV = 'production';
+
+    expect(isDevMode()).toBe(false);
+
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: new SpyTransport(), console: mockConsole });
+
+    const { rerender, unmount } = render(
+      <ObjectivProvider tracker={tracker}>
+        <TrackedMain>test</TrackedMain>
+      </ObjectivProvider>
+    );
+
+    rerender(
+      <ObjectivProvider tracker={tracker}>
+        <TrackedMain>children change!</TrackedMain>
+      </ObjectivProvider>
+    );
+
+    unmount();
+
+    expect(LocationTree.initialize).not.toHaveBeenCalled();
+    expect(LocationTree.add).not.toHaveBeenCalled();
+    expect(LocationTree.remove).not.toHaveBeenCalled();
+  });
+
+  it('LocationTree: should not be invoked', () => {
+    process.env.NODE_ENV = 'development';
+
+    expect(isDevMode()).toBe(true);
+
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: new SpyTransport(), console: mockConsole });
+
+    const { rerender, unmount } = render(
+      <ObjectivProvider tracker={tracker}>
+        <TrackedMain>test</TrackedMain>
+      </ObjectivProvider>
+    );
+
+    rerender(
+      <ObjectivProvider tracker={tracker}>
+        <TrackedMain>children change!</TrackedMain>
+      </ObjectivProvider>
+    );
+
+    unmount();
+
+    expect(LocationTree.initialize).toHaveBeenCalled();
+    expect(LocationTree.add).toHaveBeenCalled();
+    expect(LocationTree.remove).toHaveBeenCalled();
+  });
+});

--- a/tracker/trackers/react/tests/TrackedAnchor.test.tsx
+++ b/tracker/trackers/react/tests/TrackedAnchor.test.tsx
@@ -3,10 +3,9 @@
  */
 
 import { SpyTransport } from '@objectiv/testing-tools';
-import { Tracker } from '@objectiv/tracker-core';
 import { fireEvent, getByText, render } from '@testing-library/react';
 import React from 'react';
-import { LocationTree, ObjectivProvider, TrackedAnchor } from '../src';
+import { LocationTree, ObjectivProvider, ReactTracker, TrackedAnchor } from '../src';
 
 describe('TrackedAnchor', () => {
   beforeEach(() => {
@@ -21,7 +20,7 @@ describe('TrackedAnchor', () => {
   it('should wrap the given Component in a LinkContext', () => {
     const spyTransport = new SpyTransport();
     jest.spyOn(spyTransport, 'handle');
-    const tracker = new Tracker({ applicationId: 'app-id', transport: spyTransport });
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: spyTransport });
 
     const { container } = render(
       <ObjectivProvider tracker={tracker}>
@@ -37,13 +36,13 @@ describe('TrackedAnchor', () => {
     expect(spyTransport.handle).toHaveBeenCalledWith(
       expect.objectContaining({
         _type: 'PressEvent',
-        location_stack: [
+        location_stack: expect.arrayContaining([
           expect.objectContaining({
             _type: 'LinkContext',
             id: 'trigger-event',
             href: '/some-url',
           }),
-        ],
+        ]),
       })
     );
   });

--- a/tracker/trackers/react/tests/TrackedButton.test.tsx
+++ b/tracker/trackers/react/tests/TrackedButton.test.tsx
@@ -3,10 +3,9 @@
  */
 
 import { SpyTransport } from '@objectiv/testing-tools';
-import { Tracker } from '@objectiv/tracker-core';
 import { fireEvent, getByText, render } from '@testing-library/react';
 import React from 'react';
-import { LocationTree, ObjectivProvider, TrackedButton } from '../src';
+import { LocationTree, ObjectivProvider, ReactTracker, TrackedButton } from '../src';
 
 describe('TrackedButton', () => {
   beforeEach(() => {
@@ -21,7 +20,7 @@ describe('TrackedButton', () => {
   it('should wrap the given Component in a PressableContext', () => {
     const spyTransport = new SpyTransport();
     jest.spyOn(spyTransport, 'handle');
-    const tracker = new Tracker({ applicationId: 'app-id', transport: spyTransport });
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: spyTransport });
 
     const { container } = render(
       <ObjectivProvider tracker={tracker}>
@@ -37,12 +36,12 @@ describe('TrackedButton', () => {
     expect(spyTransport.handle).toHaveBeenCalledWith(
       expect.objectContaining({
         _type: 'PressEvent',
-        location_stack: [
+        location_stack: expect.arrayContaining([
           expect.objectContaining({
             _type: 'PressableContext',
             id: 'trigger-event',
           }),
-        ],
+        ]),
       })
     );
   });

--- a/tracker/trackers/react/tests/TrackedContentContext.test.tsx
+++ b/tracker/trackers/react/tests/TrackedContentContext.test.tsx
@@ -3,10 +3,9 @@
  */
 
 import { SpyTransport } from '@objectiv/testing-tools';
-import { Tracker } from '@objectiv/tracker-core';
 import { fireEvent, getByText, render, screen } from '@testing-library/react';
 import React, { createRef } from 'react';
-import { LocationTree, ObjectivProvider, TrackedContentContext, usePressEventTracker } from '../src';
+import { LocationTree, ObjectivProvider, ReactTracker, TrackedContentContext, usePressEventTracker } from '../src';
 
 describe('TrackedContentContext', () => {
   beforeEach(() => {
@@ -21,7 +20,7 @@ describe('TrackedContentContext', () => {
   it('should wrap the given Component in a ContentContext', () => {
     const spyTransport = new SpyTransport();
     jest.spyOn(spyTransport, 'handle');
-    const tracker = new Tracker({ applicationId: 'app-id', transport: spyTransport });
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: spyTransport });
 
     const TrackedButton = () => {
       const trackPressEvent = usePressEventTracker();
@@ -49,18 +48,18 @@ describe('TrackedContentContext', () => {
       2,
       expect.objectContaining({
         _type: 'PressEvent',
-        location_stack: [
+        location_stack: expect.arrayContaining([
           expect.objectContaining({
             _type: 'ContentContext',
             id: 'content-id',
           }),
-        ],
+        ]),
       })
     );
   });
 
   it('should allow forwarding the id property', () => {
-    const tracker = new Tracker({ applicationId: 'app-id' });
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: new SpyTransport() });
 
     render(
       <ObjectivProvider tracker={tracker}>
@@ -78,7 +77,7 @@ describe('TrackedContentContext', () => {
   });
 
   it('should allow forwarding refs', () => {
-    const tracker = new Tracker({ applicationId: 'app-id' });
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: new SpyTransport() });
     const ref = createRef<HTMLDivElement>();
 
     render(

--- a/tracker/trackers/react/tests/TrackedDiv.test.tsx
+++ b/tracker/trackers/react/tests/TrackedDiv.test.tsx
@@ -3,10 +3,9 @@
  */
 
 import { SpyTransport } from '@objectiv/testing-tools';
-import { Tracker } from '@objectiv/tracker-core';
 import { fireEvent, getByText, render } from '@testing-library/react';
 import React from 'react';
-import { LocationTree, ObjectivProvider, TrackedDiv, usePressEventTracker } from '../src';
+import { LocationTree, ObjectivProvider, ReactTracker, TrackedDiv, usePressEventTracker } from '../src';
 
 describe('TrackedDiv', () => {
   beforeEach(() => {
@@ -21,7 +20,7 @@ describe('TrackedDiv', () => {
   it('should wrap the given Component in a ContentContext', () => {
     const spyTransport = new SpyTransport();
     jest.spyOn(spyTransport, 'handle');
-    const tracker = new Tracker({ applicationId: 'app-id', transport: spyTransport });
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: spyTransport });
 
     const TrackedButton = () => {
       const trackPressEvent = usePressEventTracker();
@@ -44,12 +43,12 @@ describe('TrackedDiv', () => {
     expect(spyTransport.handle).toHaveBeenCalledWith(
       expect.objectContaining({
         _type: 'PressEvent',
-        location_stack: [
+        location_stack: expect.arrayContaining([
           expect.objectContaining({
             _type: 'ContentContext',
             id: 'div-id',
           }),
-        ],
+        ]),
       })
     );
   });

--- a/tracker/trackers/react/tests/TrackedExpandableContext.test.tsx
+++ b/tracker/trackers/react/tests/TrackedExpandableContext.test.tsx
@@ -3,10 +3,9 @@
  */
 
 import { SpyTransport } from '@objectiv/testing-tools';
-import { Tracker } from '@objectiv/tracker-core';
 import { fireEvent, getByText, render, screen } from '@testing-library/react';
 import React, { createRef } from 'react';
-import { LocationTree, ObjectivProvider, TrackedExpandableContext, usePressEventTracker } from '../src';
+import { LocationTree, ObjectivProvider, ReactTracker, TrackedExpandableContext, usePressEventTracker } from '../src';
 
 const TrackedButton = () => {
   const trackPressEvent = usePressEventTracker();
@@ -26,7 +25,7 @@ describe('TrackedExpandableContext', () => {
   it('should wrap the given Component in an ExpandableContext', () => {
     const spyTransport = new SpyTransport();
     jest.spyOn(spyTransport, 'handle');
-    const tracker = new Tracker({ applicationId: 'app-id', transport: spyTransport });
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: spyTransport });
 
     const { container } = render(
       <ObjectivProvider tracker={tracker}>
@@ -49,12 +48,12 @@ describe('TrackedExpandableContext', () => {
       2,
       expect.objectContaining({
         _type: 'PressEvent',
-        location_stack: [
+        location_stack: expect.arrayContaining([
           expect.objectContaining({
             _type: 'ExpandableContext',
             id: 'expandable-id',
           }),
-        ],
+        ]),
       })
     );
   });
@@ -62,7 +61,7 @@ describe('TrackedExpandableContext', () => {
   it('should not track an HiddenEvent when initialized with isVisible=false', () => {
     const spyTransport = new SpyTransport();
     jest.spyOn(spyTransport, 'handle');
-    const tracker = new Tracker({ applicationId: 'app-id', transport: spyTransport });
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: spyTransport });
 
     render(
       <ObjectivProvider tracker={tracker}>
@@ -82,7 +81,7 @@ describe('TrackedExpandableContext', () => {
   it('should track an VisibleEvent when isVisible switches from false to true and vice-versa a HiddenEvent', () => {
     const spyTransport = new SpyTransport();
     jest.spyOn(spyTransport, 'handle');
-    const tracker = new Tracker({ applicationId: 'app-id', transport: spyTransport });
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: spyTransport });
 
     const { rerender } = render(
       <ObjectivProvider tracker={tracker}>
@@ -134,7 +133,7 @@ describe('TrackedExpandableContext', () => {
   });
 
   it('should allow forwarding the id property', () => {
-    const tracker = new Tracker({ applicationId: 'app-id' });
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: new SpyTransport() });
 
     render(
       <ObjectivProvider tracker={tracker}>
@@ -157,7 +156,7 @@ describe('TrackedExpandableContext', () => {
   });
 
   it('should allow forwarding refs', () => {
-    const tracker = new Tracker({ applicationId: 'app-id' });
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: new SpyTransport() });
     const ref = createRef<HTMLDivElement>();
 
     render(

--- a/tracker/trackers/react/tests/TrackedFooter.test.tsx
+++ b/tracker/trackers/react/tests/TrackedFooter.test.tsx
@@ -3,10 +3,9 @@
  */
 
 import { SpyTransport } from '@objectiv/testing-tools';
-import { Tracker } from '@objectiv/tracker-core';
 import { fireEvent, getByText, render } from '@testing-library/react';
 import React from 'react';
-import { LocationTree, ObjectivProvider, TrackedFooter, usePressEventTracker } from '../src';
+import { LocationTree, ObjectivProvider, ReactTracker, TrackedFooter, usePressEventTracker } from '../src';
 
 describe('TrackedFooter', () => {
   beforeEach(() => {
@@ -21,7 +20,7 @@ describe('TrackedFooter', () => {
   it('should wrap the given Component in a NavigationContext', () => {
     const spyTransport = new SpyTransport();
     jest.spyOn(spyTransport, 'handle');
-    const tracker = new Tracker({ applicationId: 'app-id', transport: spyTransport });
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: spyTransport });
 
     const TrackedButton = () => {
       const trackPressEvent = usePressEventTracker();
@@ -44,12 +43,12 @@ describe('TrackedFooter', () => {
     expect(spyTransport.handle).toHaveBeenCalledWith(
       expect.objectContaining({
         _type: 'PressEvent',
-        location_stack: [
+        location_stack: expect.arrayContaining([
           expect.objectContaining({
             _type: 'NavigationContext',
             id: 'footer',
           }),
-        ],
+        ]),
       })
     );
   });
@@ -57,7 +56,7 @@ describe('TrackedFooter', () => {
   it('should allow specifying a custom id', () => {
     const spyTransport = new SpyTransport();
     jest.spyOn(spyTransport, 'handle');
-    const tracker = new Tracker({ applicationId: 'app-id', transport: spyTransport });
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: spyTransport });
 
     const TrackedButton = () => {
       const trackPressEvent = usePressEventTracker();
@@ -80,12 +79,12 @@ describe('TrackedFooter', () => {
     expect(spyTransport.handle).toHaveBeenCalledWith(
       expect.objectContaining({
         _type: 'PressEvent',
-        location_stack: [
+        location_stack: expect.arrayContaining([
           expect.objectContaining({
             _type: 'NavigationContext',
             id: 'secondary-footer',
           }),
-        ],
+        ]),
       })
     );
   });

--- a/tracker/trackers/react/tests/TrackedHeader.test.tsx
+++ b/tracker/trackers/react/tests/TrackedHeader.test.tsx
@@ -3,10 +3,9 @@
  */
 
 import { SpyTransport } from '@objectiv/testing-tools';
-import { Tracker } from '@objectiv/tracker-core';
 import { fireEvent, getByText, render } from '@testing-library/react';
 import React from 'react';
-import { LocationTree, ObjectivProvider, TrackedHeader, usePressEventTracker } from '../src';
+import { LocationTree, ObjectivProvider, ReactTracker, TrackedHeader, usePressEventTracker } from '../src';
 
 describe('TrackedHeader', () => {
   beforeEach(() => {
@@ -21,7 +20,7 @@ describe('TrackedHeader', () => {
   it('should wrap the given Component in a NavigationContext', () => {
     const spyTransport = new SpyTransport();
     jest.spyOn(spyTransport, 'handle');
-    const tracker = new Tracker({ applicationId: 'app-id', transport: spyTransport });
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: spyTransport });
 
     const TrackedButton = () => {
       const trackPressEvent = usePressEventTracker();
@@ -44,12 +43,12 @@ describe('TrackedHeader', () => {
     expect(spyTransport.handle).toHaveBeenCalledWith(
       expect.objectContaining({
         _type: 'PressEvent',
-        location_stack: [
+        location_stack: expect.arrayContaining([
           expect.objectContaining({
             _type: 'NavigationContext',
             id: 'header',
           }),
-        ],
+        ]),
       })
     );
   });
@@ -57,7 +56,7 @@ describe('TrackedHeader', () => {
   it('should allow specifying a custom id', () => {
     const spyTransport = new SpyTransport();
     jest.spyOn(spyTransport, 'handle');
-    const tracker = new Tracker({ applicationId: 'app-id', transport: spyTransport });
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: spyTransport });
 
     const TrackedButton = () => {
       const trackPressEvent = usePressEventTracker();
@@ -80,12 +79,12 @@ describe('TrackedHeader', () => {
     expect(spyTransport.handle).toHaveBeenCalledWith(
       expect.objectContaining({
         _type: 'PressEvent',
-        location_stack: [
+        location_stack: expect.arrayContaining([
           expect.objectContaining({
             _type: 'NavigationContext',
             id: 'secondary-header',
           }),
-        ],
+        ]),
       })
     );
   });

--- a/tracker/trackers/react/tests/TrackedInput.test.tsx
+++ b/tracker/trackers/react/tests/TrackedInput.test.tsx
@@ -3,10 +3,9 @@
  */
 
 import { SpyTransport } from '@objectiv/testing-tools';
-import { Tracker } from '@objectiv/tracker-core';
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
-import { LocationTree, ObjectivProvider, TrackedInput } from '../src';
+import { LocationTree, ObjectivProvider, ReactTracker, TrackedInput } from '../src';
 
 describe('TrackedInputContext', () => {
   beforeEach(() => {
@@ -21,7 +20,7 @@ describe('TrackedInputContext', () => {
   it('should wrap the given Component in an InputContext', () => {
     const spyTransport = new SpyTransport();
     jest.spyOn(spyTransport, 'handle');
-    const tracker = new Tracker({ applicationId: 'app-id', transport: spyTransport });
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: spyTransport });
 
     render(
       <ObjectivProvider tracker={tracker}>
@@ -37,12 +36,12 @@ describe('TrackedInputContext', () => {
     expect(spyTransport.handle).toHaveBeenCalledWith(
       expect.objectContaining({
         _type: 'InputChangeEvent',
-        location_stack: [
+        location_stack: expect.arrayContaining([
           expect.objectContaining({
             _type: 'InputContext',
             id: 'input-id',
           }),
-        ],
+        ]),
       })
     );
   });

--- a/tracker/trackers/react/tests/TrackedInputContext.test.tsx
+++ b/tracker/trackers/react/tests/TrackedInputContext.test.tsx
@@ -3,10 +3,9 @@
  */
 
 import { SpyTransport } from '@objectiv/testing-tools';
-import { Tracker } from '@objectiv/tracker-core';
 import { fireEvent, render, screen } from '@testing-library/react';
 import React, { createRef } from 'react';
-import { LocationTree, ObjectivProvider, TrackedInputContext } from '../src';
+import { LocationTree, ObjectivProvider, ReactTracker, TrackedInputContext } from '../src';
 
 describe('TrackedInputContext', () => {
   beforeEach(() => {
@@ -21,7 +20,7 @@ describe('TrackedInputContext', () => {
   it('should wrap the given Component in an InputContext and not trigger InputChangeEvent on mount', () => {
     const spyTransport = new SpyTransport();
     jest.spyOn(spyTransport, 'handle');
-    const tracker = new Tracker({ applicationId: 'app-id', transport: spyTransport });
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: spyTransport });
 
     render(
       <ObjectivProvider tracker={tracker}>
@@ -43,7 +42,7 @@ describe('TrackedInputContext', () => {
   it('should not track an InputChangeEvent when value did not change from the previous InputChangeEvent', () => {
     const spyTransport = new SpyTransport();
     jest.spyOn(spyTransport, 'handle');
-    const tracker = new Tracker({ applicationId: 'app-id', transport: spyTransport });
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: spyTransport });
 
     render(
       <ObjectivProvider tracker={tracker}>
@@ -71,7 +70,7 @@ describe('TrackedInputContext', () => {
   it('should track an InputChangeEvent when value changed from the previous InputChangeEvent', () => {
     const spyTransport = new SpyTransport();
     jest.spyOn(spyTransport, 'handle');
-    const tracker = new Tracker({ applicationId: 'app-id', transport: spyTransport });
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: spyTransport });
 
     render(
       <ObjectivProvider tracker={tracker}>
@@ -90,18 +89,18 @@ describe('TrackedInputContext', () => {
     expect(spyTransport.handle).toHaveBeenCalledWith(
       expect.objectContaining({
         _type: 'InputChangeEvent',
-        location_stack: [
+        location_stack: expect.arrayContaining([
           expect.objectContaining({
             _type: 'InputContext',
             id: 'input-id',
           }),
-        ],
+        ]),
       })
     );
   });
 
   it('should allow forwarding the id property', () => {
-    const tracker = new Tracker({ applicationId: 'app-id' });
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: new SpyTransport() });
 
     render(
       <ObjectivProvider tracker={tracker}>
@@ -128,7 +127,7 @@ describe('TrackedInputContext', () => {
   });
 
   it('should allow forwarding refs', () => {
-    const tracker = new Tracker({ applicationId: 'app-id' });
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: new SpyTransport() });
     const ref = createRef<HTMLInputElement>();
 
     render(
@@ -147,7 +146,7 @@ describe('TrackedInputContext', () => {
 
   it('should execute the given onBlur as well', () => {
     const blurSpy = jest.fn();
-    const tracker = new Tracker({ applicationId: 'app-id' });
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: new SpyTransport() });
 
     render(
       <ObjectivProvider tracker={tracker}>

--- a/tracker/trackers/react/tests/TrackedLinkContext.test.tsx
+++ b/tracker/trackers/react/tests/TrackedLinkContext.test.tsx
@@ -116,10 +116,10 @@ describe('TrackedLinkContext', () => {
     render(
       <ObjectivProvider tracker={tracker}>
         <TrackedLinkContext Component={'a'} href={'/some-url'} data-testid={'test-link-1'}>
-          test
+          test 1
         </TrackedLinkContext>
         <TrackedLinkContext Component={'a'} href={'/some-url'} forwardHref={true} data-testid={'test-link-2'}>
-          test
+          test 2
         </TrackedLinkContext>
       </ObjectivProvider>
     );

--- a/tracker/trackers/react/tests/TrackedLinkContext.test.tsx
+++ b/tracker/trackers/react/tests/TrackedLinkContext.test.tsx
@@ -5,7 +5,14 @@
 import { SpyTransport } from '@objectiv/testing-tools';
 import { fireEvent, getByText, render, screen, waitFor } from '@testing-library/react';
 import React, { createRef } from 'react';
-import { LocationTree, ObjectivProvider, ReactTracker, TrackedLinkContext } from '../src';
+import {
+  LocationTree,
+  ObjectivProvider,
+  ReactTracker,
+  TrackedDiv,
+  TrackedLinkContext,
+  TrackedRootLocationContext,
+} from '../src';
 
 describe('TrackedLinkContext', () => {
   beforeEach(() => {
@@ -76,6 +83,28 @@ describe('TrackedLinkContext', () => {
 
     expect(screen.getByTestId('test-link-1').getAttribute('id')).toBe(null);
     expect(screen.getByTestId('test-link-2').getAttribute('id')).toBe('link-id-2');
+  });
+
+  it('should console.error if an id cannot be automatically generated', () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: new SpyTransport() });
+
+    render(
+      <ObjectivProvider tracker={tracker}>
+        <TrackedRootLocationContext Component={'div'} id={'root'}>
+          <TrackedDiv id={'content'}>
+            <TrackedLinkContext Component={'a'} href={'/some-url'}>
+              {/* nothing to see here */}
+            </TrackedLinkContext>
+          </TrackedDiv>
+        </TrackedRootLocationContext>
+      </ObjectivProvider>
+    );
+
+    expect(console.error).toHaveBeenCalledTimes(1);
+    expect(console.error).toHaveBeenCalledWith(
+      '｢objectiv｣ Could not generate a valid id for LinkContext @ RootLocation:root / Content:content. Please provide either the `title` or the `id` property manually.'
+    );
   });
 
   it('should allow forwarding the title property', () => {

--- a/tracker/trackers/react/tests/TrackedLinkContext.test.tsx
+++ b/tracker/trackers/react/tests/TrackedLinkContext.test.tsx
@@ -3,10 +3,9 @@
  */
 
 import { SpyTransport } from '@objectiv/testing-tools';
-import { Tracker } from '@objectiv/tracker-core';
 import { fireEvent, getByText, render, screen, waitFor } from '@testing-library/react';
 import React, { createRef } from 'react';
-import { LocationTree, ObjectivProvider, TrackedLinkContext } from '../src';
+import { LocationTree, ObjectivProvider, ReactTracker, TrackedLinkContext } from '../src';
 
 describe('TrackedLinkContext', () => {
   beforeEach(() => {
@@ -22,7 +21,7 @@ describe('TrackedLinkContext', () => {
   it('should wrap the given Component in a LinkContext', () => {
     const spyTransport = new SpyTransport();
     jest.spyOn(spyTransport, 'handle');
-    const tracker = new Tracker({ applicationId: 'app-id', transport: spyTransport });
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: spyTransport });
 
     const { container } = render(
       <ObjectivProvider tracker={tracker}>
@@ -45,18 +44,18 @@ describe('TrackedLinkContext', () => {
       2,
       expect.objectContaining({
         _type: 'PressEvent',
-        location_stack: [
+        location_stack: expect.arrayContaining([
           expect.objectContaining({
             _type: 'LinkContext',
             id: 'link-id',
           }),
-        ],
+        ]),
       })
     );
   });
 
   it('should allow forwarding the id property', () => {
-    const tracker = new Tracker({ applicationId: 'app-id' });
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: new SpyTransport() });
 
     render(
       <ObjectivProvider tracker={tracker}>
@@ -80,7 +79,7 @@ describe('TrackedLinkContext', () => {
   });
 
   it('should allow forwarding the title property', () => {
-    const tracker = new Tracker({ applicationId: 'app-id' });
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: new SpyTransport() });
 
     render(
       <ObjectivProvider tracker={tracker}>
@@ -111,7 +110,7 @@ describe('TrackedLinkContext', () => {
   });
 
   it('should allow forwarding the href property', () => {
-    const tracker = new Tracker({ applicationId: 'app-id' });
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: new SpyTransport() });
 
     render(
       <ObjectivProvider tracker={tracker}>
@@ -129,7 +128,7 @@ describe('TrackedLinkContext', () => {
   });
 
   it('should allow forwarding refs', () => {
-    const tracker = new Tracker({ applicationId: 'app-id' });
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: new SpyTransport() });
     const ref = createRef<HTMLDivElement>();
 
     render(
@@ -149,7 +148,7 @@ describe('TrackedLinkContext', () => {
 
   it('should execute the given onClick as well', async () => {
     const clickSpy = jest.fn();
-    const tracker = new Tracker({ applicationId: 'app-id' });
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: new SpyTransport() });
 
     const { container } = render(
       <ObjectivProvider tracker={tracker}>
@@ -170,7 +169,7 @@ describe('TrackedLinkContext', () => {
     const spyTransport = new SpyTransport();
     const handleMock = jest.fn(async () => new Promise((resolve) => setTimeout(resolve, 10000)));
     jest.spyOn(spyTransport, 'handle').mockImplementation(handleMock);
-    const tracker = new Tracker({ applicationId: 'app-id', transport: spyTransport });
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: spyTransport });
 
     const { container } = render(
       <ObjectivProvider tracker={tracker}>
@@ -196,7 +195,7 @@ describe('TrackedLinkContext', () => {
     jest
       .spyOn(spyTransport, 'handle')
       .mockImplementation(async () => new Promise((resolve) => setTimeout(resolve, 100)));
-    const tracker = new Tracker({ applicationId: 'app-id', transport: spyTransport });
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: spyTransport });
 
     const { container } = render(
       <ObjectivProvider tracker={tracker}>
@@ -217,12 +216,12 @@ describe('TrackedLinkContext', () => {
       1,
       expect.objectContaining({
         _type: 'PressEvent',
-        location_stack: [
+        location_stack: expect.arrayContaining([
           expect.objectContaining({
             _type: 'LinkContext',
             id: 'press-me',
           }),
-        ],
+        ]),
       })
     );
   });

--- a/tracker/trackers/react/tests/TrackedMain.test.tsx
+++ b/tracker/trackers/react/tests/TrackedMain.test.tsx
@@ -3,10 +3,9 @@
  */
 
 import { SpyTransport } from '@objectiv/testing-tools';
-import { Tracker } from '@objectiv/tracker-core';
 import { fireEvent, getByText, render } from '@testing-library/react';
 import React from 'react';
-import { LocationTree, ObjectivProvider, TrackedMain, usePressEventTracker } from '../src';
+import { LocationTree, ObjectivProvider, ReactTracker, TrackedMain, usePressEventTracker } from '../src';
 
 describe('TrackedMain', () => {
   beforeEach(() => {
@@ -21,7 +20,7 @@ describe('TrackedMain', () => {
   it('should wrap the given Component in a ContentContext', () => {
     const spyTransport = new SpyTransport();
     jest.spyOn(spyTransport, 'handle');
-    const tracker = new Tracker({ applicationId: 'app-id', transport: spyTransport });
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: spyTransport });
 
     const TrackedButton = () => {
       const trackPressEvent = usePressEventTracker();
@@ -44,12 +43,12 @@ describe('TrackedMain', () => {
     expect(spyTransport.handle).toHaveBeenCalledWith(
       expect.objectContaining({
         _type: 'PressEvent',
-        location_stack: [
+        location_stack: expect.arrayContaining([
           expect.objectContaining({
             _type: 'ContentContext',
             id: 'main',
           }),
-        ],
+        ]),
       })
     );
   });
@@ -57,7 +56,7 @@ describe('TrackedMain', () => {
   it('should allow specifying a custom id', () => {
     const spyTransport = new SpyTransport();
     jest.spyOn(spyTransport, 'handle');
-    const tracker = new Tracker({ applicationId: 'app-id', transport: spyTransport });
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: spyTransport });
 
     const TrackedButton = () => {
       const trackPressEvent = usePressEventTracker();
@@ -80,12 +79,12 @@ describe('TrackedMain', () => {
     expect(spyTransport.handle).toHaveBeenCalledWith(
       expect.objectContaining({
         _type: 'PressEvent',
-        location_stack: [
+        location_stack: expect.arrayContaining([
           expect.objectContaining({
             _type: 'ContentContext',
             id: 'hero-element',
           }),
-        ],
+        ]),
       })
     );
   });

--- a/tracker/trackers/react/tests/TrackedMediaPlayerContext.test.tsx
+++ b/tracker/trackers/react/tests/TrackedMediaPlayerContext.test.tsx
@@ -3,10 +3,9 @@
  */
 
 import { SpyTransport } from '@objectiv/testing-tools';
-import { Tracker } from '@objectiv/tracker-core';
 import { fireEvent, getByText, render, screen } from '@testing-library/react';
 import React, { createRef } from 'react';
-import { LocationTree, ObjectivProvider, TrackedMediaPlayerContext, usePressEventTracker } from '../src';
+import { LocationTree, ObjectivProvider, ReactTracker, TrackedMediaPlayerContext, usePressEventTracker } from '../src';
 
 describe('TrackedMediaPlayerContext', () => {
   beforeEach(() => {
@@ -21,7 +20,7 @@ describe('TrackedMediaPlayerContext', () => {
   it('should wrap the given Component in a MediaPlayerContext', () => {
     const spyTransport = new SpyTransport();
     jest.spyOn(spyTransport, 'handle');
-    const tracker = new Tracker({ applicationId: 'app-id', transport: spyTransport });
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: spyTransport });
 
     const TrackedButton = () => {
       const trackPressEvent = usePressEventTracker();
@@ -49,18 +48,18 @@ describe('TrackedMediaPlayerContext', () => {
       2,
       expect.objectContaining({
         _type: 'PressEvent',
-        location_stack: [
+        location_stack: expect.arrayContaining([
           expect.objectContaining({
             _type: 'MediaPlayerContext',
             id: 'video-id',
           }),
-        ],
+        ]),
       })
     );
   });
 
   it('should allow forwarding the id property', () => {
-    const tracker = new Tracker({ applicationId: 'app-id' });
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: new SpyTransport() });
 
     render(
       <ObjectivProvider tracker={tracker}>
@@ -78,7 +77,7 @@ describe('TrackedMediaPlayerContext', () => {
   });
 
   it('should allow forwarding refs', () => {
-    const tracker = new Tracker({ applicationId: 'app-id' });
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: new SpyTransport() });
     const ref = createRef<HTMLDivElement>();
 
     render(

--- a/tracker/trackers/react/tests/TrackedNav.test.tsx
+++ b/tracker/trackers/react/tests/TrackedNav.test.tsx
@@ -3,10 +3,9 @@
  */
 
 import { SpyTransport } from '@objectiv/testing-tools';
-import { Tracker } from '@objectiv/tracker-core';
 import { fireEvent, getByText, render } from '@testing-library/react';
 import React from 'react';
-import { LocationTree, ObjectivProvider, TrackedNav, usePressEventTracker } from '../src';
+import { LocationTree, ObjectivProvider, ReactTracker, TrackedNav, usePressEventTracker } from '../src';
 
 describe('TrackedNav', () => {
   beforeEach(() => {
@@ -21,7 +20,7 @@ describe('TrackedNav', () => {
   it('should wrap the given Component in a NavigationContext', () => {
     const spyTransport = new SpyTransport();
     jest.spyOn(spyTransport, 'handle');
-    const tracker = new Tracker({ applicationId: 'app-id', transport: spyTransport });
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: spyTransport });
 
     const TrackedButton = () => {
       const trackPressEvent = usePressEventTracker();
@@ -44,12 +43,12 @@ describe('TrackedNav', () => {
     expect(spyTransport.handle).toHaveBeenCalledWith(
       expect.objectContaining({
         _type: 'PressEvent',
-        location_stack: [
+        location_stack: expect.arrayContaining([
           expect.objectContaining({
             _type: 'NavigationContext',
             id: 'nav',
           }),
-        ],
+        ]),
       })
     );
   });
@@ -57,7 +56,7 @@ describe('TrackedNav', () => {
   it('should allow specifying a custom id', () => {
     const spyTransport = new SpyTransport();
     jest.spyOn(spyTransport, 'handle');
-    const tracker = new Tracker({ applicationId: 'app-id', transport: spyTransport });
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: spyTransport });
 
     const TrackedButton = () => {
       const trackPressEvent = usePressEventTracker();
@@ -80,12 +79,12 @@ describe('TrackedNav', () => {
     expect(spyTransport.handle).toHaveBeenCalledWith(
       expect.objectContaining({
         _type: 'PressEvent',
-        location_stack: [
+        location_stack: expect.arrayContaining([
           expect.objectContaining({
             _type: 'NavigationContext',
             id: 'sidebar-nav',
           }),
-        ],
+        ]),
       })
     );
   });

--- a/tracker/trackers/react/tests/TrackedNavigationContext.test.tsx
+++ b/tracker/trackers/react/tests/TrackedNavigationContext.test.tsx
@@ -3,10 +3,9 @@
  */
 
 import { SpyTransport } from '@objectiv/testing-tools';
-import { Tracker } from '@objectiv/tracker-core';
 import { fireEvent, getByText, render, screen } from '@testing-library/react';
 import React, { createRef } from 'react';
-import { LocationTree, ObjectivProvider, TrackedNavigationContext, usePressEventTracker } from '../src';
+import { LocationTree, ObjectivProvider, ReactTracker, TrackedNavigationContext, usePressEventTracker } from '../src';
 
 describe('TrackedNavigationContext', () => {
   beforeEach(() => {
@@ -21,7 +20,7 @@ describe('TrackedNavigationContext', () => {
   it('should wrap the given Component in a NavigationContext', () => {
     const spyTransport = new SpyTransport();
     jest.spyOn(spyTransport, 'handle');
-    const tracker = new Tracker({ applicationId: 'app-id', transport: spyTransport });
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: spyTransport });
 
     const TrackedButton = () => {
       const trackPressEvent = usePressEventTracker();
@@ -49,18 +48,18 @@ describe('TrackedNavigationContext', () => {
       2,
       expect.objectContaining({
         _type: 'PressEvent',
-        location_stack: [
+        location_stack: expect.arrayContaining([
           expect.objectContaining({
             _type: 'NavigationContext',
             id: 'nav-id',
           }),
-        ],
+        ]),
       })
     );
   });
 
   it('should allow forwarding the id property', () => {
-    const tracker = new Tracker({ applicationId: 'app-id' });
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: new SpyTransport() });
 
     render(
       <ObjectivProvider tracker={tracker}>
@@ -78,7 +77,7 @@ describe('TrackedNavigationContext', () => {
   });
 
   it('should allow forwarding refs', () => {
-    const tracker = new Tracker({ applicationId: 'app-id' });
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: new SpyTransport() });
     const ref = createRef<HTMLDivElement>();
 
     render(

--- a/tracker/trackers/react/tests/TrackedOverlayContext.test.tsx
+++ b/tracker/trackers/react/tests/TrackedOverlayContext.test.tsx
@@ -3,10 +3,9 @@
  */
 
 import { SpyTransport } from '@objectiv/testing-tools';
-import { Tracker } from '@objectiv/tracker-core';
 import { fireEvent, getByText, render, screen } from '@testing-library/react';
 import React, { createRef } from 'react';
-import { LocationTree, ObjectivProvider, TrackedOverlayContext, usePressEventTracker } from '../src';
+import { LocationTree, ObjectivProvider, ReactTracker, TrackedOverlayContext, usePressEventTracker } from '../src';
 
 const TrackedButton = () => {
   const trackPressEvent = usePressEventTracker();
@@ -26,7 +25,7 @@ describe('TrackedOverlayContext', () => {
   it('should wrap the given Component in an OverlayContext', () => {
     const spyTransport = new SpyTransport();
     jest.spyOn(spyTransport, 'handle');
-    const tracker = new Tracker({ applicationId: 'app-id', transport: spyTransport });
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: spyTransport });
 
     const { container } = render(
       <ObjectivProvider tracker={tracker}>
@@ -49,12 +48,12 @@ describe('TrackedOverlayContext', () => {
       2,
       expect.objectContaining({
         _type: 'PressEvent',
-        location_stack: [
+        location_stack: expect.arrayContaining([
           expect.objectContaining({
             _type: 'OverlayContext',
             id: 'modal-id',
           }),
-        ],
+        ]),
       })
     );
   });
@@ -62,7 +61,7 @@ describe('TrackedOverlayContext', () => {
   it('should not track an HiddenEvent when initialized with isVisible=false', () => {
     const spyTransport = new SpyTransport();
     jest.spyOn(spyTransport, 'handle');
-    const tracker = new Tracker({ applicationId: 'app-id', transport: spyTransport });
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: spyTransport });
 
     render(
       <ObjectivProvider tracker={tracker}>
@@ -82,7 +81,7 @@ describe('TrackedOverlayContext', () => {
   it('should track an VisibleEvent when isVisible switches from false to true and vice-versa a HiddenEvent', () => {
     const spyTransport = new SpyTransport();
     jest.spyOn(spyTransport, 'handle');
-    const tracker = new Tracker({ applicationId: 'app-id', transport: spyTransport });
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: spyTransport });
 
     const { rerender } = render(
       <ObjectivProvider tracker={tracker}>
@@ -134,7 +133,7 @@ describe('TrackedOverlayContext', () => {
   });
 
   it('should allow forwarding the id property', () => {
-    const tracker = new Tracker({ applicationId: 'app-id' });
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: new SpyTransport() });
 
     render(
       <ObjectivProvider tracker={tracker}>
@@ -152,7 +151,7 @@ describe('TrackedOverlayContext', () => {
   });
 
   it('should allow forwarding refs', () => {
-    const tracker = new Tracker({ applicationId: 'app-id' });
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: new SpyTransport() });
     const ref = createRef<HTMLDivElement>();
 
     render(

--- a/tracker/trackers/react/tests/TrackedPressableContext.test.tsx
+++ b/tracker/trackers/react/tests/TrackedPressableContext.test.tsx
@@ -5,7 +5,14 @@
 import { SpyTransport } from '@objectiv/testing-tools';
 import { fireEvent, getByText, render, screen, waitFor } from '@testing-library/react';
 import React, { createRef } from 'react';
-import { LocationTree, ObjectivProvider, ReactTracker, TrackedPressableContext } from '../src';
+import {
+  LocationTree,
+  ObjectivProvider,
+  ReactTracker,
+  TrackedDiv,
+  TrackedPressableContext,
+  TrackedRootLocationContext,
+} from '../src';
 
 describe('TrackedPressableContext', () => {
   beforeEach(() => {
@@ -75,6 +82,26 @@ describe('TrackedPressableContext', () => {
 
     expect(screen.getByTestId('test-pressable-1').getAttribute('id')).toBe(null);
     expect(screen.getByTestId('test-pressable-2').getAttribute('id')).toBe('pressable-id-2');
+  });
+
+  it('should console.error if an id cannot be automatically generated', () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: new SpyTransport() });
+
+    render(
+      <ObjectivProvider tracker={tracker}>
+        <TrackedRootLocationContext Component={'div'} id={'root'}>
+          <TrackedDiv id={'content'}>
+            <TrackedPressableContext Component={'button'}>{/* nothing to see here */}</TrackedPressableContext>
+          </TrackedDiv>
+        </TrackedRootLocationContext>
+      </ObjectivProvider>
+    );
+
+    expect(console.error).toHaveBeenCalledTimes(1);
+    expect(console.error).toHaveBeenCalledWith(
+      '｢objectiv｣ Could not generate a valid id for PressableContext @ RootLocation:root / Content:content. Please provide either the `title` or the `id` property manually.'
+    );
   });
 
   it('should allow forwarding the title property', () => {

--- a/tracker/trackers/react/tests/TrackedPressableContext.test.tsx
+++ b/tracker/trackers/react/tests/TrackedPressableContext.test.tsx
@@ -3,10 +3,9 @@
  */
 
 import { SpyTransport } from '@objectiv/testing-tools';
-import { Tracker } from '@objectiv/tracker-core';
 import { fireEvent, getByText, render, screen, waitFor } from '@testing-library/react';
 import React, { createRef } from 'react';
-import { LocationTree, ObjectivProvider, TrackedPressableContext } from '../src';
+import { LocationTree, ObjectivProvider, ReactTracker, TrackedPressableContext } from '../src';
 
 describe('TrackedPressableContext', () => {
   beforeEach(() => {
@@ -22,7 +21,7 @@ describe('TrackedPressableContext', () => {
   it('should wrap the given Component in a PressableContext', () => {
     const spyTransport = new SpyTransport();
     jest.spyOn(spyTransport, 'handle');
-    const tracker = new Tracker({ applicationId: 'app-id', transport: spyTransport });
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: spyTransport });
 
     const { container } = render(
       <ObjectivProvider tracker={tracker}>
@@ -45,18 +44,18 @@ describe('TrackedPressableContext', () => {
       2,
       expect.objectContaining({
         _type: 'PressEvent',
-        location_stack: [
+        location_stack: expect.arrayContaining([
           expect.objectContaining({
             _type: 'PressableContext',
             id: 'pressable-id',
           }),
-        ],
+        ]),
       })
     );
   });
 
   it('should allow forwarding the id property', () => {
-    const tracker = new Tracker({ applicationId: 'app-id' });
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: new SpyTransport() });
 
     render(
       <ObjectivProvider tracker={tracker}>
@@ -79,7 +78,7 @@ describe('TrackedPressableContext', () => {
   });
 
   it('should allow forwarding the title property', () => {
-    const tracker = new Tracker({ applicationId: 'app-id' });
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: new SpyTransport() });
 
     render(
       <ObjectivProvider tracker={tracker}>
@@ -108,7 +107,7 @@ describe('TrackedPressableContext', () => {
   });
 
   it('should allow forwarding refs', () => {
-    const tracker = new Tracker({ applicationId: 'app-id' });
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: new SpyTransport() });
     const ref = createRef<HTMLDivElement>();
 
     render(
@@ -128,7 +127,7 @@ describe('TrackedPressableContext', () => {
 
   it('should execute the given onClick as well', async () => {
     const clickSpy = jest.fn();
-    const tracker = new Tracker({ applicationId: 'app-id' });
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: new SpyTransport() });
 
     const { container } = render(
       <ObjectivProvider tracker={tracker}>
@@ -149,7 +148,7 @@ describe('TrackedPressableContext', () => {
     const spyTransport = new SpyTransport();
     const handleMock = jest.fn(async () => new Promise((resolve) => setTimeout(resolve, 10000)));
     jest.spyOn(spyTransport, 'handle').mockImplementation(handleMock);
-    const tracker = new Tracker({ applicationId: 'app-id', transport: spyTransport });
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: spyTransport });
 
     const { container } = render(
       <ObjectivProvider tracker={tracker}>
@@ -175,7 +174,7 @@ describe('TrackedPressableContext', () => {
     jest
       .spyOn(spyTransport, 'handle')
       .mockImplementation(async () => new Promise((resolve) => setTimeout(resolve, 100)));
-    const tracker = new Tracker({ applicationId: 'app-id', transport: spyTransport });
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: spyTransport });
 
     const { container } = render(
       <ObjectivProvider tracker={tracker}>
@@ -196,12 +195,12 @@ describe('TrackedPressableContext', () => {
       1,
       expect.objectContaining({
         _type: 'PressEvent',
-        location_stack: [
+        location_stack: expect.arrayContaining([
           expect.objectContaining({
             _type: 'PressableContext',
             id: 'press-me',
           }),
-        ],
+        ]),
       })
     );
   });

--- a/tracker/trackers/react/tests/TrackedRootLocationContext.test.tsx
+++ b/tracker/trackers/react/tests/TrackedRootLocationContext.test.tsx
@@ -3,10 +3,9 @@
  */
 
 import { SpyTransport } from '@objectiv/testing-tools';
-import { Tracker } from '@objectiv/tracker-core';
 import { fireEvent, getByText, render, screen } from '@testing-library/react';
 import React, { createRef } from 'react';
-import { LocationTree, ObjectivProvider, TrackedRootLocationContext, usePressEventTracker } from '../src';
+import { LocationTree, ObjectivProvider, ReactTracker, TrackedRootLocationContext, usePressEventTracker } from '../src';
 
 describe('TrackedRootLocationContext', () => {
   beforeEach(() => {
@@ -21,7 +20,7 @@ describe('TrackedRootLocationContext', () => {
   it('should wrap the given Component in a RootLocationContext', () => {
     const spyTransport = new SpyTransport();
     jest.spyOn(spyTransport, 'handle');
-    const tracker = new Tracker({ applicationId: 'app-id', transport: spyTransport });
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: spyTransport });
 
     const TrackedButton = () => {
       const trackPressEvent = usePressEventTracker();
@@ -49,18 +48,18 @@ describe('TrackedRootLocationContext', () => {
       2,
       expect.objectContaining({
         _type: 'PressEvent',
-        location_stack: [
+        location_stack: expect.arrayContaining([
           expect.objectContaining({
             _type: 'RootLocationContext',
             id: 'root-id',
           }),
-        ],
+        ]),
       })
     );
   });
 
   it('should allow forwarding the id property', () => {
-    const tracker = new Tracker({ applicationId: 'app-id' });
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: new SpyTransport() });
 
     render(
       <ObjectivProvider tracker={tracker}>
@@ -78,7 +77,7 @@ describe('TrackedRootLocationContext', () => {
   });
 
   it('should allow forwarding refs', () => {
-    const tracker = new Tracker({ applicationId: 'app-id' });
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: new SpyTransport() });
     const ref = createRef<HTMLDivElement>();
 
     render(

--- a/tracker/trackers/react/tests/TrackedSection.test.tsx
+++ b/tracker/trackers/react/tests/TrackedSection.test.tsx
@@ -3,10 +3,9 @@
  */
 
 import { SpyTransport } from '@objectiv/testing-tools';
-import { Tracker } from '@objectiv/tracker-core';
 import { fireEvent, getByText, render } from '@testing-library/react';
 import React from 'react';
-import { LocationTree, ObjectivProvider, TrackedSection, usePressEventTracker } from '../src';
+import { LocationTree, ObjectivProvider, ReactTracker, TrackedSection, usePressEventTracker } from '../src';
 
 describe('TrackedSection', () => {
   beforeEach(() => {
@@ -21,7 +20,7 @@ describe('TrackedSection', () => {
   it('should wrap the given Component in a ContentContext', () => {
     const spyTransport = new SpyTransport();
     jest.spyOn(spyTransport, 'handle');
-    const tracker = new Tracker({ applicationId: 'app-id', transport: spyTransport });
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: spyTransport });
 
     const TrackedButton = () => {
       const trackPressEvent = usePressEventTracker();
@@ -44,12 +43,12 @@ describe('TrackedSection', () => {
     expect(spyTransport.handle).toHaveBeenCalledWith(
       expect.objectContaining({
         _type: 'PressEvent',
-        location_stack: [
+        location_stack: expect.arrayContaining([
           expect.objectContaining({
             _type: 'ContentContext',
             id: 'section-id',
           }),
-        ],
+        ]),
       })
     );
   });

--- a/tracker/trackers/react/tests/makeIdFromString.test.ts
+++ b/tracker/trackers/react/tests/makeIdFromString.test.ts
@@ -5,7 +5,6 @@
 import { makeIdFromString } from '../src';
 
 describe('makeIdFromString', () => {
-  // setting output to `null` means expecting `makeIdFromString` to throw
   const testCases: [input: string, output: string | null][] = [
     // @ts-ignore
     [undefined, null],
@@ -37,12 +36,8 @@ describe('makeIdFromString', () => {
   ];
 
   testCases.forEach(([input, output]) =>
-    it(`'${JSON.stringify(input)}' -> '${output === null ? 'throw' : JSON.stringify(output)}'`, () => {
-      if (output === null) {
-        expect(() => makeIdFromString(input)).toThrow('Could not generated a valid id. Please provide one manually.');
-      } else {
-        expect(makeIdFromString(input)).toBe(output);
-      }
+    it(`${JSON.stringify(input)} -> ${JSON.stringify(output)}`, () => {
+      expect(makeIdFromString(input)).toBe(output);
     })
   );
 });

--- a/tracker/trackers/react/tests/makeTitleFromChildren.test.tsx
+++ b/tracker/trackers/react/tests/makeTitleFromChildren.test.tsx
@@ -7,16 +7,14 @@ import { ReactNode } from 'react';
 import { makeTitleFromChildren } from '../src';
 
 describe('makeTitleFromChildren', () => {
-  // setting output to `null` means expecting `makeTitleFromChildren` to throw
-  const testCases: [input: ReactNode, output: string | null][] = [
-    [undefined, null],
-    [null, null],
-    [false, null],
-    [true, null],
-    [[], null],
-    [{}, null],
-    ['', null],
-
+  const testCases: [input: ReactNode, output: string][] = [
+    [undefined, ''],
+    [null, ''],
+    [false, ''],
+    [true, ''],
+    [[], ''],
+    [{}, ''],
+    ['', ''],
     [0, '0'],
     [123, '123'],
     [456.12, '456.12'],
@@ -38,14 +36,8 @@ describe('makeTitleFromChildren', () => {
   ];
 
   testCases.forEach(([input, output]) =>
-    it(`'${JSON.stringify(input)}' -> '${output === null ? 'throw' : JSON.stringify(output)}'`, () => {
-      if (output === null) {
-        expect(() => makeTitleFromChildren(input)).toThrow(
-          'Could not infer a title from children nodes. Please provide one manually.'
-        );
-      } else {
-        expect(makeTitleFromChildren(input)).toBe(output);
-      }
+    it(`${JSON.stringify(input)} -> ${JSON.stringify(output)}`, () => {
+      expect(makeTitleFromChildren(input)).toBe(output);
     })
   );
 });

--- a/tracker/trackers/react/tests/useParentLocationContext.test.tsx
+++ b/tracker/trackers/react/tests/useParentLocationContext.test.tsx
@@ -5,12 +5,12 @@
 import { Tracker } from '@objectiv/tracker-core';
 import { render } from '@testing-library/react';
 import React from 'react';
-import { LocationContextWrapper, makeContentContext, ObjectivProvider, useParentLocationContext } from '../src/';
+import { ContentContextWrapper, ObjectivProvider, useParentLocationContext } from '../src/';
 
 describe('useParentLocationContext', () => {
   beforeEach(() => {
     jest.resetAllMocks();
-    jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'debug').mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -20,28 +20,25 @@ describe('useParentLocationContext', () => {
   it('should return the parent location context', () => {
     const tracker = new Tracker({ applicationId: 'app-id' });
 
-    const parentContext1 = makeContentContext({ id: 'parent-1' });
-    const parentContext2 = makeContentContext({ id: 'parent-2' });
-
     const TestChild = () => {
       const parentLocationContext = useParentLocationContext();
 
-      console.log(parentLocationContext);
+      console.debug(parentLocationContext);
 
       return <div>test child</div>;
     };
 
     render(
       <ObjectivProvider tracker={tracker}>
-        <LocationContextWrapper locationContext={parentContext1}>
-          <LocationContextWrapper locationContext={parentContext2}>
+        <ContentContextWrapper id={'parent-1'}>
+          <ContentContextWrapper id={'parent-2'}>
             <TestChild />
-          </LocationContextWrapper>
-        </LocationContextWrapper>
+          </ContentContextWrapper>
+        </ContentContextWrapper>
       </ObjectivProvider>
     );
 
-    expect(console.log).toHaveBeenCalledTimes(1);
-    expect(console.log).toHaveBeenNthCalledWith(1, expect.objectContaining(parentContext2));
+    expect(console.debug).toHaveBeenCalledTimes(1);
+    expect(console.debug).toHaveBeenNthCalledWith(1, expect.objectContaining({ id: 'parent-2' }));
   });
 });

--- a/tracker/trackers/react/tests/useParentLocationContext.test.tsx
+++ b/tracker/trackers/react/tests/useParentLocationContext.test.tsx
@@ -10,7 +10,7 @@ import { ContentContextWrapper, ObjectivProvider, useParentLocationContext } fro
 describe('useParentLocationContext', () => {
   beforeEach(() => {
     jest.resetAllMocks();
-    jest.spyOn(console, 'debug').mockImplementation(() => {});
+    jest.spyOn(console, 'log').mockImplementation(() => {});
   });
 
   afterEach(() => {
@@ -23,7 +23,7 @@ describe('useParentLocationContext', () => {
     const TestChild = () => {
       const parentLocationContext = useParentLocationContext();
 
-      console.debug(parentLocationContext);
+      console.log(parentLocationContext);
 
       return <div>test child</div>;
     };
@@ -38,7 +38,7 @@ describe('useParentLocationContext', () => {
       </ObjectivProvider>
     );
 
-    expect(console.debug).toHaveBeenCalledTimes(1);
-    expect(console.debug).toHaveBeenNthCalledWith(1, expect.objectContaining({ id: 'parent-2' }));
+    expect(console.log).toHaveBeenCalledTimes(1);
+    expect(console.log).toHaveBeenNthCalledWith(1, expect.objectContaining({ id: 'parent-2' }));
   });
 });

--- a/tracker/trackers/react/tests/withoutDOM.test.ts
+++ b/tracker/trackers/react/tests/withoutDOM.test.ts
@@ -6,7 +6,7 @@
 import { ReactTracker } from '../src';
 
 describe('Without DOM', () => {
-  it('should not instantiate LocalStorage but MemoryQueue instead', () => {
+  it('ReactTracker: should not instantiate LocalStorage but MemoryQueue instead', () => {
     expect(
       new ReactTracker({
         applicationId: 'app-id',


### PR DESCRIPTION
In this PR I've refactored the Validation module (LocationTree) to correctly function in React, also when using SSR or pre-rendered components like Docusaurus does.

Main changes:

- The internal state holding the LocationNode entries of the LocationTree is now a linked list. Each node has a parent link. 
- There are several new helper methods, such as `children`, `rootNode`, `error`.
- Errors are cached by instance id, not by location path, this ensures they are up to date across re-renders.
- LocationContextWrapper is now tracking id changes. These occur whenever a wrapper re-renders.
- New validation: we validate root uniqueness. Before it was possible to have an array of roots in the LocationTree.
- LocationTree can infer Tracker Plugins location mutations. This ensures the validation is aware of what Plugins do.
- BUGFIX: Location removal now cleans up also the errorCache. This cache ensures we don't over-report errors.
- Improvement: Location removal now clears up orphaned nodes. This keeps the location list in sync with the UI.
- BUGIFX: TrackerProvider initializes LocationTree instead of ObjectivProvider. This allows using multiple trackers.
- Improvement: The relevant Providers and Wrappers auto detect the environment and enable validation accordingly. 
- Improvement: We do not throw errors anymore if we can't infer id and title from Pressables, instead we console.error.
- Improvement: Whenever we cannot infer id or title we help pinpoint where to look by hinting the LocationStack.
- Several small fixes and improvements to existing tests. Mostly related to using ReactTracker instead of Core Tracker.

To Do:

- [x] Manual testing in Website
- [x] Manual testing in ROD

