### PR TITLE
add trailing slash to index

### DIFF
--- a/bach/docs/generate.py
+++ b/bach/docs/generate.py
@@ -325,7 +325,7 @@ for url in urls:
 
     if page == index_page:
         # special case where we map the index to Introduction
-        slug = f'/{module}'
+        slug = f'/{module}/'
         sidebar_label = 'Introduction'
 
     else:

--- a/bach/docs/source/Series.rst
+++ b/bach/docs/source/Series.rst
@@ -142,7 +142,6 @@ Sql Model
 .. autosummary::
     :toctree: Series
 
-    Series.engine
     Series.base_node
     Series.view_sql
 

--- a/bach/docs/source/examples.rst
+++ b/bach/docs/source/examples.rst
@@ -10,7 +10,7 @@ In the examples we'll assume that the database has a table called 'example', wit
 columns. The SQL to create that table can be found below in :ref:`appendix_example_data`.
 
 To get a taste of what you can do with Objectiv Bach, There is a `demo
-<https://objectiv.io/docs/quickstart-guide>`_ available that enables you to run the full Objectiv pipeline
+</docs/quickstart-guide>`_ available that enables you to run the full Objectiv pipeline
 on your local machine. It includes our website as a demo app, a Jupyter Notebook environment with working
 models and a Metabase environment to output data to.
 

--- a/bach/docs/source/intro.rst
+++ b/bach/docs/source/intro.rst
@@ -12,7 +12,7 @@ full dataset, and you can output models to SQL with a single command. It include
 enable effective feature creation for datasets that embrace the open taxonomy of analytics.
 
 To get a taste of what you can do with Objectiv Bach, There is a `demo 
-<https://objectiv.io/docs/quickstart-guide>`_ available that enables you to run the full Objectiv pipeline on your local machine. It includes our website as a demo app, a Jupyter Notebook 
+</docs/quickstart-guide>`_ available that enables you to run the full Objectiv pipeline on your local machine. It includes our website as a demo app, a Jupyter Notebook 
 environment with working models and a Metabase environment to output data to.
 
 What is Bach?


### PR DESCRIPTION
add trailing / to introduction / index page

as a bonus, remove an Internal property from sphinx, as that causes the sidebar in docusaurus to disappear