### PR TITLE
Correct Series.copy_override() return type to 'Series'

### DIFF
--- a/bach/bach/dataframe.py
+++ b/bach/bach/dataframe.py
@@ -2557,8 +2557,9 @@ class DataFrame:
             cases_fmt = f' + '.join([f'case when {{}} then 1 else 0 end'] * len(dropna_series))
             expression_fmt = f'{len(self.data_columns)} - ({cases_fmt}) < {thresh}'
 
-        drop_row_series = conditions[0].copy_override(
-            expression=Expression.construct(expression_fmt, *conditions),
+        drop_row_series = cast(
+            'SeriesBoolean',
+            conditions[0].copy_override(expression=Expression.construct(expression_fmt, *conditions))
         )
 
         dropna_df = self[~drop_row_series]

--- a/bach/bach/series/series.py
+++ b/bach/bach/series/series.py
@@ -382,7 +382,7 @@ class Series(ABC):
         if index and index_sorting is None:
             index_sorting = []
 
-        klass: type = self.__class__ if dtype is None else get_series_type_from_dtype(dtype)
+        klass: Type['Series'] = self.__class__ if dtype is None else get_series_type_from_dtype(dtype)
         return klass(
             engine=self._engine if engine is None else engine,
             base_node=self._base_node if base_node is None else base_node,

--- a/bach/bach/series/series_boolean.py
+++ b/bach/bach/series/series_boolean.py
@@ -70,7 +70,7 @@ class SeriesBoolean(Series, ABC):
 
     def __invert__(self) -> 'SeriesBoolean':
         expression = Expression.construct('NOT ({})', self)
-        return self.copy_override(expression=expression)
+        return cast('SeriesBoolean', self.copy_override(expression=expression))
 
     def __and__(self, other) -> 'SeriesBoolean':
         return self._boolean_operator(other, 'AND')

--- a/bach/bach/series/series_datetime.py
+++ b/bach/bach/series/series_datetime.py
@@ -46,9 +46,7 @@ class DateTimeOperation:
         """
         expression = Expression.construct('to_char({}, {})',
                                           self._series, Expression.string_value(format_str))
-        str_series = self._series.copy_override(dtype='string', expression=expression)
-        # mypy assumes `self._series.copy_override` returns a SeriesAbstractDateTime
-        assert isinstance(str_series, SeriesString)
+        str_series = cast('SeriesString', self._series.copy_override(dtype='string', expression=expression))
         return str_series
 
 

--- a/bach/bach/series/series_json.py
+++ b/bach/bach/series/series_json.py
@@ -98,7 +98,7 @@ class SeriesJsonb(Series):
         """
         class with accessor methods to json(b) type data columns.
         """
-        def __init__(self, series_object):
+        def __init__(self, series_object: 'SeriesJsonb'):
             self._series_object = series_object
 
         def __getitem__(self, key: Union[str, int, slice]):

--- a/bach/bach/series/series_numeric.py
+++ b/bach/bach/series/series_numeric.py
@@ -45,9 +45,10 @@ class SeriesAbstractNumeric(Series, ABC):
         Round the value of this series to the given amount of decimals.
         :param decimals: The amount of decimals to round to
         """
-        return self.copy_override(
-            expression=Expression.construct(f'round(cast({{}} as numeric), {decimals})', self)
-        )
+        result = self.copy_override(
+                expression=Expression.construct(f'round(cast({{}} as numeric), {decimals})', self)
+            )
+        return cast('SeriesAbstractNumeric', result)
 
     def _ddof_unsupported(self, ddof: Optional[int]):
         if ddof is not None and ddof != 1:

--- a/bach/bach/series/series_string.py
+++ b/bach/bach/series/series_string.py
@@ -1,7 +1,7 @@
 """
 Copyright 2021 Objectiv B.V.
 """
-from typing import Union, TYPE_CHECKING
+from typing import Union, TYPE_CHECKING, cast
 
 from bach.series import Series
 from bach.expression import Expression
@@ -72,7 +72,7 @@ class StringOperation:
                     else:
                         expression = Expression.construct("''")
 
-        return self._base.copy_override(dtype='string', expression=expression)
+        return cast('SeriesString', self._base.copy_override(dtype='string', expression=expression))
 
     def slice(self, start=None, stop=None) -> 'SeriesString':
         """

--- a/bach/bach/series/series_uuid.py
+++ b/bach/bach/series/series_uuid.py
@@ -1,12 +1,16 @@
 """
 Copyright 2021 Objectiv B.V.
 """
-from typing import Union
+from typing import Union, cast, TYPE_CHECKING
 from uuid import UUID
 
 from bach import DataFrameOrSeries
 from bach.series import Series, const_to_series
 from bach.expression import Expression
+
+
+if TYPE_CHECKING:
+    from bach.series import SeriesBoolean
 
 
 class SeriesUuid(Series):
@@ -66,7 +70,7 @@ class SeriesUuid(Series):
             group_by=None
         )
 
-    def _comparator_operation(self, other, comparator, other_dtypes=('uuid', 'string')):
+    def _comparator_operation(self, other, comparator, other_dtypes=('uuid', 'string')) -> 'SeriesBoolean':
         other = const_to_series(base=self, value=other)
         self_modified, other = self._get_supported(f"comparator '{comparator}'", other_dtypes, other)
         if other.dtype == 'uuid':
@@ -76,4 +80,4 @@ class SeriesUuid(Series):
                                               self_modified,
                                               other)
 
-        return self_modified.copy_override(dtype='bool', expression=expression)
+        return cast('SeriesBoolean', self_modified.copy_override(dtype='bool', expression=expression))


### PR DESCRIPTION
Alternative fix for `Series.copy_override()` signature. After discussions in https://github.com/objectiv/objectiv-analytics/pull/464