### PR TITLE
improve generated documentation for recently added functions

### DIFF
--- a/bach/bach/dataframe.py
+++ b/bach/bach/dataframe.py
@@ -1528,8 +1528,9 @@ class DataFrame:
     ) -> Optional['DataFrame']:
         """
         Sort dataframe by index levels.
+
         :param level: int or level name or list of ints or level names.
-         If not specified, all index series are used
+            If not specified, all index series are used
         :param ascending: Whether to sort ascending (True) or descending (False). If this is a list, then the
             `level` must also be a list and ``len(ascending) == len(level)``.
         :param inplace: Perform operation on self if ``inplace=True``, or create a copy.

--- a/bach/bach/series/series.py
+++ b/bach/bach/series/series.py
@@ -484,9 +484,12 @@ class Series(ABC):
 
     def sort_index(self: T, *, ascending: Union[List[bool], bool] = True) -> T:
         """
-        Return a copy of this Series, that is sorted by the index.
+        Sort this Series by its index.
+        Returns a new instance and does not modify the instance it is called on.
+
         :param ascending: either a bool indicating whether to sort ascending or descending, or a list of
             bools indicating ascending/descending for each of the index levels/columns.
+
         """
         if isinstance(ascending, list):
             if len(ascending) != len(self.index):

--- a/bach/docs/source/DataFrame.rst
+++ b/bach/docs/source/DataFrame.rst
@@ -134,12 +134,22 @@ Sql Model
     DataFrame.get_unsampled
     DataFrame.view_sql
 
+Variables
++++++++++
+.. autosummary::
+    :toctree: DataFrame
+
+    DataFrame.create_variable
+    DataFrame.set_variable
+    DataFrame.get_all_variable_usage
+
 
 Reshaping, indexing, sorting & merging
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. autosummary::
     :toctree: DataFrame
 
+    DataFrame.sort_index
     DataFrame.sort_values
     DataFrame.rename
     DataFrame.drop

--- a/bach/docs/source/Series.rst
+++ b/bach/docs/source/Series.rst
@@ -163,6 +163,7 @@ Conversion, reshaping, sorting
 .. autosummary::
     :toctree: Series
 
+    Series.sort_index
     Series.sort_values
     Series.fillna
 


### PR DESCRIPTION
This resolves issue https://github.com/objectiv/objectiv-analytics/issues/388
Some recently added functions were not listed in the DataFrame and Series overview documentation pages (e.g. https://objectiv.io/docs/modeling/DataFrame). This PR adds those functions there. Will be available online after next redeployment.

Please have a look @jansentom @KathiaBarahona 