### PR TITLE
Add more typing to Series

### DIFF
--- a/bach/bach/concat.py
+++ b/bach/bach/concat.py
@@ -282,10 +282,9 @@ class SeriesConcatOperation(ConcatOperation[Series]):
             all_names.append(series.name)
             dtypes.add(series.dtype)
 
-        main_series = self.objects[0].copy_override(
-            name='_'.join(all_names),
-            dtype=_get_merged_series_dtype(dtypes),
-        )
+        main_series = self.objects[0]\
+            .copy_override_dtype(dtype=_get_merged_series_dtype(dtypes))\
+            .copy_override(name='_'.join(all_names))
         return self._get_result_series([main_series])
 
     def _join_series_expressions(self, obj: Series) -> Expression:

--- a/bach/bach/dataframe.py
+++ b/bach/bach/dataframe.py
@@ -2112,10 +2112,9 @@ class DataFrame:
             # a hack in order to avoid calling quantile_df.materialized().
             # Currently doing quantile['q'] = qt
             # will raise some errors since the expression is not an instance of AggregateFunctionExpression
-            quantile_df['q'] = initial_series.copy_override(
-                dtype='float64',
-                expression=AggregateFunctionExpression.construct(fmt=f'{qt}'),
-            )
+            quantile_df['q'] = initial_series\
+                .copy_override_dtype(dtype='float64')\
+                .copy_override(expression=AggregateFunctionExpression.construct(fmt=f'{qt}'))
             all_quantile_dfs.append(quantile_df)
 
         from bach.concat import DataFrameConcatOperation

--- a/bach/bach/series/series.py
+++ b/bach/bach/series/series.py
@@ -152,7 +152,7 @@ class Series(ABC):
     def dtype_aliases(cls) -> Tuple[Union[Type, str], ...]:
         """
         INTERNAL: One or more aliases for the dtype.
-        For example a BooleanSeries might have dtype 'bool', and as an alias the string 'boolean' and
+        For example a SeriesBoolean might have dtype 'bool', and as an alias the string 'boolean' and
         the builtin `bool`. An alias can be used in a similar way as the real dtype, e.g. to cast data to a
         certain type: `x.astype('boolean')` is the same as `x.astype('bool')`.
 
@@ -376,7 +376,7 @@ class Series(ABC):
 
     def copy_override(
         self: T,
-        dtype: Optional[str] = None,
+        *,
         engine: Optional[Engine] = None,
         base_node: Optional[BachSqlModel] = None,
         index: Optional[Dict[str, 'Series']] = None,
@@ -395,8 +395,7 @@ class Series(ABC):
         if index and index_sorting is None:
             index_sorting = []
 
-        klass: type = self.__class__ if dtype is None else get_series_type_from_dtype(dtype)
-        return klass(
+        return self.__class__(
             engine=self._engine if engine is None else engine,
             base_node=self._base_node if base_node is None else base_node,
             index=self._index if index is None else index,
@@ -405,6 +404,29 @@ class Series(ABC):
             group_by=self._group_by if group_by is not_set else group_by,
             sorted_ascending=self._sorted_ascending if sorted_ascending is not_set else sorted_ascending,
             index_sorting=self._index_sorting if index_sorting is None else index_sorting
+        )
+
+    def copy_override_dtype(self, dtype: Optional[str]) -> 'Series':
+        """
+        INTERNAL: create an instance of the Series subtype with the given dtype, and copy
+        all values from self into that instance.
+        """
+        klass: Type['Series'] = get_series_type_from_dtype(self.dtype if dtype is None else dtype)
+        return self.copy_override_type(klass)
+
+    def copy_override_type(self, series_type: Type[T]) -> T:
+        """
+        INTERNAL: create an instance of the given Series subtype, copy all values from self.
+        """
+        return series_type(
+            engine=self._engine,
+            base_node=self._base_node,
+            index=self._index,
+            name=self._name,
+            expression=self._expression,
+            group_by=self._group_by,
+            sorted_ascending=self._sorted_ascending,
+            index_sorting=self._index_sorting
         )
 
     def unstack(self,
@@ -469,7 +491,12 @@ class Series(ABC):
         expression = self.expression.resolve_column_references(table_alias)
         return Expression.construct_expr_as_name(expression, self.name)
 
-    def _get_supported(self, operation_name: str, supported_dtypes: Tuple[str, ...], other: 'Series'):
+    def _get_supported(
+            self,
+            operation_name: str,
+            supported_dtypes: Tuple[str, ...],
+            other: 'Series'
+    ) -> Tuple['Series', 'Series']:
         """
         Check whether `other` is supported for this operation, and if not, possibly do something
         about it by using subquery / materialization / aligning base nodes using a merge.
@@ -487,7 +514,7 @@ class Series(ABC):
                     # todo now using private method from DataFrame. This will change to use merge, once this
                     #  type of 'index merge' works with that method.
                     df._index_merge(key='__other', value=other, how='outer')
-                    return df[self.name], df['__other']
+                    return cast('Series', df[self.name]), cast('Series', df['__other'])
                     # todo pandas: if name of both series are same, use that name of result. we always use
                     #  name of self
 
@@ -629,7 +656,7 @@ class Series(ABC):
         )
 
     @staticmethod
-    def as_independent_subquery(series, operation: str = None, dtype: str = None) -> 'Series':
+    def as_independent_subquery(series: 'Series', operation: str = None, dtype: str = None) -> 'Series':
         """
         INTERNAL: Get a series representing an independent subquery, created by materializing the series
         given and crafting a subquery expression from it, possibly adding the given operation.
@@ -655,7 +682,9 @@ class Series(ABC):
             # The expression is lost when materializing
             expr = SingleValueExpression(expr)
 
-        s = series.copy_override(expression=expr, dtype=dtype, index={}, group_by=None)
+        s = series\
+            .copy_override_dtype(dtype=dtype)\
+            .copy_override(expression=expr, index={}, group_by=None)
         return s
 
     def exists(self):
@@ -681,14 +710,15 @@ class Series(ABC):
         """
         return Series.as_independent_subquery(self, 'all')
 
-    def isin(self, other: 'Series'):
+    def isin(self, other: 'Series') -> 'SeriesBoolean':
         """
         Evaluate for every row in this series whether the value is contained in other
 
         Example: a.isin(b) evaluates to True for a specific row if a > b for all values of b.
         """
         in_expr = Expression.construct('{} {}', self, Series.as_independent_subquery(other, 'in'))
-        return self.copy_override(expression=in_expr, dtype='boolean')
+        from bach import SeriesBoolean
+        return self.copy_override_type(SeriesBoolean).copy_override(expression=in_expr)
 
     def astype(self, dtype: Union[str, Type]) -> 'Series':
         """
@@ -703,7 +733,7 @@ class Series(ABC):
         expression = series_type.dtype_to_expression(self.dtype, self.expression)
         # get the real dtype, in case the provided dtype was an alias. mypy needs some help
         new_dtype = cast(str, series_type.dtype)
-        return self.copy_override(dtype=new_dtype, expression=expression)
+        return self.copy_override_dtype(dtype=new_dtype).copy_override(expression=expression)
 
     def equals(self, other: Any, recursion: str = None) -> bool:
         """
@@ -752,7 +782,7 @@ class Series(ABC):
         # limit to 1 row, will make all series SingleValueExpression, and get that series.
         return frame[:1][self.name]
 
-    def isnull(self):
+    def isnull(self) -> 'SeriesBoolean':
         """
         Evaluate for every row in this series whether the value is missing or NULL.
 
@@ -769,9 +799,10 @@ class Series(ABC):
             expression_str,
             self
         )
-        return self.copy_override(dtype='bool', expression=expression)
+        from bach import SeriesBoolean
+        return self.copy_override_type(SeriesBoolean).copy_override(expression=expression)
 
-    def notnull(self):
+    def notnull(self) -> 'SeriesBoolean':
         """
         Evaluate for every row in this series whether the value is not missing or NULL.
 
@@ -788,7 +819,8 @@ class Series(ABC):
             expression_str,
             self
         )
-        return self.copy_override(dtype='bool', expression=expression)
+        from bach import SeriesBoolean
+        return self.copy_override_type(SeriesBoolean).copy_override(expression=expression)
 
     def fillna(self, other):
         """
@@ -811,7 +843,7 @@ class Series(ABC):
 
     def _binary_operation(self, other: 'Series', operation: str, fmt_str: str,
                           other_dtypes: Tuple[str, ...] = (),
-                          dtype: Union[str, Mapping[str, Optional[str]]] = None) -> 'Series':
+                          dtype: Union[str, None, Mapping[str, Optional[str]]] = None) -> 'Series':
         """
         The standard way to perform a binary operation
 
@@ -833,12 +865,18 @@ class Series(ABC):
         other = const_to_series(base=self, value=other)
         self_modified, other = self._get_supported(operation, other_dtypes, other)
         expression = NonAtomicExpression.construct(fmt_str, self_modified, other)
-        if isinstance(dtype, dict):
+        # if dtype is None or isinstance(dtype, str):
+        #
+        new_dtype: Optional[str]
+        if dtype is None or isinstance(dtype, str):
+            new_dtype = dtype
+        else:  # dtype is Mapping[str, Optional[str]]
             if other.dtype not in dtype:
-                dtype = None
+                new_dtype = None
             else:
-                dtype = dtype[other.dtype]
-        return self_modified.copy_override(dtype=dtype, expression=expression)
+                new_dtype = dtype[other.dtype]
+
+        return self_modified.copy_override_dtype(dtype=new_dtype).copy_override(expression=expression)
 
     def _arithmetic_operation(self, other: 'Series', operation: str, fmt_str: str,
                               other_dtypes: Tuple[str, ...] = (),
@@ -1127,21 +1165,23 @@ class Series(ABC):
                 # we're creating an aggregation on everything, this will yield one value
                 expression = SingleValueExpression(expression)
 
-            return self.copy_override(
-                dtype=derived_dtype,
-                index=partition.index,
-                group_by=partition,
-                expression=expression,
-                index_sorting=[],
-            )
+            return self\
+                .copy_override_dtype(dtype=derived_dtype)\
+                .copy_override(
+                    index=partition.index,
+                    group_by=partition,
+                    expression=expression,
+                    index_sorting=[],
+                )
         else:
             # The window expression already contains the full partition and sorting, no need
             # to keep that with this series, the expression can be used without any of those.
-            return self.copy_override(
-                dtype=derived_dtype,
-                group_by=None,
-                expression=partition.get_window_expression(expression),
-            )
+            return self\
+                .copy_override_dtype(dtype=derived_dtype)\
+                .copy_override(
+                    group_by=None,
+                    expression=partition.get_window_expression(expression),
+                )
 
     def count(self, partition: WrappedPartition = None, skipna: bool = True):
         # count is not constant because it depends on the number of rows in the selection.

--- a/bach/bach/series/series_datetime.py
+++ b/bach/bach/series/series_datetime.py
@@ -33,9 +33,7 @@ class DateTimeOperation:
         """
         expression = Expression.construct('to_char({}, {})',
                                           self._series, Expression.string_value(format_str))
-        str_series = self._series.copy_override(dtype='string', expression=expression)
-        # mypy assumes `self._series.copy_override` returns a SeriesAbstractDateTime
-        assert isinstance(str_series, SeriesString)
+        str_series = self._series.copy_override_type(SeriesString).copy_override(expression=expression)
         return str_series
 
 

--- a/bach/bach/series/series_json.py
+++ b/bach/bach/series/series_json.py
@@ -98,7 +98,7 @@ class SeriesJsonb(Series):
         """
         class with accessor methods to json(b) type data columns.
         """
-        def __init__(self, series_object):
+        def __init__(self, series_object: 'SeriesJsonb'):
             self._series_object = series_object
 
         def __getitem__(self, key: Union[str, int, slice]):
@@ -151,10 +151,9 @@ class SeriesJsonb(Series):
             Name: jsonb_column, dtype: object
             """
             if isinstance(key, int):
-                return self._series_object.copy_override(
-                    dtype=self._series_object.return_dtype,
-                    expression=Expression.construct(f'{{}}->{key}', self._series_object)
-                )
+                return self._series_object\
+                    .copy_override_dtype(dtype=self._series_object.return_dtype)\
+                    .copy_override(expression=Expression.construct(f'{{}}->{key}', self._series_object))
             elif isinstance(key, str):
                 return self.get_value(key)
             elif isinstance(key, slice):
@@ -195,12 +194,14 @@ class SeriesJsonb(Series):
                 from jsonb_array_elements({{}}) with ordinality x
                 where ordinality - 1 {where})"""
                 expression_references += 1
-                return self._series_object.copy_override(
-                    dtype=self._series_object.return_dtype,
-                    expression=Expression.construct(
-                        combined_expression,
-                        *([self._series_object] * expression_references)
-                    ))
+                return self._series_object\
+                    .copy_override_dtype(dtype=self._series_object.return_dtype)\
+                    .copy_override(
+                        expression=Expression.construct(
+                            combined_expression,
+                            *([self._series_object] * expression_references)
+                        )
+                    )
             raise TypeError(f'key should be int or slice, actual type: {type(key)}')
 
         def _find_in_json_list(self, key: Union[str, Dict[str, str]]):
@@ -229,7 +230,9 @@ class SeriesJsonb(Series):
             expression = Expression.construct(f"{{}}->{return_as_string_operator}{{}}",
                                               self._series_object,
                                               Expression.string_value(key))
-            return self._series_object.copy_override(dtype=return_dtype, expression=expression)
+            return self._series_object\
+                .copy_override_dtype(dtype=return_dtype)\
+                .copy_override(expression=expression)
 
     @property
     def json(self):

--- a/bach/bach/series/series_numeric.py
+++ b/bach/bach/series/series_numeric.py
@@ -158,7 +158,6 @@ class SeriesAbstractNumeric(Series, ABC):
             # Currently doing quantile['q'] = qt
             # will raise some errors since the expression is not an instance of AggregateFunctionExpression
             quantile_df['q'] = agg_result.copy_override(
-                dtype='float64',
                 expression=AggregateFunctionExpression.construct(fmt=f'{qt}'),
             )
             quantile_df.set_index('q', inplace=True)

--- a/bach/bach/series/series_string.py
+++ b/bach/bach/series/series_string.py
@@ -72,7 +72,7 @@ class StringOperation:
                     else:
                         expression = Expression.construct("''")
 
-        return self._base.copy_override(dtype='string', expression=expression)
+        return self._base.copy_override(expression=expression)
 
     def slice(self, start=None, stop=None) -> 'SeriesString':
         """

--- a/bach/bach/series/series_uuid.py
+++ b/bach/bach/series/series_uuid.py
@@ -76,4 +76,5 @@ class SeriesUuid(Series):
                                               self_modified,
                                               other)
 
-        return self_modified.copy_override(dtype='bool', expression=expression)
+        from bach import SeriesBoolean
+        return self_modified.copy_override_type(SeriesBoolean).copy_override(expression=expression)


### PR DESCRIPTION
* Added typing in a lot of places
* Removed `dtype` as parameter from `copy_override()`
  * Now the return type of `copy_override()` is actually `T`
  * Added new function `copy_override_type()` for the special case where we want to change the type
