### PR TITLE
remove inplace from DataFrame

### DIFF
--- a/bach/bach/operations/concat.py
+++ b/bach/bach/operations/concat.py
@@ -142,13 +142,10 @@ class DataFrameConcatOperation(ConcatOperation[DataFrame]):
             if isinstance(obj, Series):
                 raise Exception('Cannot concat Series to DataFrame')
 
-            df = obj.copy()
-            if self.ignore_index:
-                df.reset_index(drop=True, inplace=True)
-
+            df = obj.copy() if not self.ignore_index else obj.reset_index(drop=True)
             # need to materialize in order to avoid further problems
             if df.group_by:
-                df.materialize(inplace=True)
+                df = df.materialize()
 
             dfs.append(df)
 
@@ -267,7 +264,7 @@ class SeriesConcatOperation(ConcatOperation[Series]):
 
             df = obj.to_frame()
             if df.group_by:
-                df.materialize(inplace=True)
+                df = df.materialize()
             series.append(df.all_series[obj.name])
 
         return series

--- a/bach/bach/operations/describe.py
+++ b/bach/bach/operations/describe.py
@@ -142,7 +142,7 @@ class DescribeOperation:
         describe_df = DataFrameConcatOperation(objects=all_stats_df)()
         describe_df = describe_df.sort_values(by=f'{self.STAT_SERIES_NAME}_position')
         describe_df = describe_df.round(decimals=self.RESULT_DECIMALS)
-        describe_df.set_index(self.STAT_SERIES_NAME, inplace=True)
+        describe_df = describe_df.set_index(self.STAT_SERIES_NAME)
 
         all_described_series = [
             series_name
@@ -177,17 +177,19 @@ class DescribeOperation:
         if not series_to_aggregate:
             return None
 
-        stat_df = self.df[series_to_aggregate]
-        assert isinstance(stat_df, DataFrame)
-        stat_df.reset_index(drop=True, inplace=True)
+        stat_df = self.df.copy_override(
+            series={
+                s: self.df.all_series[s].copy_override(index={})
+                for s in series_to_aggregate
+            }, index={}
 
+        )
         original_series_names = stat_df.data_columns
         stat_df = stat_df.agg(func=stat.value).materialize()
 
         # original column names should remain
-        stat_df.rename(
+        stat_df = stat_df.rename(
             columns=dict(zip(stat_df.data_columns, original_series_names)),
-            inplace=True,
         )
         stat_df[self.STAT_SERIES_NAME] = stat.value
         stat_df[f'{self.STAT_SERIES_NAME}_position'] = stat_position
@@ -198,14 +200,15 @@ class DescribeOperation:
         Returns dataframe containing percentiles per each numerical series.
         """
         # filter series that can perform the aggregation 'quantile' operation
-        series_to_aggregate = [
-            s for s in self.series_to_describe if hasattr(self.df.all_series[s], 'quantile')
-        ]
+        series_to_aggregate = {
+            s: self.df.all_series[s]
+            for s in self.series_to_describe if hasattr(self.df.all_series[s], 'quantile')
+        }
         if not series_to_aggregate:
             return None
 
-        percentile_df: DataFrame = self.df[series_to_aggregate]  # type: ignore
-        percentile_df.reset_index(drop=True, inplace=True)
+        percentile_df: DataFrame = self.df.copy_override(series=series_to_aggregate)
+        percentile_df = percentile_df.reset_index(drop=True)
 
         percentile_df = percentile_df.quantile(q=list(self.percentiles))
         has_q_index = 'q' in percentile_df.all_series
@@ -214,14 +217,14 @@ class DescribeOperation:
             col: col.replace('_quantile', '')
             for col in percentile_df.data_columns
         }
-        percentile_df.reset_index(drop=not has_q_index, inplace=True)
+        percentile_df = percentile_df.reset_index(drop=not has_q_index)
 
         if not has_q_index:
             percentile_df['q'] = self.percentiles[0]
 
         # original column names should remain
         columns_rename['q'] = self.STAT_SERIES_NAME
-        percentile_df.rename(columns=columns_rename, inplace=True)
+        percentile_df = percentile_df.rename(columns=columns_rename)
         current_position = len(SupportedStats)
 
         # SeriesFloat64 + int is not supported, need an expression

--- a/bach/bach/quantile.py
+++ b/bach/bach/quantile.py
@@ -43,7 +43,7 @@ def calculate_quantiles(
         quantile_df['q'] = agg_result.copy_override(
             expression=AggregateFunctionExpression.construct(fmt=f'{qt}'),
         )
-        quantile_df.set_index('q', inplace=True)
+        quantile_df = quantile_df.set_index('q')
         quantile_results.append(quantile_df.all_series[series.name])
 
     return SeriesConcatOperation(

--- a/bach/bach/series/series.py
+++ b/bach/bach/series/series.py
@@ -458,8 +458,7 @@ class Series(ABC):
             raise ValueError("index contains empty values, cannot be unstacked")
         name_series = self.name
         remaining_indexes = list(index_dict.keys())
-        df = self.to_frame()
-        df.reset_index(inplace=True)
+        df = self.to_frame().reset_index()
         df = df.groupby(remaining_indexes)
 
         series_dict = {}
@@ -1408,8 +1407,7 @@ class Series(ABC):
         :return: a new series with dropped duplicates
         """
         df = self.to_frame().drop_duplicates(keep=keep)
-        assert isinstance(df, DataFrame)
-        df.materialize(inplace=True)
+        df = df.materialize()
 
         result = df.all_series[self.name]
         return cast(T, result)
@@ -1418,7 +1416,7 @@ class Series(ABC):
         """
         Removes rows with missing values.
 
-        :return: a new series with dropped rows if inplace = False, otherwise None.
+        :return: a new series with dropped rows.
         """
         df = self.to_frame().dropna()
         assert isinstance(df, DataFrame)
@@ -1463,7 +1461,7 @@ class Series(ABC):
 
         assert isinstance(empty_bins_df, DataFrame)
         empty_bins_df['value_counts'] = 0
-        empty_bins_df.set_index(CutOperation.RANGE_SERIES_NAME, inplace=True)
+        empty_bins_df = empty_bins_df.set_index(CutOperation.RANGE_SERIES_NAME)
 
         # append empty bins with count 0, final result must show those ranges
         result = value_counts_result.append(empty_bins_df.all_series['value_counts'])

--- a/bach/tests/functional/bach/test_df.py
+++ b/bach/tests/functional/bach/test_df.py
@@ -47,14 +47,6 @@ def test_drop_items():
     with pytest.raises(KeyError):
         nbt.founding
 
-    nbt = bt.drop(columns=['founding'], inplace=True)
-    assert nbt is None
-    assert 'founding' not in bt.data.keys()
-
-    bt.drop(columns=['inhabitants', 'city'], inplace=True)
-    assert 'inhabitants' not in bt.data.keys()
-    assert 'city' not in bt.data.keys()
-
     with pytest.raises(KeyError):
         bt.drop(columns=['non existing column'])
 
@@ -168,7 +160,7 @@ def test_quantile_no_numeric_columns() -> None:
         },
     )
     bt = get_from_df('test_quantile', pdf)
-    bt.reset_index(drop=True, inplace=True)
+    bt = bt.reset_index(drop=True)
 
     with pytest.raises(ValueError, match=r'DataFrame has no series supporting'):
         bt.quantile()

--- a/bach/tests/functional/bach/test_df_drop_duplicates.py
+++ b/bach/tests/functional/bach/test_df_drop_duplicates.py
@@ -34,18 +34,6 @@ def test_df_basic_drop_duplicates() -> None:
     )
     pd.testing.assert_frame_equal(pdf.drop_duplicates(), result.to_pandas(), check_names=False)
 
-    df_inplace = df.copy()
-    result_inplace = df_inplace.drop_duplicates(inplace=True)
-    assert result_inplace is None
-
-    df_inplace = df_inplace.sort_index()
-    assert_equals_data(
-        df_inplace,
-        expected_columns=expected_pdf.columns.tolist(),
-        expected_data=expected_pdf.to_numpy().tolist(),
-    )
-    pd.testing.assert_frame_equal(pdf.drop_duplicates(), df_inplace.to_pandas(), check_names=False)
-
     result_w_ignore_index = df.drop_duplicates(ignore_index=True).sort_values(by='a')
     assert_equals_data(
         result_w_ignore_index,
@@ -90,18 +78,6 @@ def test_df_basic_w_subset_drop_duplicates() -> None:
     )
     pd.testing.assert_frame_equal(pdf.drop_duplicates(subset), result.to_pandas(), check_names=False)
 
-    df_inplace = df.copy()
-    result_inplace = df_inplace.drop_duplicates(subset=subset, inplace=True)
-    assert result_inplace is None
-
-    df_inplace = df_inplace.sort_index()
-    assert_equals_data(
-        df_inplace,
-        expected_columns=expected_pdf.columns.tolist(),
-        expected_data=expected_pdf.to_numpy().tolist(),
-    )
-    pd.testing.assert_frame_equal(pdf.drop_duplicates(subset), df_inplace.to_pandas(), check_names=False)
-
     result_w_ignore_index = df.drop_duplicates(subset=subset, ignore_index=True).sort_values(by='c')
     assert_equals_data(
         result_w_ignore_index,
@@ -144,18 +120,6 @@ def test_df_keep_last_drop_duplicates() -> None:
         result.to_pandas(),
         check_names=False,
     )
-
-    df_inplace = df.copy()
-    result_inplace = df_inplace.drop_duplicates(keep='last', inplace=True)
-    assert result_inplace is None
-
-    df_inplace = df_inplace.sort_index()
-    assert_equals_data(
-        df_inplace,
-        expected_columns=expected_df.columns.tolist(),
-        expected_data=expected_df.to_numpy().tolist(),
-    )
-    pd.testing.assert_frame_equal(pdf.drop_duplicates(keep='last'), df_inplace.to_pandas(), check_names=False)
 
     subset = ['a', 'b']
     result_w_ignore_index = df.drop_duplicates(keep='last', ignore_index=True).sort_values(by=subset)

--- a/bach/tests/functional/bach/test_df_dropna.py
+++ b/bach/tests/functional/bach/test_df_dropna.py
@@ -56,15 +56,6 @@ def test_basic_dropna() -> None:
         check_names=False,
     )
 
-    df_inplace = df.copy()
-    result_inplace = df_inplace.dropna(inplace=True)
-    assert result_inplace is None
-    assert_equals_data(
-        df_inplace,
-        expected_columns=['_index_0', 'name', 'toy', 'born'],
-        expected_data=[[1, 'Batman', 'Batmobile', pd.Timestamp("1940-04-25")]],
-    )
-
 
 def test_dropna_all() -> None:
     pdf = pd.DataFrame(DATA)
@@ -77,19 +68,6 @@ def test_dropna_all() -> None:
         check_names=False,
     )
 
-    df_inplace = df.copy()
-    result_inplace = df_inplace.dropna(how='all', inplace=True)
-    assert result_inplace is None
-    assert_equals_data(
-        df_inplace,
-        expected_columns=['_index_0', 'name', 'toy', 'born'],
-        expected_data=[
-            [0, 'Alfred', None, None],
-            [1, 'Batman', 'Batmobile', pd.Timestamp("1940-04-25")],
-            [2, 'Catwoman', 'Bullwhip', None],
-        ],
-    )
-
 
 def test_dropna_thresh() -> None:
     pdf = pd.DataFrame(DATA)
@@ -100,16 +78,4 @@ def test_dropna_thresh() -> None:
         pdf.dropna(thresh=2),
         result.to_pandas(),
         check_names=False,
-    )
-
-    df_inplace = df.copy()
-    result_inplace = df_inplace.dropna(thresh=2, inplace=True)
-    assert result_inplace is None
-    assert_equals_data(
-        df_inplace,
-        expected_columns=['_index_0', 'name', 'toy', 'born'],
-        expected_data=[
-            [1, 'Batman', 'Batmobile', pd.Timestamp("1940-04-25")],
-            [2, 'Catwoman', 'Bullwhip', None],
-        ],
     )

--- a/bach/tests/functional/bach/test_df_groupby.py
+++ b/bach/tests/functional/bach/test_df_groupby.py
@@ -594,7 +594,7 @@ def test_groupby_frame_split_recombine():
     assert btg1 == btg2
 
     # recombine from different parent with same grouping
-    btg2.drop(columns=['founding'], inplace=True)
+    btg2 = btg2.drop(columns=['founding'])
     btg2['founding'] = btg1b
     r2 = btg1a.sum()
     assert btg2 == btg1
@@ -632,7 +632,7 @@ def test_groupby_frame_split_recombine_aggregation_applied():
     r1 = inhabitants_sum.to_frame()
     r1['founding_sum'] = group1['founding'].sum()
     r1['founding_mean'] = founding_mean
-    r1.rename(columns={'inhabitants': 'inhabitants_sum'}, inplace=True)
+    r1 = r1.rename(columns={'inhabitants': 'inhabitants_sum'})
     assert r1.base_node == bt.base_node
 
     for r in [founding_inhabitants_sum, r1]:

--- a/bach/tests/functional/bach/test_df_reset_index.py
+++ b/bach/tests/functional/bach/test_df_reset_index.py
@@ -16,18 +16,12 @@ def test_reset_index_to_empty():
     assert list(rbt.index.keys()) == []
     assert '_index_skating_order' in rbt.data
 
-    # inplace
-    ipbt = get_bt_with_test_data()
-    ipbt.reset_index(inplace=True)
-    assert list(ipbt.index.keys()) == []
-    assert '_index_skating_order' in ipbt.data
-
     # drop
     dbt = bt.reset_index(drop=True)
     assert list(dbt.index.keys()) == []
     assert '_index_skating_order' not in bt.data
 
-    for r in [bt, rbt, ipbt, dbt]:
+    for r in [bt, rbt, dbt]:
         for s in r.index.values():
             assert(s.index == {})
         for s in r.data.values():
@@ -73,8 +67,6 @@ def test_set_index():
     assert '_index_skating_order' not in rbt.data
     sbt.head()  # check valid sql /df conversion
     rbt.head()
-
-    # we won't test inplace here, as that's done in test_reset_index_to_empty().
 
     # regular set
     with pytest.raises(ValueError,
@@ -167,20 +159,19 @@ def test_reset_index_materialize():
     assert list(bt.index.keys()) == ['municipality']
     assert list(rbt.index.keys()) == []
 
-
-    bt_copy = bt.copy()
-    bt_copy.reset_index(inplace=True)
-
-    for r in [bt, rbt, bt_copy]:
+    for r in [bt, rbt]:
         for s in r.index.values():
             assert(s.index == {})
         for s in r.data.values():
             assert(s.index == r.index)
 
-        assert_equals_data(r,
-                           expected_columns=['municipality', '_index_skating_order_sum',
-                                             'inhabitants_sum'],
-                           expected_data=[
-                               ['Leeuwarden', 1, 93485],
-                               ['Súdwest-Fryslân', 5, 36575]
-                           ])
+        assert_equals_data(
+            r,
+            expected_columns=[
+                'municipality', '_index_skating_order_sum', 'inhabitants_sum'
+            ],
+            expected_data=[
+                ['Leeuwarden', 1, 93485],
+                ['Súdwest-Fryslân', 5, 36575],
+            ],
+        )

--- a/bach/tests/functional/bach/test_df_sort_index.py
+++ b/bach/tests/functional/bach/test_df_sort_index.py
@@ -65,21 +65,3 @@ def test_index_sort_w_ascending():
             [1268, 'Drylts'],
         ],
     )
-
-
-def test_index_sort_w_inplace():
-    bt = get_bt_with_test_data()[['founding', 'city']]
-    bt = bt.set_index(['founding'], drop=True)
-
-    result = bt.sort_index(inplace=True, ascending=False)
-    assert result is None
-
-    assert_equals_data(
-        bt,
-        expected_columns=['founding', 'city'],
-        expected_data=[
-            [1456, 'Snits'],
-            [1285, 'Ljouwert'],
-            [1268, 'Drylts'],
-        ],
-    )

--- a/bach/tests/unit/bach/test_df_rename.py
+++ b/bach/tests/unit/bach/test_df_rename.py
@@ -45,16 +45,6 @@ def test_rename_swap():
     assert nbt.inhabitants.expression == expr_city
 
 
-def test_rename_inplace():
-    bt = get_fake_df_test_data()
-    expr = bt.founding.expression
-    nbt = bt.rename(columns={'founding': 'fnd'}, inplace=True)
-    assert nbt is None
-    assert 'founding' not in bt.data.keys()
-    assert 'fnd' in bt.data.keys()
-    assert bt.fnd.expression == expr
-
-
 def test_rename_multiple():
     bt = get_fake_df_test_data()
     nbt = bt.rename(columns={'founding': 'fnd', 'city': 'cty'})


### PR DESCRIPTION
Removed all `inplace` params from most of DataFrame's functions, except for `materialize`, as `set_savepoint` actually updates `self`.

## Checklist
- [X] Make sure all notebooks that use this are updated
- [X] Update tests
- [] Make sure that changelog is clear on this