### PR TITLE
Add release.yml for auto-generation of changelogs

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,28 @@
+changelog:
+  exclude:
+    labels:
+      - "Release: Ignore for Changelog"
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - "Type: Breaking Change"
+    - title: New Features 🎉
+      labels:
+        - "Type: Epic"
+        - "Type: Story"
+        - "Type: Enhancement"
+    - title: Fixes
+      labels:
+        - "Type: Bug"
+    - title: Docs
+      labels:
+        - "Area: Docs"
+    - title: Demo notebooks
+      labels:
+        - "Area: Demo"
+    - title: Under the hood
+      labels:
+        - "Type: Under the Hood"
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -3,10 +3,7 @@ changelog:
     labels:
       - "Release: Ignore for Changelog"
   categories:
-    - title: Breaking Changes 🛠
-      labels:
-        - "Type: Breaking Change"
-    - title: New Features 🎉
+    - title: Changes 🎉
       labels:
         - "Type: Epic"
         - "Type: Story"
@@ -14,9 +11,6 @@ changelog:
     - title: Fixes
       labels:
         - "Type: Bug"
-    - title: Docs
-      labels:
-        - "Area: Docs"
     - title: Demo notebooks
       labels:
         - "Area: Demo"
@@ -26,3 +20,6 @@ changelog:
     - title: Other Changes
       labels:
         - "*"
+    - title: Docs
+      labels:
+        - "Area: Docs"


### PR DESCRIPTION
This configuration helps to automatically generate changelogs based on labels of PRs. See [docs here](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes).

Configuration options are fairly limited for our monorepo, but this is a nice first step to help with generating changelogs.