### PR TITLE
Tracker: improvements and clean up

### DIFF
--- a/tracker/CONTRIBUTING.md
+++ b/tracker/CONTRIBUTING.md
@@ -19,19 +19,21 @@ The Objectiv JavaScript Tracker is composed of three workspaces.
 
 This is a complete list of the currently available packages.
 
-| Name                                   | Type      | Path                           | Links                                                      |
-|----------------------------------------|-----------|--------------------------------|------------------------------------------------------------|
-| @objectiv/schema                       | core      | /core/schema                   | [README](/tracker/core/schema/README.md)                   |
-| @objectiv/tracker-core                 | core      | /core/tracker                  | [README](/tracker/core/tracker/README.md)                  |
-| @objectiv/testing-tools                | core      | /core/testing-tools            | [README](/tracker/core/testing-tools/README.md)            |
-| @objectiv/utilities                    | core      | /core/utilities                | [README](/tracker/core/utilities/README.md)                |
-| @objectiv/plugin-path-context-from-url | plugin    | /plugins/path-context-from-url | [README](/tracker/plugins/path-context-from-url/README.md) |
-| @objectiv/tracker-angular              | tracker   | /trackers/angular              | [README](/tracker/trackers/angular/README.md)              |
-| @objectiv/tracker-browser              | tracker   | /trackers/browser              | [README](/tracker/trackers/browser/README.md)              |
-| @objectiv/tracker-react                | tracker   | /trackers/react                | [README](/tracker/trackers/react/README.md)                |
-| @objectiv/transport-debug              | transport | /transports/browser            | [README](/tracker/transports/debug/README.md)              |
-| @objectiv/transport-fetch              | transport | /transports/browser            | [README](/tracker/transports/fetch/README.md)              |
-| @objectiv/transport-xhr                | transport | /transports/browser            | [README](/tracker/transports/xhr/README.md)                |
+| Name                                            | Type      | Path                                    | Links                                                               |
+|-------------------------------------------------|-----------|-----------------------------------------|---------------------------------------------------------------------|
+| @objectiv/schema                                | core      | /core/schema                            | [README](/tracker/core/schema/README.md)                            |
+| @objectiv/tracker-core                          | core      | /core/tracker                           | [README](/tracker/core/tracker/README.md)                           |
+| @objectiv/testing-tools                         | core      | /core/testing-tools                     | [README](/tracker/core/testing-tools/README.md)                     |
+| @objectiv/utilities                             | core      | /core/utilities                         | [README](/tracker/core/utilities/README.md)                         |
+| @objectiv/http-context                          | plugin    | /plugins/http-context                   | [README](/tracker/plugins/http-context/README.md)                   | 
+| @objectiv/plugin-path-context-from-url          | plugin    | /plugins/path-context-from-url          | [README](/tracker/plugins/path-context-from-url/README.md)          |
+| @objectiv/plugin-root-location-context-from-url | plugin    | /plugins/root-location-context-from-url | [README](/tracker/plugins/root-location-context-from-url/README.md) |
+| @objectiv/tracker-angular                       | tracker   | /trackers/angular                       | [README](/tracker/trackers/angular/README.md)                       |
+| @objectiv/tracker-browser                       | tracker   | /trackers/browser                       | [README](/tracker/trackers/browser/README.md)                       |
+| @objectiv/tracker-react                         | tracker   | /trackers/react                         | [README](/tracker/trackers/react/README.md)                         |
+| @objectiv/transport-debug                       | transport | /transports/browser                     | [README](/tracker/transports/debug/README.md)                       |
+| @objectiv/transport-fetch                       | transport | /transports/browser                     | [README](/tracker/transports/fetch/README.md)                       |
+| @objectiv/transport-xhr                         | transport | /transports/browser                     | [README](/tracker/transports/xhr/README.md)                         |
 
 >Note: Packages may be completely independent of each other. Currently, many of them share the same testing framework or bundler but that's not required. Each has its own local configurations and may diverge if needed.
 

--- a/tracker/CONTRIBUTING.md
+++ b/tracker/CONTRIBUTING.md
@@ -213,6 +213,9 @@ Verifies if there are changes in the current branch and if a release strategy ha
 ### `yarn version apply --all`
 Executes the release strategy and bumps versions accordingly
 
+### `yarn version:patch`
+Patches all packages right away, without using version release strategies
+
 ## Troubleshooting
 
 #### `Error: Cannot find module '[...]/angular/node_modules/rollup/dist/rollup.js'`

--- a/tracker/package.json
+++ b/tracker/package.json
@@ -29,6 +29,7 @@
     "check:dependencies": "yarn workspaces foreach --parallel --exclude root --exclude @objectiv/tracker-angular --verbose run check:dependencies",
     "publish": "yarn workspaces foreach --exclude root --exclude @objectiv/utilities --exclude @objectiv/testing-tools --verbose run npm-publish",
     "publish:verdaccio": "yarn workspaces foreach --exclude root --exclude @objectiv/utilities --exclude @objectiv/testing-tools --verbose run npm-publish:verdaccio",
-    "utils:generate": "yarn workspace @objectiv/utilities generate && yarn prettify:generated && yarn tsc:generated"
+    "utils:generate": "yarn workspace @objectiv/utilities generate && yarn prettify:generated && yarn tsc:generated",
+    "version:patch": "yarn workspaces foreach --exclude root --verbose version patch && rm -rf .yarn/versions"
   }
 }

--- a/tracker/trackers/browser/src/BrowserTracker.ts
+++ b/tracker/trackers/browser/src/BrowserTracker.ts
@@ -29,8 +29,18 @@ import { BrowserTrackerConfig } from './definitions/BrowserTrackerConfig';
  *  const queueStorage = new LocalStorageQueueStore({ trackerId, console })
  *  const trackerQueue = new TrackerQueue({ storage: trackerStorage, console });
  *  const applicationContextPlugin = new ApplicationContextPlugin({ applicationId: 'app-id', console });
+ *  const httpContextPlugin = new HttpContextPlugin({ console });
  *  const pathContextFromURLPlugin = new PathContextFromURLPlugin({ console });
- *  const plugins = new TrackerPlugins({ plugins: [ applicationContextPlugin, pathContextFromURLPlugin ], console });
+ *  const rootLocationContextFromURLPlugin = new RootLocationContextFromURLPlugin({ console });
+ *  const plugins = new TrackerPlugins({
+ *    plugins: [
+ *      applicationContextPlugin,
+ *      httpContextPlugin,
+ *      pathContextFromURLPlugin,
+ *      rootLocationContextFromURLPlugin
+ *    ],
+ *    console
+ *  });
  *  const tracker = new Tracker({ transport, queue, plugins, console });
  *
  *  See also `makeDefaultTransport`, `makeDefaultQueue` and
@@ -64,7 +74,7 @@ export class BrowserTracker extends Tracker {
       config = {
         ...config,
         transport: makeDefaultTransport(config),
-        queue: makeDefaultQueue(config),
+        queue: config.queue ?? makeDefaultQueue(config),
       };
     }
 

--- a/tracker/trackers/browser/tests/BrowserTracker.test.ts
+++ b/tracker/trackers/browser/tests/BrowserTracker.test.ts
@@ -3,7 +3,13 @@
  */
 
 import { mockConsole } from '@objectiv/testing-tools';
-import { TrackerEvent, TrackerPlugins, TrackerQueue, TrackerTransportRetry } from '@objectiv/tracker-core';
+import {
+  TrackerEvent,
+  TrackerPlugins,
+  TrackerQueue,
+  TrackerQueueMemoryStore,
+  TrackerTransportRetry,
+} from '@objectiv/tracker-core';
 import { DebugTransport } from '@objectiv/transport-debug';
 import { defaultFetchFunction, FetchTransport } from '@objectiv/transport-fetch';
 import fetchMock from 'jest-fetch-mock';
@@ -89,13 +95,23 @@ describe('BrowserTracker', () => {
     });
   });
 
-  it('should instantiate with `transport`', () => {
+  it('should instantiate with given `transport`', () => {
     const testTracker = new BrowserTracker({
       applicationId: 'app-id',
       transport: new FetchTransport({ endpoint: 'localhost' }),
     });
     expect(testTracker).toBeInstanceOf(BrowserTracker);
     expect(testTracker.transport).toBeInstanceOf(FetchTransport);
+  });
+
+  it('should instantiate with given `queue`', () => {
+    const testTracker = new BrowserTracker({
+      applicationId: 'app-id',
+      endpoint: 'localhost',
+      queue: new TrackerQueue({ store: new TrackerQueueMemoryStore() }),
+    });
+    expect(testTracker).toBeInstanceOf(BrowserTracker);
+    expect(testTracker.queue?.store).toBeInstanceOf(TrackerQueueMemoryStore);
   });
 
   describe('env sensitive logic', () => {
@@ -163,6 +179,7 @@ describe('BrowserTracker', () => {
       expect(testTracker.plugins?.plugins).toEqual(
         expect.arrayContaining([
           expect.objectContaining({ pluginName: 'ApplicationContextPlugin' }),
+          expect.objectContaining({ pluginName: 'HttpContextPlugin' }),
           expect.objectContaining({ pluginName: 'PathContextFromURLPlugin' }),
           expect.objectContaining({ pluginName: 'RootLocationContextFromURLPlugin' }),
         ])
@@ -182,6 +199,7 @@ describe('BrowserTracker', () => {
       );
       expect(testTracker.plugins?.plugins).toEqual(
         expect.not.arrayContaining([
+          expect.objectContaining({ pluginName: 'HttpContextPlugin' }),
           expect.objectContaining({ pluginName: 'PathContextFromURLPlugin' }),
           expect.objectContaining({ pluginName: 'RootLocationContextFromURLPlugin' }),
         ])

--- a/tracker/trackers/react/src/ReactTracker.ts
+++ b/tracker/trackers/react/src/ReactTracker.ts
@@ -19,6 +19,11 @@ export type ReactTrackerConfig = TrackerConfig & {
   endpoint?: string;
 
   /**
+   * Optional. Whether to automatically create HttpContext based on Document and Navigation APIs. Enabled by default.
+   */
+  trackHttpContext?: boolean;
+
+  /**
    * Optional. Whether to automatically create PathContext based on URLs. Enabled by default.
    */
   trackPathContextFromURL?: boolean;
@@ -51,8 +56,18 @@ export type ReactTrackerConfig = TrackerConfig & {
  *  const queueStorage = new TrackerQueueLocalStorage({ trackerId, console })
  *  const trackerQueue = new TrackerQueue({ storage: trackerStorage, console });
  *  const applicationContextPlugin = new ApplicationContextPlugin({ applicationId: 'app-id', console });
+ *  const httpContextPlugin = new HttpContextPlugin({ console });
  *  const pathContextFromURLPlugin = new PathContextFromURLPlugin({ console });
- *  const plugins = new TrackerPlugins({ plugins: [ applicationContextPlugin, pathContextFromURLPlugin ], console });
+ *  const rootLocationContextFromURLPlugin = new RootLocationContextFromURLPlugin({ console });
+ *  const plugins = new TrackerPlugins({
+ *    plugins: [
+ *      applicationContextPlugin,
+ *      httpContextPlugin,
+ *      pathContextFromURLPlugin,
+ *      rootLocationContextFromURLPlugin
+ *      ],
+ *      console
+ *   });
  *  const tracker = new Tracker({ transport, queue, plugins, console });
  *
  *  @see makeDefaultTransport
@@ -83,7 +98,7 @@ export class ReactTracker extends Tracker {
       config = {
         ...config,
         transport: makeDefaultTransport(config),
-        queue: makeDefaultQueue(config),
+        queue: config.queue ?? makeDefaultQueue(config),
       };
     }
 

--- a/tracker/trackers/react/src/common/factories/makeDefaultPluginsList.ts
+++ b/tracker/trackers/react/src/common/factories/makeDefaultPluginsList.ts
@@ -12,12 +12,17 @@ import { ReactTrackerConfig } from '../../ReactTracker';
  * The default list of Plugins of React Tracker
  */
 export const makeDefaultPluginsList = (trackerConfig: ReactTrackerConfig) => {
-  const { trackPathContextFromURL = true, trackRootLocationContextFromURL = true } = trackerConfig;
+  const {
+    trackHttpContext = true,
+    trackPathContextFromURL = true,
+    trackRootLocationContextFromURL = true,
+  } = trackerConfig;
 
-  const plugins: TrackerPluginInterface[] = [
-    ...makeTrackerDefaultPluginsList(trackerConfig),
-    new HttpContextPlugin(trackerConfig),
-  ];
+  const plugins: TrackerPluginInterface[] = makeTrackerDefaultPluginsList(trackerConfig);
+
+  if (trackHttpContext) {
+    plugins.push(new HttpContextPlugin(trackerConfig));
+  }
 
   if (trackPathContextFromURL) {
     plugins.push(new PathContextFromURLPlugin(trackerConfig));

--- a/tracker/trackers/react/tests/ReactTracker.test.ts
+++ b/tracker/trackers/react/tests/ReactTracker.test.ts
@@ -3,7 +3,13 @@
  */
 
 import { mockConsole } from '@objectiv/testing-tools';
-import { TrackerEvent, TrackerPlugins, TrackerQueue, TrackerTransportRetry } from '@objectiv/tracker-core';
+import {
+  TrackerEvent,
+  TrackerPlugins,
+  TrackerQueue,
+  TrackerQueueMemoryStore,
+  TrackerTransportRetry,
+} from '@objectiv/tracker-core';
 import { DebugTransport } from '@objectiv/transport-debug';
 import { defaultFetchFunction, FetchTransport } from '@objectiv/transport-fetch';
 import fetchMock from 'jest-fetch-mock';
@@ -81,13 +87,23 @@ describe('BrowserTracker', () => {
     });
   });
 
-  it('should instantiate with `transport`', () => {
+  it('should instantiate with given `transport`', () => {
     const testTracker = new ReactTracker({
       applicationId: 'app-id',
       transport: new FetchTransport({ endpoint: 'localhost' }),
     });
     expect(testTracker).toBeInstanceOf(ReactTracker);
     expect(testTracker.transport).toBeInstanceOf(FetchTransport);
+  });
+
+  it('should instantiate with given `queue`', () => {
+    const testTracker = new ReactTracker({
+      applicationId: 'app-id',
+      endpoint: 'localhost',
+      queue: new TrackerQueue({ store: new TrackerQueueMemoryStore() }),
+    });
+    expect(testTracker).toBeInstanceOf(ReactTracker);
+    expect(testTracker.queue?.store).toBeInstanceOf(TrackerQueueMemoryStore);
   });
 
   describe('env sensitive logic', () => {
@@ -155,16 +171,18 @@ describe('BrowserTracker', () => {
       expect(testTracker.plugins?.plugins).toEqual(
         expect.arrayContaining([
           expect.objectContaining({ pluginName: 'ApplicationContextPlugin' }),
+          expect.objectContaining({ pluginName: 'HttpContextPlugin' }),
           expect.objectContaining({ pluginName: 'PathContextFromURLPlugin' }),
           expect.objectContaining({ pluginName: 'RootLocationContextFromURLPlugin' }),
         ])
       );
     });
 
-    it('should allow disabling PathContextFromURLPlugin and RootLocationContextFromURLPlugin', () => {
+    it('should allow disabling default plugins', () => {
       const testTracker = new ReactTracker({
         applicationId: 'app-id',
         endpoint: 'localhost',
+        trackHttpContext: false,
         trackPathContextFromURL: false,
         trackRootLocationContextFromURL: false,
       });
@@ -174,6 +192,7 @@ describe('BrowserTracker', () => {
       );
       expect(testTracker.plugins?.plugins).toEqual(
         expect.not.arrayContaining([
+          expect.objectContaining({ pluginName: 'HttpContextPlugin' }),
           expect.objectContaining({ pluginName: 'PathContextFromURLPlugin' }),
           expect.objectContaining({ pluginName: 'RootLocationContextFromURLPlugin' }),
         ])


### PR DESCRIPTION
A few chore items in here and some improvements:

- Updated tracker CONTRIBUTING.md with latest plugins and scripts.
- Added a new command to scripts for bulk patching all packages without going through yarn version releases.
- Update React and Browser Tracker docblocks with latest plugins.
- Added `trackHttpContext` option prop to React Tracker, default: true.
- React and Browser Tracker: it's now possible to specify a custom Queue without having to specify a custom Transport.
- Updated tests to verify HttpContext and new Queue configurability