### PR TITLE
Validate support optionals

### DIFF
--- a/backend/objectiv_backend/schema/event_schemas.py
+++ b/backend/objectiv_backend/schema/event_schemas.py
@@ -157,10 +157,12 @@ class EventSubSchema:
                     value['items']['type'] = 'object'
                 properties[key] = deepcopy(value)
 
+        # only add the property if it is required
+        required_properties = [p for p, v in properties.items() if not v.get('optional', False)]
         schema = {
             "type": "object",
             "properties": properties,
-            "required": sorted(properties.keys())
+            "required": sorted(required_properties)
         }
         return schema
 
@@ -297,10 +299,12 @@ class ContextSubSchema:
             class_properties = deepcopy(self.schema[klass].get("properties", {}))
             for key, value in class_properties.items():
                 properties[key] = deepcopy(value)
+
+        required_properties = [p for p, v in properties.items() if not v.get('optional', False)]
         schema = {
             "type": "object",
             "properties": properties,
-            "required": sorted(properties.keys())
+            "required": sorted(required_properties)
         }
         return schema
 

--- a/backend/objectiv_backend/schema/event_schemas.py
+++ b/backend/objectiv_backend/schema/event_schemas.py
@@ -157,7 +157,6 @@ class EventSubSchema:
                     value['items']['type'] = 'object'
                 properties[key] = deepcopy(value)
 
-        # only add the property if it is required
         required_properties = [p for p, v in properties.items() if not v.get('optional', False)]
         schema = {
             "type": "object",

--- a/backend/tests/schema/test_event_schema.py
+++ b/backend/tests/schema/test_event_schema.py
@@ -182,6 +182,11 @@ def test_get_context_schema():
             'other_property': {
                 'type': 'number',
                 'description': 'test other property'
+            },
+            'optional_property': {
+                'type': 'string',
+                'description': 'this property is optional',
+                'optional': True
             }
         },
         'required': ['extra_property', 'id', 'other_property'],
@@ -192,9 +197,19 @@ def test_get_context_schema():
     assert schema.get_context_schema('ExtraContext') == extra_context_json_schema
 
 
+def test_optional_property():
+    schema = _get_schema()
+
+    other_context = schema.get_context_schema("OtherContext")
+
+    # check optional property is there
+    assert other_context['properties']['optional_property']
+
+    # check optional property is not required
+    assert other_context['required'] == ['id', 'other_property']
+
+
 # ### Below are helper functions and test data
-
-
 def _get_schema() -> EventSchema:
 
     return EventSchema()\
@@ -248,6 +263,11 @@ _SIMPLE_BASE_SCHEMA = {
                 "other_property": {
                     "type": "number",
                     "description": "test other property"
+                },
+                "optional_property": {
+                    "type": "string",
+                    "description": "this property is optional",
+                    "optional": True
                 }
             }
         }


### PR DESCRIPTION
This add support for optionals in the validation. Basically, to make a context property optional, add `optional: True`

```
example:
"properties": {
        "referrer": {
          "description": "Full URL to HTTP referrer of the current page.",
          "type": "string",
          "optional": true
        }
}
```