### PR TITLE
Tracker: new bundler tweaks

### DIFF
--- a/tracker/core/schema/package.json
+++ b/tracker/core/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/schema",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Objectiv TypeScript implementation of the open taxonomy for analytics",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",

--- a/tracker/core/testing-tools/package.json
+++ b/tracker/core/testing-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/testing-tools",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "private": true,
   "license": "Apache-2.0",
   "description": "Mocks and other testing utilities shared across Objectiv Trackers",

--- a/tracker/core/tracker/package.json
+++ b/tracker/core/tracker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/tracker-core",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Core functionality for Objectiv JavaScript trackers",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -50,7 +50,7 @@
     "npm-publish:verdaccio": "shx cp ../../verdaccio/.npmrc .npmrc && npm publish && shx rm -f .npmrc"
   },
   "devDependencies": {
-    "@objectiv/testing-tools": "^0.0.8",
+    "@objectiv/testing-tools": "^0.0.9",
     "@types/jest": "^27.0.3",
     "jest": "^27.4.5",
     "jest-standard-reporter": "^2.0.0",
@@ -62,7 +62,7 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "@objectiv/schema": "^0.0.8",
+    "@objectiv/schema": "^0.0.9",
     "uuid-random": "^1.3.2"
   }
 }

--- a/tracker/core/tracker/package.json
+++ b/tracker/core/tracker/package.json
@@ -25,7 +25,7 @@
     }
   ],
   "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
+  "module": "./dist/esm/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"
@@ -33,12 +33,12 @@
   "exports": {
     ".": {
       "require": "./dist/index.js",
-      "import": "./dist/index.mjs",
+      "import": "./dist/esm/index.js",
       "types": "./dist/index.d.ts"
     }
   },
   "scripts": {
-    "build": "tsup src/index.ts --format cjs,esm --minify --dts --sourcemap --clean",
+    "build": "tsup src/index.ts --format cjs,esm --legacy-output --minify --dts --sourcemap --clean",
     "prettify": "prettier --write .",
     "prettify:generated": "yarn prettier --write ./src/ContextFactories.ts ./src/EventFactories.ts",
     "tsc": "tsc --noEmit",

--- a/tracker/core/utilities/package.json
+++ b/tracker/core/utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/utilities",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "private": true,
   "license": "Apache-2.0",
   "description": "Objectiv Core Utilities",

--- a/tracker/plugins/http-context/.prettierignore
+++ b/tracker/plugins/http-context/.prettierignore
@@ -1,0 +1,26 @@
+# Logs
+*.log
+
+# Yarn 2
+.yarn/*
+!.yarn/releases
+!.yarn/plugins
+
+# Dependencies
+node_modules/
+
+# OS X temporary files
+.DS_Store
+
+# Test coverage reports
+coverage/
+
+# Distribution files
+dist/
+
+# IDE files
+.idea/
+.vscode/
+
+# Markdown
+*.md

--- a/tracker/plugins/http-context/.prettierrc.json
+++ b/tracker/plugins/http-context/.prettierrc.json
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "printWidth": 120
+}

--- a/tracker/plugins/http-context/README.md
+++ b/tracker/plugins/http-context/README.md
@@ -1,0 +1,26 @@
+# Objectiv HttpContext Plugin
+
+Plugin for Objectiv web trackers. Detects user_agents and referrer via document and navigator APIs and factors in an `HttpContext` that is attached to each `TrackerEvent`'s `global_contexts`.
+
+---
+## Package Installation
+To install the most recent stable version:
+
+```sh
+yarn add @objectiv/http-context
+```
+
+### or
+```sh
+npm install @objectiv/http-context
+```
+
+# Usage
+For a detailed usage guide, see the documentation: [https://objectiv.io/docs](https://objectiv.io/docs)
+
+# Copyright and license
+Licensed and distributed under the Apache 2.0 License (An OSI Approved License).
+
+Copyright (c) 2021 Objectiv B.V.
+
+All rights reserved.

--- a/tracker/plugins/http-context/jest.config.js
+++ b/tracker/plugins/http-context/jest.config.js
@@ -1,0 +1,15 @@
+/*
+ * Copyright 2021-2022 Objectiv B.V.
+ */
+
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  reporters: ['jest-standard-reporter'],
+  collectCoverageFrom: ['src/**.ts'],
+  moduleNameMapper: {
+    '@objectiv/testing-tools': '<rootDir>../../core/testing-tools/src',
+    '@objectiv/tracker-core': '<rootDir>../../core/tracker/src',
+  },
+  setupFilesAfterEnv: ['jest-extended/all'],
+};

--- a/tracker/plugins/http-context/package.json
+++ b/tracker/plugins/http-context/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@objectiv/tracker-browser",
+  "name": "@objectiv/plugin-http-context",
   "version": "0.0.9",
-  "description": "Objectiv Web application analytics tracker for the open taxonomy for analytics",
+  "description": "Plugin for Objectiv trackers to automatically generate and attach HttpContext from document and navigator APIs",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
   "keywords": [
@@ -10,12 +10,16 @@
     "web",
     "analytics",
     "events",
-    "taxonomy"
+    "taxonomy",
+    "plugin",
+    "httpcontext",
+    "useragent",
+    "referrer"
   ],
   "repository": {
     "type": "git",
     "url": "https://github.com/objectiv/objectiv-analytics.git",
-    "directory": "tracker/trackers/browser"
+    "directory": "tracker/plugins/http-context"
   },
   "bugs": "https://github.com/objectiv/objectiv-analytics/issues",
   "contributors": [
@@ -53,6 +57,7 @@
     "@objectiv/testing-tools": "^0.0.9",
     "@types/jest": "^27.0.3",
     "jest": "^27.4.5",
+    "jest-extended": "^1.1.0",
     "jest-fetch-mock": "^3.0.3",
     "jest-standard-reporter": "^2.0.0",
     "jest-useragent-mock": "^0.1.1",
@@ -62,14 +67,7 @@
     "tsup": "^5.11.13",
     "typescript": "^4.5.5"
   },
-  "dependencies": {
-    "@objectiv/plugin-http-context": "^0.0.9",
-    "@objectiv/plugin-path-context-from-url": "^0.0.9",
-    "@objectiv/plugin-root-location-context-from-url": "^0.0.9",
-    "@objectiv/queue-local-storage": "^0.0.9",
-    "@objectiv/tracker-core": "^0.0.9",
-    "@objectiv/transport-debug": "^0.0.9",
-    "@objectiv/transport-fetch": "^0.0.9",
-    "@objectiv/transport-xhr": "^0.0.9"
+  "peerDependencies": {
+    "@objectiv/tracker-core": "^0.0.9"
   }
 }

--- a/tracker/plugins/http-context/src/HttpContextPlugin.ts
+++ b/tracker/plugins/http-context/src/HttpContextPlugin.ts
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021-2022 Objectiv B.V.
+ */
+
+import {
+  ContextsConfig,
+  makeHttpContext,
+  TrackerConsole,
+  TrackerPluginConfig,
+  TrackerPluginInterface,
+} from '@objectiv/tracker-core';
+
+/**
+ * The HttpContext Plugin gathers the current URL using the Location API.
+ * It implements the `initialize` lifecycle method. This ensures the Context is generated when the tracker is created.
+ */
+export class HttpContextPlugin implements TrackerPluginInterface {
+  readonly console?: TrackerConsole;
+  readonly pluginName = `HttpContextPlugin`;
+
+  /**
+   * The constructor is responsible for processing the given TrackerPluginConfiguration `console` parameter.
+   */
+  constructor(config?: TrackerPluginConfig) {
+    this.console = config?.console;
+
+    if (this.console) {
+      this.console.log(`%c｢objectiv:${this.pluginName}｣ Initialized`, 'font-weight: bold');
+    }
+  }
+
+  /**
+   * Generate an HttpContext.
+   */
+  initialize(contexts: Required<ContextsConfig>): void {
+    const httpContext = makeHttpContext({
+      id: 'http_context',
+      referer: document.referrer,
+      user_agent: navigator.userAgent,
+      remote_address: '127.0.0.1',
+    });
+    contexts.global_contexts.push(httpContext);
+  }
+
+  /**
+   * Make this plugin usable only on web, eg: Document and Navigation APIs are both available
+   */
+  isUsable(): boolean {
+    return typeof document !== 'undefined' && typeof navigator !== 'undefined';
+  }
+}

--- a/tracker/plugins/http-context/src/index.ts
+++ b/tracker/plugins/http-context/src/index.ts
@@ -1,0 +1,5 @@
+/*
+ * Copyright 2021-2022 Objectiv B.V.
+ */
+
+export * from './HttpContextPlugin';

--- a/tracker/plugins/http-context/tests/HttpContextPlugin.node.test.ts
+++ b/tracker/plugins/http-context/tests/HttpContextPlugin.node.test.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright 2021-2022 Objectiv B.V.
+ * @jest-environment node
+ */
+import { HttpContextPlugin } from '../src';
+
+describe('HttpContextPlugin - node', () => {
+  it('should instantiate as unusable', () => {
+    const testHttpContextPlugin = new HttpContextPlugin();
+    expect(testHttpContextPlugin.isUsable()).toBe(false);
+  });
+});

--- a/tracker/plugins/http-context/tests/HttpContextPlugin.test.ts
+++ b/tracker/plugins/http-context/tests/HttpContextPlugin.test.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2021-2022 Objectiv B.V.
+ */
+
+import { mockConsole } from '@objectiv/testing-tools';
+import { ContextsConfig, Tracker, TrackerEvent, TrackerPlugins } from '@objectiv/tracker-core';
+import { HttpContextPlugin } from '../src';
+
+describe('HttpContextPlugin', () => {
+  it('should instantiate without a console', () => {
+    const testHttpContextPlugin = new HttpContextPlugin();
+    expect(testHttpContextPlugin).toBeInstanceOf(HttpContextPlugin);
+    expect(testHttpContextPlugin.console).toBeUndefined();
+  });
+
+  it('should instantiate with the given console', () => {
+    const testHttpContextPlugin = new HttpContextPlugin({ console: mockConsole });
+    expect(testHttpContextPlugin).toBeInstanceOf(HttpContextPlugin);
+    expect(testHttpContextPlugin.console).toBe(mockConsole);
+  });
+
+  it('should add the HttpContext to the Event when `initialize` is executed by the Tracker', async () => {
+    const originalReferrer = document.referrer;
+    const originalUserAgent = navigator.userAgent;
+    Object.defineProperty(document, 'referrer', { value: 'MOCK_REFERRER', configurable: true });
+    Object.defineProperty(navigator, 'userAgent', { value: 'MOCK_USER_AGENT', configurable: true });
+
+    const testTracker = new Tracker({
+      applicationId: 'app-id',
+      plugins: new TrackerPlugins({ plugins: [new HttpContextPlugin()] }),
+    });
+    const eventContexts: ContextsConfig = {
+      location_stack: [
+        { __location_context: true, _type: 'section', id: 'A' },
+        { __location_context: true, _type: 'section', id: 'B' },
+      ],
+      global_contexts: [
+        { __global_context: true, _type: 'GlobalA', id: 'abc' },
+        { __global_context: true, _type: 'GlobalB', id: 'def' },
+      ],
+    };
+    const testEvent = new TrackerEvent({ _type: 'test-event', ...eventContexts });
+    expect(testEvent.location_stack).toHaveLength(2);
+    const trackedEvent = await testTracker.trackEvent(testEvent);
+    expect(trackedEvent.location_stack).toHaveLength(2);
+    expect(trackedEvent.global_contexts).toHaveLength(3);
+    expect(trackedEvent.global_contexts).toEqual(
+      expect.arrayContaining([
+        {
+          __global_context: true,
+          _type: 'HttpContext',
+          id: 'http_context',
+          referer: 'MOCK_REFERRER',
+          remote_address: '127.0.0.1',
+          user_agent: 'MOCK_USER_AGENT',
+        },
+      ])
+    );
+
+    Object.defineProperty(document, 'referrer', { value: originalReferrer });
+    Object.defineProperty(navigator, 'userAgent', { value: originalUserAgent });
+  });
+});

--- a/tracker/plugins/http-context/tests/global.d.ts
+++ b/tracker/plugins/http-context/tests/global.d.ts
@@ -1,0 +1,5 @@
+/*
+ * Copyright 2021-2022 Objectiv B.V.
+ */
+
+import 'jest-extended';

--- a/tracker/plugins/http-context/tsconfig.json
+++ b/tracker/plugins/http-context/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/tracker/plugins/path-context-from-url/package.json
+++ b/tracker/plugins/path-context-from-url/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/plugin-path-context-from-url",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Plugin for Objectiv trackers to automatically generate and attach PathContext from URLs",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -52,7 +52,7 @@
     "npm-publish:verdaccio": "shx cp ../../verdaccio/.npmrc .npmrc && npm publish && shx rm -f .npmrc"
   },
   "devDependencies": {
-    "@objectiv/testing-tools": "^0.0.8",
+    "@objectiv/testing-tools": "^0.0.9",
     "@types/jest": "^27.0.3",
     "jest": "^27.4.5",
     "jest-extended": "^1.1.0",
@@ -66,6 +66,6 @@
     "typescript": "^4.5.5"
   },
   "peerDependencies": {
-    "@objectiv/tracker-core": "^0.0.8"
+    "@objectiv/tracker-core": "^0.0.9"
   }
 }

--- a/tracker/plugins/path-context-from-url/package.json
+++ b/tracker/plugins/path-context-from-url/package.json
@@ -28,7 +28,7 @@
     }
   ],
   "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
+  "module": "./dist/esm/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"
@@ -36,12 +36,12 @@
   "exports": {
     ".": {
       "require": "./dist/index.js",
-      "import": "./dist/index.mjs",
+      "import": "./dist/esm/index.js",
       "types": "./dist/index.d.ts"
     }
   },
   "scripts": {
-    "build": "tsup src/index.ts --format cjs,esm --minify --dts --sourcemap --clean",
+    "build": "tsup src/index.ts --format cjs,esm --legacy-output --minify --dts --sourcemap --clean",
     "prettify": "prettier --write .",
     "tsc": "tsc --noEmit",
     "test": "jest --silent --runInBand",

--- a/tracker/plugins/root-location-context-from-url/package.json
+++ b/tracker/plugins/root-location-context-from-url/package.json
@@ -29,7 +29,7 @@
     }
   ],
   "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
+  "module": "./dist/esm/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"
@@ -37,12 +37,12 @@
   "exports": {
     ".": {
       "require": "./dist/index.js",
-      "import": "./dist/index.mjs",
+      "import": "./dist/esm/index.js",
       "types": "./dist/index.d.ts"
     }
   },
   "scripts": {
-    "build": "tsup src/index.ts --format cjs,esm --minify --dts --sourcemap --clean",
+    "build": "tsup src/index.ts --format cjs,esm --legacy-output --minify --dts --sourcemap --clean",
     "prettify": "prettier --write .",
     "tsc": "tsc --noEmit",
     "test": "jest --silent --runInBand",

--- a/tracker/plugins/root-location-context-from-url/package.json
+++ b/tracker/plugins/root-location-context-from-url/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/plugin-root-location-context-from-url",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Plugin for Objectiv trackers to automatically generate and attach RootLocationContext from URLs",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -53,7 +53,7 @@
     "npm-publish:verdaccio": "shx cp ../../verdaccio/.npmrc .npmrc && npm publish && shx rm -f .npmrc"
   },
   "devDependencies": {
-    "@objectiv/testing-tools": "^0.0.8",
+    "@objectiv/testing-tools": "^0.0.9",
     "@types/jest": "^27.0.3",
     "jest": "^27.4.5",
     "jest-extended": "^1.1.0",
@@ -67,6 +67,6 @@
     "typescript": "^4.5.5"
   },
   "peerDependencies": {
-    "@objectiv/tracker-core": "^0.0.8"
+    "@objectiv/tracker-core": "^0.0.9"
   }
 }

--- a/tracker/queues/local-storage/package.json
+++ b/tracker/queues/local-storage/package.json
@@ -27,7 +27,7 @@
     }
   ],
   "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
+  "module": "./dist/esm/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"
@@ -35,12 +35,12 @@
   "exports": {
     ".": {
       "require": "./dist/index.js",
-      "import": "./dist/index.mjs",
+      "import": "./dist/esm/index.js",
       "types": "./dist/index.d.ts"
     }
   },
   "scripts": {
-    "build": "tsup src/index.ts --format cjs,esm --minify --dts --sourcemap --clean",
+    "build": "tsup src/index.ts --format cjs,esm --legacy-output --minify --dts --sourcemap --clean",
     "prettify": "prettier --write .",
     "tsc": "tsc --noEmit",
     "test": "jest --silent --runInBand",

--- a/tracker/queues/local-storage/package.json
+++ b/tracker/queues/local-storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/queue-local-storage",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "A TrackerQueueStore based on localStorage API",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -51,7 +51,7 @@
     "npm-publish:verdaccio": "shx cp ../../verdaccio/.npmrc .npmrc && npm publish && shx rm -f .npmrc"
   },
   "devDependencies": {
-    "@objectiv/testing-tools": "^0.0.8",
+    "@objectiv/testing-tools": "^0.0.9",
     "@types/jest": "^27.0.3",
     "jest": "^27.4.5",
     "jest-standard-reporter": "^2.0.0",
@@ -62,6 +62,6 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "@objectiv/tracker-core": "~0.0.8"
+    "@objectiv/tracker-core": "~0.0.9"
   }
 }

--- a/tracker/trackers/angular/package.json
+++ b/tracker/trackers/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/tracker-angular",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Objectiv Angular framework analytics tracker for the open taxonomy for analytics",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -38,13 +38,13 @@
   "peerDependencies": {
     "@angular/common": "^9.0.0",
     "@angular/core": "^9.0.0",
-    "@objectiv/tracker-browser": "^0.0.8"
+    "@objectiv/tracker-browser": "^0.0.9"
   },
   "devDependencies": {
     "@angular/compiler": "~9.1.13",
     "@angular/compiler-cli": "~9.1.13",
     "@angular/core": "~9.1.13",
-    "@objectiv/tracker-browser": "^0.0.8",
+    "@objectiv/tracker-browser": "^0.0.9",
     "ng-packagr": "^9.0.0",
     "prettier": "^2.5.1",
     "rxjs": "~6.5.4",

--- a/tracker/trackers/browser/package.json
+++ b/tracker/trackers/browser/package.json
@@ -26,7 +26,7 @@
     }
   ],
   "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
+  "module": "./dist/esm/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"
@@ -34,12 +34,12 @@
   "exports": {
     ".": {
       "require": "./dist/index.js",
-      "import": "./dist/index.mjs",
+      "import": "./dist/esm/index.js",
       "types": "./dist/index.d.ts"
     }
   },
   "scripts": {
-    "build": "tsup src/index.ts --format cjs,esm --minify --dts --sourcemap --clean",
+    "build": "tsup src/index.ts --format cjs,esm --legacy-output --minify --dts --sourcemap --clean",
     "prettify": "prettier --write .",
     "tsc": "tsc --noEmit",
     "test": "jest --silent --runInBand",

--- a/tracker/trackers/browser/package.json
+++ b/tracker/trackers/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/tracker-browser",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Objectiv Web application analytics tracker for the open taxonomy for analytics",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -50,7 +50,7 @@
     "npm-publish:verdaccio": "shx cp ../../verdaccio/.npmrc .npmrc && npm publish && shx rm -f .npmrc"
   },
   "devDependencies": {
-    "@objectiv/testing-tools": "^0.0.8",
+    "@objectiv/testing-tools": "^0.0.9",
     "@types/jest": "^27.0.3",
     "jest": "^27.4.5",
     "jest-fetch-mock": "^3.0.3",
@@ -63,12 +63,12 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "@objectiv/plugin-path-context-from-url": "^0.0.8",
-    "@objectiv/plugin-root-location-context-from-url": "^0.0.8",
-    "@objectiv/queue-local-storage": "^0.0.8",
-    "@objectiv/tracker-core": "^0.0.8",
-    "@objectiv/transport-debug": "^0.0.8",
-    "@objectiv/transport-fetch": "^0.0.8",
-    "@objectiv/transport-xhr": "^0.0.8"
+    "@objectiv/plugin-path-context-from-url": "^0.0.9",
+    "@objectiv/plugin-root-location-context-from-url": "^0.0.9",
+    "@objectiv/queue-local-storage": "^0.0.9",
+    "@objectiv/tracker-core": "^0.0.9",
+    "@objectiv/transport-debug": "^0.0.9",
+    "@objectiv/transport-fetch": "^0.0.9",
+    "@objectiv/transport-xhr": "^0.0.9"
   }
 }

--- a/tracker/trackers/browser/src/common/factories/makeDefaultPluginsList.ts
+++ b/tracker/trackers/browser/src/common/factories/makeDefaultPluginsList.ts
@@ -2,6 +2,7 @@
  * Copyright 2021-2022 Objectiv B.V.
  */
 
+import { HttpContextPlugin } from '@objectiv/plugin-http-context';
 import { PathContextFromURLPlugin } from '@objectiv/plugin-path-context-from-url';
 import { RootLocationContextFromURLPlugin } from '@objectiv/plugin-root-location-context-from-url';
 import { makeTrackerDefaultPluginsList, TrackerPluginInterface } from '@objectiv/tracker-core';
@@ -13,7 +14,10 @@ import { BrowserTrackerConfig } from '../../definitions/BrowserTrackerConfig';
 export const makeDefaultPluginsList = (trackerConfig: BrowserTrackerConfig) => {
   const { trackPathContextFromURL = true, trackRootLocationContextFromURL = true } = trackerConfig;
 
-  const plugins: TrackerPluginInterface[] = [...makeTrackerDefaultPluginsList(trackerConfig)];
+  const plugins: TrackerPluginInterface[] = [
+    ...makeTrackerDefaultPluginsList(trackerConfig),
+    new HttpContextPlugin(trackerConfig),
+  ];
 
   if (trackPathContextFromURL) {
     plugins.push(new PathContextFromURLPlugin(trackerConfig));

--- a/tracker/trackers/browser/tests/BrowserTracker.test.ts
+++ b/tracker/trackers/browser/tests/BrowserTracker.test.ts
@@ -221,9 +221,13 @@ describe('BrowserTracker', () => {
 
       const trackedEvent = await testTracker.trackEvent(testEvent);
 
-      expect(trackedEvent.global_contexts).toHaveLength(2);
+      expect(trackedEvent.global_contexts).toHaveLength(3);
       expect(trackedEvent.global_contexts).toEqual(
         expect.arrayContaining([
+          expect.objectContaining({
+            _type: 'HttpContext',
+            id: 'http_context',
+          }),
           expect.objectContaining({
             _type: 'ApplicationContext',
             id: 'app-id',

--- a/tracker/trackers/react/package.json
+++ b/tracker/trackers/react/package.json
@@ -26,7 +26,7 @@
     }
   ],
   "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
+  "module": "./dist/esm/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"
@@ -34,12 +34,12 @@
   "exports": {
     ".": {
       "require": "./dist/index.js",
-      "import": "./dist/index.mjs",
+      "import": "./dist/esm/index.js",
       "types": "./dist/index.d.ts"
     }
   },
   "scripts": {
-    "build": "tsup src/index.ts --format cjs,esm --minify --dts --sourcemap --clean",
+    "build": "tsup src/index.ts --format cjs,esm --legacy-output --minify --dts --sourcemap --clean",
     "prettify": "prettier --write .",
     "tsc": "tsc --noEmit",
     "test": "jest --silent --runInBand",

--- a/tracker/trackers/react/package.json
+++ b/tracker/trackers/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/tracker-react",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Objectiv React application analytics tracker for the open taxonomy for analytics",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -50,7 +50,7 @@
     "npm-publish:verdaccio": "shx cp ../../verdaccio/.npmrc .npmrc && npm publish && shx rm -f .npmrc"
   },
   "devDependencies": {
-    "@objectiv/testing-tools": "^0.0.8",
+    "@objectiv/testing-tools": "^0.0.9",
     "@testing-library/react": "^12.1.2",
     "@testing-library/react-hooks": "^7.0.2",
     "@types/jest": "^27.0.3",
@@ -68,12 +68,12 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "@objectiv/plugin-path-context-from-url": "^0.0.8",
-    "@objectiv/plugin-root-location-context-from-url": "^0.0.8",
-    "@objectiv/queue-local-storage": "^0.0.8",
-    "@objectiv/tracker-core": "~0.0.8",
-    "@objectiv/transport-fetch": "^0.0.8",
-    "@objectiv/transport-xhr": "^0.0.8",
+    "@objectiv/plugin-path-context-from-url": "^0.0.9",
+    "@objectiv/plugin-root-location-context-from-url": "^0.0.9",
+    "@objectiv/queue-local-storage": "^0.0.9",
+    "@objectiv/tracker-core": "~0.0.9",
+    "@objectiv/transport-fetch": "^0.0.9",
+    "@objectiv/transport-xhr": "^0.0.9",
     "fast-deep-equal": "^3.1.3"
   },
   "peerDependencies": {

--- a/tracker/trackers/react/package.json
+++ b/tracker/trackers/react/package.json
@@ -68,6 +68,7 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
+    "@objectiv/plugin-http-context": "^0.0.9",
     "@objectiv/plugin-path-context-from-url": "^0.0.9",
     "@objectiv/plugin-root-location-context-from-url": "^0.0.9",
     "@objectiv/queue-local-storage": "^0.0.9",

--- a/tracker/trackers/react/src/common/factories/makeDefaultPluginsList.ts
+++ b/tracker/trackers/react/src/common/factories/makeDefaultPluginsList.ts
@@ -2,6 +2,7 @@
  * Copyright 2021-2022 Objectiv B.V.
  */
 
+import { HttpContextPlugin } from '@objectiv/plugin-http-context';
 import { PathContextFromURLPlugin } from '@objectiv/plugin-path-context-from-url';
 import { RootLocationContextFromURLPlugin } from '@objectiv/plugin-root-location-context-from-url';
 import { makeTrackerDefaultPluginsList, TrackerPluginInterface } from '@objectiv/tracker-core';
@@ -13,7 +14,10 @@ import { ReactTrackerConfig } from '../../ReactTracker';
 export const makeDefaultPluginsList = (trackerConfig: ReactTrackerConfig) => {
   const { trackPathContextFromURL = true, trackRootLocationContextFromURL = true } = trackerConfig;
 
-  const plugins: TrackerPluginInterface[] = [...makeTrackerDefaultPluginsList(trackerConfig)];
+  const plugins: TrackerPluginInterface[] = [
+    ...makeTrackerDefaultPluginsList(trackerConfig),
+    new HttpContextPlugin(trackerConfig),
+  ];
 
   if (trackPathContextFromURL) {
     plugins.push(new PathContextFromURLPlugin(trackerConfig));

--- a/tracker/trackers/react/tests/ReactTracker.test.ts
+++ b/tracker/trackers/react/tests/ReactTracker.test.ts
@@ -212,9 +212,13 @@ describe('BrowserTracker', () => {
 
       const trackedEvent = await testTracker.trackEvent(testEvent);
 
-      expect(trackedEvent.global_contexts).toHaveLength(2);
+      expect(trackedEvent.global_contexts).toHaveLength(3);
       expect(trackedEvent.global_contexts).toEqual(
         expect.arrayContaining([
+          expect.objectContaining({
+            _type: 'HttpContext',
+            id: 'http_context',
+          }),
           expect.objectContaining({
             _type: 'ApplicationContext',
             id: 'app-id',

--- a/tracker/transports/debug/package.json
+++ b/tracker/transports/debug/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/transport-debug",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "A TrackerTransport that logs incoming events to console.debug",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -52,7 +52,7 @@
     "npm-publish:verdaccio": "shx cp ../../verdaccio/.npmrc .npmrc && npm publish && shx rm -f .npmrc"
   },
   "devDependencies": {
-    "@objectiv/testing-tools": "^0.0.8",
+    "@objectiv/testing-tools": "^0.0.9",
     "@types/jest": "^27.0.3",
     "jest": "^27.4.5",
     "jest-standard-reporter": "^2.0.0",
@@ -63,6 +63,6 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "@objectiv/tracker-core": "~0.0.8"
+    "@objectiv/tracker-core": "~0.0.9"
   }
 }

--- a/tracker/transports/debug/package.json
+++ b/tracker/transports/debug/package.json
@@ -28,7 +28,7 @@
     }
   ],
   "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
+  "module": "./dist/esm/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"
@@ -36,12 +36,12 @@
   "exports": {
     ".": {
       "require": "./dist/index.js",
-      "import": "./dist/index.mjs",
+      "import": "./dist/esm/index.js",
       "types": "./dist/index.d.ts"
     }
   },
   "scripts": {
-    "build": "tsup src/index.ts --format cjs,esm --minify --dts --sourcemap --clean",
+    "build": "tsup src/index.ts --format cjs,esm --legacy-output --minify --dts --sourcemap --clean",
     "prettify": "prettier --write .",
     "tsc": "tsc --noEmit",
     "test": "jest --silent --runInBand",

--- a/tracker/transports/fetch/package.json
+++ b/tracker/transports/fetch/package.json
@@ -27,7 +27,7 @@
     }
   ],
   "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
+  "module": "./dist/esm/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"
@@ -35,12 +35,12 @@
   "exports": {
     ".": {
       "require": "./dist/index.js",
-      "import": "./dist/index.mjs",
+      "import": "./dist/esm/index.js",
       "types": "./dist/index.d.ts"
     }
   },
   "scripts": {
-    "build": "tsup src/index.ts --format cjs,esm --minify --dts --sourcemap --clean",
+    "build": "tsup src/index.ts --format cjs,esm --legacy-output --minify --dts --sourcemap --clean",
     "prettify": "prettier --write .",
     "tsc": "tsc --noEmit",
     "test": "jest --silent --runInBand",

--- a/tracker/transports/fetch/package.json
+++ b/tracker/transports/fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/transport-fetch",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "A TrackerTransport based on Fetch API",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -51,7 +51,7 @@
     "npm-publish:verdaccio": "shx cp ../../verdaccio/.npmrc .npmrc && npm publish && shx rm -f .npmrc"
   },
   "devDependencies": {
-    "@objectiv/testing-tools": "^0.0.8",
+    "@objectiv/testing-tools": "^0.0.9",
     "@types/jest": "^27.0.3",
     "jest": "^27.4.5",
     "jest-fetch-mock": "^3.0.3",
@@ -63,6 +63,6 @@
     "typescript": "^4.5.5"
   },
   "dependencies": {
-    "@objectiv/tracker-core": "~0.0.8"
+    "@objectiv/tracker-core": "~0.0.9"
   }
 }

--- a/tracker/transports/xhr/package.json
+++ b/tracker/transports/xhr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/transport-xhr",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "A TrackerTransport based on XMLHttpRequest API",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -52,7 +52,7 @@
     "npm-publish:verdaccio": "shx cp ../../verdaccio/.npmrc .npmrc && npm publish && shx rm -f .npmrc"
   },
   "devDependencies": {
-    "@objectiv/testing-tools": "^0.0.8",
+    "@objectiv/testing-tools": "^0.0.9",
     "@types/jest": "^27.0.3",
     "jest": "^27.4.5",
     "jest-standard-reporter": "^2.0.0",
@@ -64,6 +64,6 @@
     "xhr-mock": "^2.5.1"
   },
   "dependencies": {
-    "@objectiv/tracker-core": "~0.0.8"
+    "@objectiv/tracker-core": "~0.0.9"
   }
 }

--- a/tracker/transports/xhr/package.json
+++ b/tracker/transports/xhr/package.json
@@ -28,7 +28,7 @@
     }
   ],
   "main": "./dist/index.js",
-  "module": "./dist/index.mjs",
+  "module": "./dist/esm/index.js",
   "types": "./dist/index.d.ts",
   "files": [
     "dist"
@@ -36,12 +36,12 @@
   "exports": {
     ".": {
       "require": "./dist/index.js",
-      "import": "./dist/index.mjs",
+      "import": "./dist/esm/index.js",
       "types": "./dist/index.d.ts"
     }
   },
   "scripts": {
-    "build": "tsup src/index.ts --format cjs,esm --minify --dts --sourcemap --clean",
+    "build": "tsup src/index.ts --format cjs,esm --legacy-output --minify --dts --sourcemap --clean",
     "prettify": "prettier --write .",
     "tsc": "tsc --noEmit",
     "test": "jest --silent --runInBand",

--- a/tracker/yarn.lock
+++ b/tracker/yarn.lock
@@ -751,11 +751,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@objectiv/plugin-path-context-from-url@^0.0.8, @objectiv/plugin-path-context-from-url@workspace:plugins/path-context-from-url":
+"@objectiv/plugin-path-context-from-url@^0.0.9, @objectiv/plugin-path-context-from-url@workspace:plugins/path-context-from-url":
   version: 0.0.0-use.local
   resolution: "@objectiv/plugin-path-context-from-url@workspace:plugins/path-context-from-url"
   dependencies:
-    "@objectiv/testing-tools": ^0.0.8
+    "@objectiv/testing-tools": ^0.0.9
     "@types/jest": ^27.0.3
     jest: ^27.4.5
     jest-extended: ^1.1.0
@@ -768,15 +768,15 @@ __metadata:
     tsup: ^5.11.13
     typescript: ^4.5.5
   peerDependencies:
-    "@objectiv/tracker-core": ^0.0.8
+    "@objectiv/tracker-core": ^0.0.9
   languageName: unknown
   linkType: soft
 
-"@objectiv/plugin-root-location-context-from-url@^0.0.8, @objectiv/plugin-root-location-context-from-url@workspace:plugins/root-location-context-from-url":
+"@objectiv/plugin-root-location-context-from-url@^0.0.9, @objectiv/plugin-root-location-context-from-url@workspace:plugins/root-location-context-from-url":
   version: 0.0.0-use.local
   resolution: "@objectiv/plugin-root-location-context-from-url@workspace:plugins/root-location-context-from-url"
   dependencies:
-    "@objectiv/testing-tools": ^0.0.8
+    "@objectiv/testing-tools": ^0.0.9
     "@types/jest": ^27.0.3
     jest: ^27.4.5
     jest-extended: ^1.1.0
@@ -789,16 +789,16 @@ __metadata:
     tsup: ^5.11.13
     typescript: ^4.5.5
   peerDependencies:
-    "@objectiv/tracker-core": ^0.0.8
+    "@objectiv/tracker-core": ^0.0.9
   languageName: unknown
   linkType: soft
 
-"@objectiv/queue-local-storage@^0.0.8, @objectiv/queue-local-storage@workspace:queues/local-storage":
+"@objectiv/queue-local-storage@^0.0.9, @objectiv/queue-local-storage@workspace:queues/local-storage":
   version: 0.0.0-use.local
   resolution: "@objectiv/queue-local-storage@workspace:queues/local-storage"
   dependencies:
-    "@objectiv/testing-tools": ^0.0.8
-    "@objectiv/tracker-core": ~0.0.8
+    "@objectiv/testing-tools": ^0.0.9
+    "@objectiv/tracker-core": ~0.0.9
     "@types/jest": ^27.0.3
     jest: ^27.4.5
     jest-standard-reporter: ^2.0.0
@@ -810,7 +810,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@objectiv/schema@^0.0.8, @objectiv/schema@workspace:core/schema":
+"@objectiv/schema@^0.0.9, @objectiv/schema@workspace:core/schema":
   version: 0.0.0-use.local
   resolution: "@objectiv/schema@workspace:core/schema"
   dependencies:
@@ -820,7 +820,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@objectiv/testing-tools@^0.0.8, @objectiv/testing-tools@workspace:core/testing-tools":
+"@objectiv/testing-tools@^0.0.9, @objectiv/testing-tools@workspace:core/testing-tools":
   version: 0.0.0-use.local
   resolution: "@objectiv/testing-tools@workspace:core/testing-tools"
   dependencies:
@@ -836,7 +836,7 @@ __metadata:
     "@angular/compiler": ~9.1.13
     "@angular/compiler-cli": ~9.1.13
     "@angular/core": ~9.1.13
-    "@objectiv/tracker-browser": ^0.0.8
+    "@objectiv/tracker-browser": ^0.0.9
     ng-packagr: ^9.0.0
     prettier: ^2.5.1
     rxjs: ~6.5.4
@@ -847,22 +847,22 @@ __metadata:
   peerDependencies:
     "@angular/common": ^9.0.0
     "@angular/core": ^9.0.0
-    "@objectiv/tracker-browser": ^0.0.8
+    "@objectiv/tracker-browser": ^0.0.9
   languageName: unknown
   linkType: soft
 
-"@objectiv/tracker-browser@^0.0.8, @objectiv/tracker-browser@workspace:trackers/browser":
+"@objectiv/tracker-browser@^0.0.9, @objectiv/tracker-browser@workspace:trackers/browser":
   version: 0.0.0-use.local
   resolution: "@objectiv/tracker-browser@workspace:trackers/browser"
   dependencies:
-    "@objectiv/plugin-path-context-from-url": ^0.0.8
-    "@objectiv/plugin-root-location-context-from-url": ^0.0.8
-    "@objectiv/queue-local-storage": ^0.0.8
-    "@objectiv/testing-tools": ^0.0.8
-    "@objectiv/tracker-core": ^0.0.8
-    "@objectiv/transport-debug": ^0.0.8
-    "@objectiv/transport-fetch": ^0.0.8
-    "@objectiv/transport-xhr": ^0.0.8
+    "@objectiv/plugin-path-context-from-url": ^0.0.9
+    "@objectiv/plugin-root-location-context-from-url": ^0.0.9
+    "@objectiv/queue-local-storage": ^0.0.9
+    "@objectiv/testing-tools": ^0.0.9
+    "@objectiv/tracker-core": ^0.0.9
+    "@objectiv/transport-debug": ^0.0.9
+    "@objectiv/transport-fetch": ^0.0.9
+    "@objectiv/transport-xhr": ^0.0.9
     "@types/jest": ^27.0.3
     jest: ^27.4.5
     jest-fetch-mock: ^3.0.3
@@ -876,12 +876,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@objectiv/tracker-core@^0.0.8, @objectiv/tracker-core@workspace:core/tracker, @objectiv/tracker-core@~0.0.8":
+"@objectiv/tracker-core@^0.0.9, @objectiv/tracker-core@workspace:core/tracker, @objectiv/tracker-core@~0.0.9":
   version: 0.0.0-use.local
   resolution: "@objectiv/tracker-core@workspace:core/tracker"
   dependencies:
-    "@objectiv/schema": ^0.0.8
-    "@objectiv/testing-tools": ^0.0.8
+    "@objectiv/schema": ^0.0.9
+    "@objectiv/testing-tools": ^0.0.9
     "@types/jest": ^27.0.3
     jest: ^27.4.5
     jest-standard-reporter: ^2.0.0
@@ -899,13 +899,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@objectiv/tracker-react@workspace:trackers/react"
   dependencies:
-    "@objectiv/plugin-path-context-from-url": ^0.0.8
-    "@objectiv/plugin-root-location-context-from-url": ^0.0.8
-    "@objectiv/queue-local-storage": ^0.0.8
-    "@objectiv/testing-tools": ^0.0.8
-    "@objectiv/tracker-core": ~0.0.8
-    "@objectiv/transport-fetch": ^0.0.8
-    "@objectiv/transport-xhr": ^0.0.8
+    "@objectiv/plugin-path-context-from-url": ^0.0.9
+    "@objectiv/plugin-root-location-context-from-url": ^0.0.9
+    "@objectiv/queue-local-storage": ^0.0.9
+    "@objectiv/testing-tools": ^0.0.9
+    "@objectiv/tracker-core": ~0.0.9
+    "@objectiv/transport-fetch": ^0.0.9
+    "@objectiv/transport-xhr": ^0.0.9
     "@testing-library/react": ^12.1.2
     "@testing-library/react-hooks": ^7.0.2
     "@types/jest": ^27.0.3
@@ -928,12 +928,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@objectiv/transport-debug@^0.0.8, @objectiv/transport-debug@workspace:transports/debug":
+"@objectiv/transport-debug@^0.0.9, @objectiv/transport-debug@workspace:transports/debug":
   version: 0.0.0-use.local
   resolution: "@objectiv/transport-debug@workspace:transports/debug"
   dependencies:
-    "@objectiv/testing-tools": ^0.0.8
-    "@objectiv/tracker-core": ~0.0.8
+    "@objectiv/testing-tools": ^0.0.9
+    "@objectiv/tracker-core": ~0.0.9
     "@types/jest": ^27.0.3
     jest: ^27.4.5
     jest-standard-reporter: ^2.0.0
@@ -945,12 +945,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@objectiv/transport-fetch@^0.0.8, @objectiv/transport-fetch@workspace:transports/fetch":
+"@objectiv/transport-fetch@^0.0.9, @objectiv/transport-fetch@workspace:transports/fetch":
   version: 0.0.0-use.local
   resolution: "@objectiv/transport-fetch@workspace:transports/fetch"
   dependencies:
-    "@objectiv/testing-tools": ^0.0.8
-    "@objectiv/tracker-core": ~0.0.8
+    "@objectiv/testing-tools": ^0.0.9
+    "@objectiv/tracker-core": ~0.0.9
     "@types/jest": ^27.0.3
     jest: ^27.4.5
     jest-fetch-mock: ^3.0.3
@@ -963,12 +963,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@objectiv/transport-xhr@^0.0.8, @objectiv/transport-xhr@workspace:transports/xhr":
+"@objectiv/transport-xhr@^0.0.9, @objectiv/transport-xhr@workspace:transports/xhr":
   version: 0.0.0-use.local
   resolution: "@objectiv/transport-xhr@workspace:transports/xhr"
   dependencies:
-    "@objectiv/testing-tools": ^0.0.8
-    "@objectiv/tracker-core": ~0.0.8
+    "@objectiv/testing-tools": ^0.0.9
+    "@objectiv/tracker-core": ~0.0.9
     "@types/jest": ^27.0.3
     jest: ^27.4.5
     jest-standard-reporter: ^2.0.0

--- a/tracker/yarn.lock
+++ b/tracker/yarn.lock
@@ -751,6 +751,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@objectiv/plugin-http-context@^0.0.9, @objectiv/plugin-http-context@workspace:plugins/http-context":
+  version: 0.0.0-use.local
+  resolution: "@objectiv/plugin-http-context@workspace:plugins/http-context"
+  dependencies:
+    "@objectiv/testing-tools": ^0.0.9
+    "@types/jest": ^27.0.3
+    jest: ^27.4.5
+    jest-extended: ^1.1.0
+    jest-fetch-mock: ^3.0.3
+    jest-standard-reporter: ^2.0.0
+    jest-useragent-mock: ^0.1.1
+    prettier: ^2.5.1
+    shx: ^0.3.3
+    ts-jest: ^27.1.2
+    tsup: ^5.11.13
+    typescript: ^4.5.5
+  peerDependencies:
+    "@objectiv/tracker-core": ^0.0.9
+  languageName: unknown
+  linkType: soft
+
 "@objectiv/plugin-path-context-from-url@^0.0.9, @objectiv/plugin-path-context-from-url@workspace:plugins/path-context-from-url":
   version: 0.0.0-use.local
   resolution: "@objectiv/plugin-path-context-from-url@workspace:plugins/path-context-from-url"
@@ -855,6 +876,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@objectiv/tracker-browser@workspace:trackers/browser"
   dependencies:
+    "@objectiv/plugin-http-context": ^0.0.9
     "@objectiv/plugin-path-context-from-url": ^0.0.9
     "@objectiv/plugin-root-location-context-from-url": ^0.0.9
     "@objectiv/queue-local-storage": ^0.0.9
@@ -899,6 +921,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@objectiv/tracker-react@workspace:trackers/react"
   dependencies:
+    "@objectiv/plugin-http-context": ^0.0.9
     "@objectiv/plugin-path-context-from-url": ^0.0.9
     "@objectiv/plugin-root-location-context-from-url": ^0.0.9
     "@objectiv/queue-local-storage": ^0.0.9


### PR DESCRIPTION
Since we want to support Angular 9, I've enabled --legacy-output for Tsup. 

This changes the output from `./dist/index.mjs` to the old format `./dist/esm/index.js` and should resolve module loading issues for older bundlers and frameworks.

This PR contains also a brand new Plugin to generate HttpContexts automatically when the Tracker initializes. These contexts contain `referrer` and `user_agent` info and will be enriched further by the Collector with `remote_address`.

