### PR TITLE
deprecate DataFrame.values and Series.values

### DIFF
--- a/bach/Makefile
+++ b/bach/Makefile
@@ -3,4 +3,4 @@
 tests:
 	mypy bach sql_models
 	pycodestyle bach sql_models
-	pytest tests/
+	pytest tests/ -W error::DeprecationWarning

--- a/bach/bach/dataframe.py
+++ b/bach/bach/dataframe.py
@@ -1620,7 +1620,7 @@ class DataFrame:
         warnings.simplefilter('default', category=DeprecationWarning)
         return self.to_numpy()
 
-    def to_numpy(self) -> np.ndarray:
+    def to_numpy(self) -> numpy.ndarray:
         """
         Return a Numpy representation of the DataFrame akin :py:attr:`pandas.Dataframe.to_numpy`
 

--- a/bach/bach/dataframe.py
+++ b/bach/bach/dataframe.py
@@ -1618,7 +1618,7 @@ class DataFrame:
             category=DeprecationWarning,
         )
         warnings.simplefilter('default', category=DeprecationWarning)
-        return self.to_pandas().values
+        return self.to_numpy()
 
     def to_numpy(self) -> np.ndarray:
         """

--- a/bach/bach/dataframe.py
+++ b/bach/bach/dataframe.py
@@ -1,9 +1,11 @@
+import warnings
 from copy import copy
 from functools import reduce
 from typing import List, Set, Union, Dict, Any, Optional, Tuple, cast, NamedTuple, \
     TYPE_CHECKING, Callable, Hashable, Sequence
 from uuid import UUID
 
+import numpy as np
 import pandas
 from sqlalchemy.engine import Engine
 from sqlalchemy.future import Connection
@@ -1599,17 +1601,35 @@ class DataFrame:
         return self.to_pandas(limit=n)
 
     @property
-    def values(self):
+    def values(self) -> np.ndarray:
         """
         Return a Numpy representation of the DataFrame akin :py:attr:`pandas.Dataframe.values`
+        .. warning::
+           We recommend using :meth:`DataFrame.to_numpy` instead.
 
         :returns: Returns the values of the DataFrame as numpy.ndarray.
 
         .. note::
             This function queries the database.
         """
-        # todo function is not recommended by pandas, change?
+        warnings.simplefilter('always', category=DeprecationWarning)
+        warnings.warn(
+            'Call to deprecated property, we recommend to use DataFrame.to_numpy() instead',
+            category=DeprecationWarning,
+        )
+        warnings.simplefilter('default', category=DeprecationWarning)
         return self.to_pandas().values
+
+    def to_numpy(self) -> np.ndarray:
+        """
+        Return a Numpy representation of the DataFrame akin :py:attr:`pandas.Dataframe.to_numpy`
+
+        :returns: Returns the values of the DataFrame as numpy.ndarray.
+
+        .. note::
+            This function queries the database.
+        """
+        return self.to_pandas().to_numpy()
 
     def _get_order_by_clause(self) -> Expression:
         """

--- a/bach/bach/dataframe.py
+++ b/bach/bach/dataframe.py
@@ -5,7 +5,7 @@ from typing import List, Set, Union, Dict, Any, Optional, Tuple, cast, NamedTupl
     TYPE_CHECKING, Callable, Hashable, Sequence
 from uuid import UUID
 
-import numpy as np
+import numpy
 import pandas
 from sqlalchemy.engine import Engine
 from sqlalchemy.future import Connection
@@ -1601,7 +1601,7 @@ class DataFrame:
         return self.to_pandas(limit=n)
 
     @property
-    def values(self) -> np.ndarray:
+    def values(self) -> numpy.ndarray:
         """
         Return a Numpy representation of the DataFrame akin :py:attr:`pandas.Dataframe.values`
         .. warning::

--- a/bach/bach/dataframe.py
+++ b/bach/bach/dataframe.py
@@ -1612,12 +1612,10 @@ class DataFrame:
         .. note::
             This function queries the database.
         """
-        warnings.simplefilter('always', category=DeprecationWarning)
         warnings.warn(
             'Call to deprecated property, we recommend to use DataFrame.to_numpy() instead',
             category=DeprecationWarning,
         )
-        warnings.simplefilter('default', category=DeprecationWarning)
         return self.to_numpy()
 
     def to_numpy(self) -> numpy.ndarray:

--- a/bach/bach/series/series.py
+++ b/bach/bach/series/series.py
@@ -449,12 +449,10 @@ class Series(ABC):
         .. note::
             This function queries the database.
         """
-        warnings.simplefilter('always', category=DeprecationWarning)
         warnings.warn(
             'Call to deprecated property, we recommend to use DataFrame.to_numpy() instead',
             category=DeprecationWarning,
         )
-        warnings.simplefilter('default', category=DeprecationWarning)
         return self.to_numpy()
 
     @property

--- a/bach/bach/series/series.py
+++ b/bach/bach/series/series.py
@@ -8,7 +8,7 @@ from typing import Optional, Dict, Tuple, Union, Type, Any, List, cast, TYPE_CHE
     TypeVar
 from uuid import UUID
 
-import numpy as np
+import numpy
 import pandas
 
 from bach import DataFrame, SortColumn, DataFrameOrSeries, get_series_type_from_dtype
@@ -481,7 +481,7 @@ class Series(ABC):
         """
         return self.to_pandas().array
 
-    def to_numpy(self) -> np.ndarray:
+    def to_numpy(self) -> numpy.ndarray:
         """
         Return a Numpy representation of the Series akin :py:attr:`pandas.Series.to_numpy`
 

--- a/bach/bach/series/series.py
+++ b/bach/bach/series/series.py
@@ -1,12 +1,14 @@
 """
 Copyright 2021 Objectiv B.V.
 """
+import warnings
 from abc import ABC, abstractmethod
 from copy import copy
 from typing import Optional, Dict, Tuple, Union, Type, Any, List, cast, TYPE_CHECKING, Callable, Mapping, \
     TypeVar
 from uuid import UUID
 
+import numpy as np
 import pandas
 
 from bach import DataFrame, SortColumn, DataFrameOrSeries, get_series_type_from_dtype
@@ -442,11 +444,18 @@ class Series(ABC):
     def values(self):
         """
         .values property accessor akin pandas.Series.values
-
+        .. warning::
+           We recommend using :meth:`Series.to_numpy` instead.
         .. note::
             This function queries the database.
         """
-        return self.to_pandas().values
+        warnings.simplefilter('always', category=DeprecationWarning)
+        warnings.warn(
+            'Call to deprecated property, we recommend to use DataFrame.to_numpy() instead',
+            category=DeprecationWarning,
+        )
+        warnings.simplefilter('default', category=DeprecationWarning)
+        return self.to_numpy()
 
     @property
     def value(self):
@@ -460,7 +469,7 @@ class Series(ABC):
         if not self.expression.is_single_value:
             raise ValueError('value accessor only supported for single value expressions. '
                              'Use .values instead')
-        return self.values[0]
+        return self.to_numpy()[0]
 
     @property
     def array(self):
@@ -471,6 +480,17 @@ class Series(ABC):
             This function queries the database.
         """
         return self.to_pandas().array
+
+    def to_numpy(self) -> np.ndarray:
+        """
+        Return a Numpy representation of the Series akin :py:attr:`pandas.Series.to_numpy`
+
+        :returns: Returns the values of the Series as numpy.ndarray.
+
+        .. note::
+            This function queries the database.
+        """
+        return self.to_pandas().to_numpy()
 
     def sort_values(self, *, ascending=True):
         """

--- a/bach/tests/functional/bach/test_df.py
+++ b/bach/tests/functional/bach/test_df.py
@@ -155,7 +155,7 @@ def test_quantile() -> None:
         result = bt.quantile(q).sort_index()
 
         # pandas returns a series when calculating just 1 quantile
-        result_values = result.values if isinstance(q, list) else result.values[0]
+        result_values = result.to_numpy() if isinstance(q, list) else result.to_numpy()[0]
         expected = pdf.reset_index(drop=False).quantile(q)
         np.testing.assert_almost_equal(expected, result_values, decimal=4)
 

--- a/bach/tests/functional/bach/test_df_append.py
+++ b/bach/tests/functional/bach/test_df_append.py
@@ -13,7 +13,7 @@ def test_append_w_aligned_columns() -> None:
 
     result = caller_df.append(other_df).sort_values('a').reset_index(drop=False)
     expected = caller_pdf.append(other_pdf).sort_values('a').reset_index(drop=False)
-    np.testing.assert_equal(expected.values, result.values)
+    np.testing.assert_equal(expected.to_numpy(), result.to_numpy())
 
 
 def test_append_w_non_aligned_columns() -> None:

--- a/bach/tests/functional/bach/test_df_groupby.py
+++ b/bach/tests/functional/bach/test_df_groupby.py
@@ -537,15 +537,15 @@ def test_groupby_frame_split_series_aggregation():
     assert df_sum_series.base_node == bt.base_node
     assert df_df_sum_series.base_node == bt.base_node
 
-    assert (founding_sum.values == df_sum_series.values).all()
-    assert (founding_sum.values == df_df_sum_series.values).all()
+    assert (founding_sum.to_numpy() == df_sum_series.to_numpy()).all()
+    assert (founding_sum.to_numpy() == df_df_sum_series.to_numpy()).all()
 
     # Does math work?
     inhabitants_sum = btg1['inhabitants'].sum()
     founding_sum = btg1['founding'].sum()
     add_series_sum = btg1['founding'].sum() + btg1['inhabitants'].sum()
     assert all(
-        (founding_sum.values + inhabitants_sum.values) == add_series_sum.values
+        (founding_sum.to_numpy() + inhabitants_sum.to_numpy()) == add_series_sum.to_numpy()
     )
     # no materialization has taken place yet.
     assert inhabitants_sum.base_node == bt.base_node

--- a/bach/tests/functional/bach/test_df_window.py
+++ b/bach/tests/functional/bach/test_df_window.py
@@ -366,12 +366,12 @@ def test_rolling_defaults_vs_pandas():
             # pandas can retain the sorting order and apply group_by,
             # but bach can not. We need to do one final sort in the larger df
             r['rolling'] = rolling
-            return r.sort_values([*group_by, 'skating_order'])['rolling'].values
+            return r.sort_values([*group_by, 'skating_order'])['rolling'].to_numpy()
         else:
             # we can't return the entire frame as in pandas it's not possible
             # to add the grouped, rolled up values back into the df, due to an
             # index mismatch.
-            return rolling.values
+            return rolling.to_numpy()
 
     for center in [False, True]:
         for window in range(1, 11):
@@ -405,7 +405,7 @@ def test_rolling_variations():
         r1 = df.rolling(**kwargs).sum()[[series + '_sum']]
         # the last [] is required because running this on a df will include the index as a series
         r2 = df[[series]].rolling(**kwargs).sum()[[series + '_sum']]
-        np.testing.assert_equal(r1.values, r2.values)
+        np.testing.assert_equal(r1.to_numpy(), r2.to_numpy())
 
     def _test_series_vs_full_df(df, series, **kwargs):
         # get the series
@@ -413,7 +413,7 @@ def test_rolling_variations():
         # get the frame selection
         # the last [] is required because running this on a df will include the index as a series
         r2 = df[[series]].rolling(**kwargs).sum()[[series + '_sum']]
-        np.testing.assert_equal(r1.values, r2.values)
+        np.testing.assert_equal(r1.to_numpy(), r2.to_numpy())
 
     for df in bt[['skating_order', 'inhabitants', 'founding']], bt.groupby('municipality'):
         for s in df.data_columns:
@@ -429,8 +429,8 @@ def test_expanding_defaults_vs_pandas():
     for series in bt.data_columns:
         for min_periods in range(0, 11):
             pdf: pd.DataFrame = bt[[series]].to_pandas()
-            pd_values = pdf.expanding(min_periods=min_periods).sum().values
-            bt_values = bt.expanding(min_periods=min_periods).sum()[[series + '_sum']].values
+            pd_values = pdf.expanding(min_periods=min_periods).sum().to_numpy()
+            bt_values = bt.expanding(min_periods=min_periods).sum()[[series + '_sum']].to_numpy()
             np.testing.assert_equal(pd_values, bt_values)
 
 
@@ -441,7 +441,7 @@ def test_expanding_variations():
         r1 = bt.expanding(**kwargs).sum()[[series + '_sum']]
         # the last [] is required because running this on a df will include the index as a series
         r2 = bt[[series]].expanding(**kwargs).sum()[[series + '_sum']]
-        np.testing.assert_equal(r1.values, r2.values)
+        np.testing.assert_equal(r1.to_numpy(), r2.to_numpy())
 
     def _test_series_vs_full_df(series, **kwargs):
         # get the series
@@ -449,7 +449,7 @@ def test_expanding_variations():
         # get the frame selection
         # the last [] is required because running this on a df will include the index as a series
         r2 = bt[[series]].expanding(**kwargs).sum()[[series + '_sum']]
-        np.testing.assert_equal(r1.values, r2.values)
+        np.testing.assert_equal(r1.to_numpy(), r2.to_numpy())
 
     for series in bt.data_columns:
         for min_periods in [1,5,11]:

--- a/bach/tests/functional/bach/test_series.py
+++ b/bach/tests/functional/bach/test_series.py
@@ -166,7 +166,7 @@ def test_fillna():
     def tf(x):
         bt_fill = bt['0'].fillna(x)
         assert bt_fill.expression.is_constant == bt['0'].expression.is_constant
-        np.testing.assert_equal(pdf[0].fillna(x).values, bt_fill.values)
+        np.testing.assert_equal(pdf[0].fillna(x).to_numpy(), bt_fill.to_numpy())
 
     assert(bt['0'].dtype == 'float64')
     tf(1.25)

--- a/bach/tests/functional/bach/test_series_boolean.py
+++ b/bach/tests/functional/bach/test_series_boolean.py
@@ -22,7 +22,7 @@ def test_to_pandas():
     bt['t'] = True
     bt['f'] = False
     bt[['t', 'f']].to_pandas()
-    numpy.testing.assert_array_equal(bt[['t', 'f']].values[0] , [True, False])
+    numpy.testing.assert_array_equal(bt[['t', 'f']].to_numpy()[0] , [True, False])
 
     
 def test_operations():

--- a/bach/tests/functional/bach/test_series_date.py
+++ b/bach/tests/functional/bach/test_series_date.py
@@ -115,4 +115,4 @@ def test_to_pandas():
     bt = get_bt_with_test_data()
     bt['d'] = datetime.date(2020, 3, 11)
     bt[['d']].to_pandas()
-    assert bt[['d']].values[0] == [datetime.date(2020, 3, 11)]
+    assert bt[['d']].to_numpy()[0] == [datetime.date(2020, 3, 11)]

--- a/bach/tests/functional/bach/test_series_numeric.py
+++ b/bach/tests/functional/bach/test_series_numeric.py
@@ -48,8 +48,8 @@ def test_round():
     for i in 0, 3, 5, 9:
         assert bt.const.round(i).expression.is_constant
         assert not bt['0'].round(i).expression.is_constant
-        np.testing.assert_equal(pdf[0].round(i).values, bt['0'].round(i).values)
-        np.testing.assert_equal(pdf[0].round(decimals=i).values, bt['0'].round(decimals=i).values)
+        np.testing.assert_equal(pdf[0].round(i).to_numpy(), bt['0'].round(i).to_numpy())
+        np.testing.assert_equal(pdf[0].round(decimals=i).to_numpy(), bt['0'].round(decimals=i).to_numpy())
 
 
 def test_round_integer():
@@ -132,7 +132,7 @@ def test_aggregations_quantile():
 
     for column, quantile in zip(pdf.columns, quantiles):
         expected = pdf[column].quantile(q=quantile)
-        result = bt[column].quantile(q=quantile).values[0]
+        result = bt[column].quantile(q=quantile).to_numpy()[0]
         assert expected == result
 
     for column in pdf.columns:

--- a/bach/tests/functional/bach/test_series_time.py
+++ b/bach/tests/functional/bach/test_series_time.py
@@ -21,4 +21,4 @@ def test_to_pandas():
     bt = get_bt_with_test_data()
     bt['t'] = datetime.time(23, 11, 5)
     bt[['t']].to_pandas()
-    assert bt[['t']].values[0] == [datetime.time(23, 11, 5)]
+    assert bt[['t']].to_numpy()[0] == [datetime.time(23, 11, 5)]

--- a/bach/tests/functional/bach/test_series_timedelta.py
+++ b/bach/tests/functional/bach/test_series_timedelta.py
@@ -84,4 +84,4 @@ def test_to_pandas():
     bt[['td']].to_pandas()
     # TODO, this is not great, but at least it does not error when imported into pandas,
     # and it looks good over there
-    assert bt[['td']].values[0] == [27744277000000000]
+    assert bt[['td']].to_numpy()[0] == [27744277000000000]

--- a/bach/tests/functional/bach/test_series_timestamp.py
+++ b/bach/tests/functional/bach/test_series_timestamp.py
@@ -30,7 +30,7 @@ def test_to_pandas():
     from numpy import array
     # TODO, this is not great, but at least it does not error when imported into pandas,
     # and it looks good over there
-    assert bt[['dt']].values[0] == [array(['2021-05-03T11:28:36.388000000'], dtype='datetime64[ns]')]
+    assert bt[['dt']].to_numpy()[0] == [array(['2021-05-03T11:28:36.388000000'], dtype='datetime64[ns]')]
 
 
 @pytest.mark.parametrize("asstring", [True, False])

--- a/bach/tests/functional/bach/test_series_uuid.py
+++ b/bach/tests/functional/bach/test_series_uuid.py
@@ -136,5 +136,5 @@ def test_to_pandas():
     bt['a'] = uuid.UUID('0022c7dd-074b-4a44-a7cb-b7716b668264')
     bt['c'] = SeriesUuid.sql_gen_random_uuid(bt)
     bt[['a', 'c']].to_pandas()
-    assert bt[['a']].values[0] == [uuid.UUID('0022c7dd-074b-4a44-a7cb-b7716b668264')]
-    assert type(bt[['a']].values[0][0]) == type(uuid.UUID('0022c7dd-074b-4a44-a7cb-b7716b668264'))
+    assert bt[['a']].to_numpy()[0] == [uuid.UUID('0022c7dd-074b-4a44-a7cb-b7716b668264')]
+    assert type(bt[['a']].to_numpy()[0][0]) == type(uuid.UUID('0022c7dd-074b-4a44-a7cb-b7716b668264'))


### PR DESCRIPTION
**Issue:** https://github.com/objectiv/objectiv-analytics/issues/387

## Description:
DataFrame's `value` property is evaluated in runtime when using the debugger (Pycharm). To avoid this, users can simply disable the automatic variable evaluation in the IDE. But, that is not a nice solution for us. Therefore we agreed to deprecate such property and use `to_numpy()` function instead (as recommended by Pandas).

## Changes:
- Added `to_numpy` method to DataFrame and Series classes
- Added deprecated warnings on both DataFrame and Series `values` property
- Added check for DeprecatedWarnings to the pytest check, this way we avoid using deprecated objects in our own tests

## Checklist:
- [na] Tests
- [X] Updated docstrings 