### PR TITLE
Bach boolean min max

### DIFF
--- a/bach/bach/describe.py
+++ b/bach/bach/describe.py
@@ -5,7 +5,7 @@ from typing import Optional, Union, Sequence, List, Type, Tuple
 
 from bach import (
     DataFrame, SeriesString, SeriesAbstractNumeric, DataFrameOrSeries,
-    get_series_type_from_dtype, SeriesAbstractDateTime,
+    get_series_type_from_dtype, SeriesAbstractDateTime, SeriesBoolean,
 )
 from bach.concat import DataFrameConcatOperation
 from bach.expression import Expression
@@ -21,9 +21,8 @@ class SupportedStats(Enum):
     MODE = 'mode'
 
 
-# TODO: Remove this constant when boolean aggregations bug (min, max) is fixed.
 _SUPPORTED_SERIES_TYPES: Tuple[Type, ...] = (
-    SeriesAbstractNumeric, SeriesString, SeriesAbstractDateTime,
+    SeriesAbstractNumeric, SeriesString, SeriesAbstractDateTime, SeriesBoolean
 )
 
 

--- a/bach/bach/series/series_boolean.py
+++ b/bach/bach/series/series_boolean.py
@@ -6,6 +6,7 @@ from typing import cast
 
 from bach.series import Series, const_to_series
 from bach.expression import Expression
+from bach.series.series import WrappedPartition
 
 
 class SeriesBoolean(Series, ABC):
@@ -81,3 +82,9 @@ class SeriesBoolean(Series, ABC):
         # This only works if both type are 'bool' in PG, but if the rhs is not, it will be cast
         # explicitly in _boolean_operator()
         return self._boolean_operator(other, '!=')
+
+    def min(self, partition: WrappedPartition = None, skipna: bool = True):
+        return self._derived_agg_func(partition, 'bool_and', skipna=skipna)
+
+    def max(self, partition: WrappedPartition = None, skipna: bool = True):
+        return self._derived_agg_func(partition, 'bool_or', skipna=skipna)

--- a/bach/tests/functional/bach/test_df_describe.py
+++ b/bach/tests/functional/bach/test_df_describe.py
@@ -116,3 +116,28 @@ def test_describe_datetime() -> None:
         columns=['__stat', 'dt_column'],
     )
     pd.testing.assert_frame_equal(expected_df, result.to_pandas())
+
+
+def test_describe_boolean() -> None:
+    pdf = pd.DataFrame(
+        data=[
+            [True], [False], [True],
+        ],
+        columns=['dt_column'],
+    )
+    df = get_from_df(table='describe_table', df=pdf)
+
+    result = df.describe()
+    result = result.reset_index(drop=False)
+
+    expected_df = pd.DataFrame(
+        data=[
+            ['count', '3'],
+            ['min', 'false'],
+            ['max', 'true'],
+            ['nunique', '2'],
+            ['mode', 'true'],
+        ],
+        columns=['__stat', 'dt_column'],
+    )
+    pd.testing.assert_frame_equal(expected_df, result.to_pandas())

--- a/bach/tests/functional/bach/test_series_boolean.py
+++ b/bach/tests/functional/bach/test_series_boolean.py
@@ -1,6 +1,5 @@
 import numpy
 
-from bach import SeriesBoolean
 from tests.functional.bach.test_data_and_utils import get_bt_with_test_data, assert_equals_data
 
 
@@ -22,7 +21,7 @@ def test_to_pandas():
     bt['t'] = True
     bt['f'] = False
     bt[['t', 'f']].to_pandas()
-    numpy.testing.assert_array_equal(bt[['t', 'f']].to_numpy()[0] , [True, False])
+    numpy.testing.assert_array_equal(bt[['t', 'f']].to_numpy()[0], [True, False])
 
     
 def test_operations():
@@ -71,3 +70,28 @@ def test_operations():
         ]
     )
 
+
+def test_min_max():
+    df = get_bt_with_test_data()[['founding']]
+    df['mixed'] = df['founding'] < 1400
+    df['yes'] = True
+    df['no'] = False
+    assert_equals_data(
+        df,
+        expected_columns=['_index_skating_order', 'founding', 'mixed', 'yes', 'no'],
+        expected_data=[
+            [1, 1285, True, True, False],
+            [2, 1456, False, True, False],
+            [3, 1268, True, True, False]
+        ]
+    )
+    assert_equals_data(
+        df.min(),
+        expected_columns=['_index_skating_order_min', 'founding_min', 'mixed_min', 'yes_min', 'no_min'],
+        expected_data=[[1, 1268, False, True, False]]
+    )
+    assert_equals_data(
+        df.max(),
+        expected_columns=['_index_skating_order_max', 'founding_max', 'mixed_max', 'yes_max', 'no_max'],
+        expected_data=[[3, 1456, True, True, False]]
+    )


### PR DESCRIPTION
* Support for min() and max() on boolean series
  * min() gives False if there is at least one False in the column
  * max() gives True if there is at least one True in the column
* Enable boolean columns in describe()

This addresses part of issue https://github.com/objectiv/objectiv-analytics/issues/430