### PR TITLE
Bach series no mutations

### DIFF
--- a/bach/bach/dataframe.py
+++ b/bach/bach/dataframe.py
@@ -196,7 +196,11 @@ class DataFrame:
                                  f'df: {value.index}, series.index: {index}')
             if value.group_by != group_by:
                 raise ValueError(f'Group_by in `series` should match dataframe. '
-                                 f'df: {value.group_by}, series.index: {group_by}')
+                                 f'df: {group_by}, series.group_by: {value.group_by}')
+            if value.base_node != base_node:
+                raise ValueError(f'Base_node in `series` should match dataframe. '
+                                 f'df: {base_node}, series.base_node: {value.base_node}')
+
             self._data[key] = value
 
         for value in index.values():

--- a/bach/bach/series/series.py
+++ b/bach/bach/series/series.py
@@ -122,20 +122,6 @@ class Series(ABC):
         self._sorted_ascending = sorted_ascending
         self._index_sorting = index_sorting
 
-    def _update_self_from_series(self, series: 'Series') -> 'Series':
-        """
-        INTERNAL: Modify self by copying all properties of 'df' to self. Returns self.
-        """
-        self._engine = series._engine
-        self._base_node = series._base_node
-        self._index = series._index.copy()
-        self._name = series._name
-        self._expression = series._expression
-        self._group_by = series._group_by
-        self._sorted_ascending = series._sorted_ascending
-        self._index_sorting = series._index_sorting
-        return self
-
     @property
     @classmethod
     @abstractmethod
@@ -1359,11 +1345,7 @@ class Series(ABC):
         )()
         return describe_df.all_series[self.name]
 
-    def drop_duplicates(
-        self,
-        keep: Union[str, bool] = 'first',
-        inplace: bool = False,
-    ) -> Optional['Series']:
+    def drop_duplicates(self: T, keep: Union[str, bool] = 'first') -> T:
         """
         Return a series with duplicated rows removed.
 
@@ -1374,20 +1356,15 @@ class Series(ABC):
             * False: drops all duplicates
 
             If no value is provided, first occurrences will be kept by default.
-        :param inplace: Perform operation on self if ``inplace=True``, or create a copy.
 
-        :return: a new series with dropped duplicates if inplace = False, otherwise None.
+        :return: a new series with dropped duplicates
         """
         df = self.to_frame().drop_duplicates(keep=keep)
         assert isinstance(df, DataFrame)
         df.materialize(inplace=True)
 
         result = df.all_series[self.name]
-        if not inplace:
-            return result
-
-        self._update_self_from_series(result)
-        return None
+        return cast(T, result)
 
 
 def const_to_series(base: Union[Series, DataFrame],

--- a/bach/tests/functional/bach/test_series_drop_duplicates.py
+++ b/bach/tests/functional/bach/test_series_drop_duplicates.py
@@ -16,11 +16,6 @@ def test_series_basic_drop_duplicates() -> None:
     expected = p_series.drop_duplicates().sort_values()
     pd.testing.assert_series_equal(result.sort_values().to_pandas(), expected, check_names=False)
 
-    series_inplace = df.a.copy()
-    result_inplace = series_inplace.drop_duplicates(inplace=True)
-    assert result_inplace is None
-    pd.testing.assert_series_equal(series_inplace.sort_values().to_pandas(), expected, check_names=False)
-
 
 def test_series_keep_last_drop_duplicates() -> None:
     p_series = pd.Series(
@@ -33,11 +28,6 @@ def test_series_keep_last_drop_duplicates() -> None:
     result = df.a.drop_duplicates(keep='last')
     expected = p_series.drop_duplicates(keep='last').sort_values()
     pd.testing.assert_series_equal(result.sort_values().to_pandas(), expected, check_names=False)
-
-    series_inplace = df.a.copy()
-    result_inplace = series_inplace.drop_duplicates(keep='last', inplace=True)
-    assert result_inplace is None
-    pd.testing.assert_series_equal(series_inplace.sort_values().to_pandas(), expected, check_names=False)
 
 
 def test_series_drop_all_duplicates() -> None:

--- a/bach/tests/unit/bach/test_df.py
+++ b/bach/tests/unit/bach/test_df.py
@@ -24,6 +24,7 @@ def test__eq__():
     assert get_fake_df(['b', 'a'], ['c']) != get_fake_df(['a', 'b'], ['c'])
     # switched order data columns
     assert get_fake_df(['a'], ['b', 'c']) != get_fake_df(['a'], ['c', 'b'])
+
     left = get_fake_df(['a'], ['b', 'c'])
     right = get_fake_df(['a'], ['b', 'c'])
     assert left == right
@@ -42,6 +43,9 @@ def test__eq__():
     assert left != right
     left._order_by = [SortColumn(expression=Expression.column_reference('a'), asc=True)]
     assert left == right
+
+    # reset left, right
+    left, right = get_fake_df(['a'], ['b', 'c']),  get_fake_df(['a'], ['b', 'c'])
 
     left = left.set_variable('a', 1234)
     right = right.set_variable('a', '1234')

--- a/bach/tests/unit/bach/test_df.py
+++ b/bach/tests/unit/bach/test_df.py
@@ -1,8 +1,14 @@
 """
 Copyright 2021 Objectiv B.V.
 """
-from bach import SortColumn
+import pytest
+
+from bach import SortColumn, DataFrame
 from bach.expression import Expression
+from bach.partitioning import GroupBy
+from bach.savepoints import Savepoints
+from bach.sql_model import BachSqlModel
+from sql_models.model import CustomSqlModelBuilder
 from tests.unit.bach.util import get_fake_df
 
 
@@ -53,3 +59,96 @@ def test__eq__():
     left = left.set_variable('a', '1234')
     right = right.set_variable('a', 1234)
     assert left == right
+
+
+def test_init_conditions():
+    df = get_fake_df(['a'], ['b', 'c'])
+    df2 = get_fake_df(['a', 'b'], ['c', 'd'])
+    other_base_node = BachSqlModel.from_sql_model(
+        sql_model=CustomSqlModelBuilder('select * from y', name='base')(),
+        columns=('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h')
+    )
+
+    # Check that with 'normal' parameters the __init__ function does not complain
+    DataFrame(
+        engine=df.engine,
+        base_node=df.base_node,
+        index=df.index,
+        series=df.data,
+        group_by=None,
+        order_by=[],
+        savepoints=Savepoints()
+    )
+
+    # Now check that with wrong values __init__ raises ValueErrors
+    with pytest.raises(ValueError, match="Indices in `series` should match dataframe"):
+        DataFrame(
+            engine=df.engine,
+            base_node=df.base_node,
+            index=df2.index,
+            series=df.data,
+            group_by=None,
+            order_by=[],
+            savepoints=Savepoints()
+        )
+
+    with pytest.raises(ValueError, match="Keys in `series` should match the name of series"):
+        DataFrame(
+            engine=df.engine,
+            base_node=df.base_node,
+            index=df.index,
+            series={k + 'suffix': v for k, v in df.data.items()},
+            group_by=None,
+            order_by=[],
+            savepoints=Savepoints()
+        )
+
+    with pytest.raises(ValueError, match="Group_by in `series` should match dataframe"):
+        DataFrame(
+            engine=df.engine,
+            base_node=df.base_node,
+            index=df.index,
+            series=df.data,
+            group_by=GroupBy([df.b]),
+            order_by=[],
+            savepoints=Savepoints()
+        )
+
+    with pytest.raises(ValueError, match="Base_node in `series` should match dataframe"):
+        DataFrame(
+            engine=df.engine,
+            base_node=other_base_node,
+            index=df.index,
+            series=df.data,
+            group_by=None,
+            order_by=[],
+            savepoints=Savepoints()
+        )
+
+    # df2.c has an index of itself
+    other_index = {'a': df2.c}
+    with pytest.raises(ValueError, match="Index series can not have non-empty index property"):
+        DataFrame(
+            engine=df.engine,
+            base_node=df.base_node,
+            index=other_index,
+            series={k: v.copy_override(index=other_index) for k, v in df.data.items()},
+            group_by=None,
+            order_by=[],
+            savepoints=Savepoints()
+        )
+
+    other_index = {'b': df.index['a']}
+    with pytest.raises(ValueError,
+                       match="The names of the index series and data series should not intersect"):
+        DataFrame(
+            engine=df.engine,
+            base_node=df.base_node,
+            index=other_index,
+            series={k: v.copy_override(index=other_index) for k, v in df.data.items()},
+            group_by=None,
+            order_by=[],
+            savepoints=Savepoints()
+        )
+    # there are a few __init__ checks that we don't check here, as they are also checked when creating a
+    # Series object, and are thus hard to actually trigger.

--- a/bach/tests/unit/bach/util.py
+++ b/bach/tests/unit/bach/util.py
@@ -6,11 +6,20 @@ from typing import List, Dict, Union, cast
 from bach import get_series_type_from_dtype, DataFrame
 from bach.expression import Expression
 from bach.savepoints import Savepoints
+from bach.sql_model import BachSqlModel
+from sql_models.model import CustomSqlModelBuilder
 
 
-def get_fake_df(index_names: List[str], data_names: List[str], dtype: Union[str, Dict[str, str]] = 'int64'):
+def get_fake_df(
+        index_names: List[str],
+        data_names: List[str],
+        dtype: Union[str, Dict[str, str]] = 'int64'
+) -> DataFrame:
     engine = None
-    base_node = None
+    base_node = BachSqlModel.from_sql_model(
+        sql_model=CustomSqlModelBuilder('select * from x', name='base')(),
+        columns=('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h')
+    )
     if isinstance(dtype, str):
         dtype = {
             col_name: dtype


### PR DESCRIPTION
* Removes the `inplace` parameter for `Series.drop_duplicates()`
  * No deprecation schedule or anything. We only just introduced it, we still have very few users, it's broken.
* Added small check in `DataFrame.__init__()` to check that base_nodes of all series match the DataFrame's

This resolves issue https://github.com/objectiv/objectiv-analytics/issues/467

**Background**
Using `Series.drop_duplicates(inplace=True)` corrupts the state of any `DataFrame` that the series is part of: The `DataFrame`'s `base_node` will be different from the `Series`'s `base_node`. This might trigger problems later on.
Example (from https://github.com/objectiv/objectiv-analytics/issues/467):
```python
# Setup
from bach import DataFrame
from tests.functional.bach.test_data_and_utils import DB_TEST_URL
import sqlalchemy
import pandas as pd
import numpy as np

engine = sqlalchemy.create_engine(DB_TEST_URL)
pdf = pd.DataFrame({'a': [1, 2, 3, 4, 4, 4], 'b': [1, 2, 3, 4, 4, 5]})
df = DataFrame.from_pandas(engine=engine, df=pdf.reset_index(drop=False), convert_objects=True, materialization='table', if_exists='replace', name='name of the test table')
df = df.reset_index(drop=True)
df = df.drop(columns=['index'])

# Actual example
df['x'] = (df.a == df.b)  # OK
df.a.drop_duplicates(inplace=True)
df['x'] = (df.a == df.b)  # FAILS
```
