### PR TITLE
use first series name as final name in concat, q-> quantile

### DIFF
--- a/bach/bach/dataframe.py
+++ b/bach/bach/dataframe.py
@@ -2126,9 +2126,9 @@ class DataFrame:
                 return quantile_df
 
             # a hack in order to avoid calling quantile_df.materialized().
-            # Currently doing quantile['q'] = qt
+            # Currently doing quantile['quantile'] = qt
             # will raise some errors since the expression is not an instance of AggregateFunctionExpression
-            quantile_df['q'] = initial_series\
+            quantile_df['quantile'] = initial_series\
                 .copy_override_dtype(dtype='float64')\
                 .copy_override(expression=AggregateFunctionExpression.construct(fmt=f'{qt}'))
             all_quantile_dfs.append(quantile_df)
@@ -2136,7 +2136,7 @@ class DataFrame:
         from bach.operations.concat import DataFrameConcatOperation
         result = DataFrameConcatOperation(objects=all_quantile_dfs, ignore_index=True)()
         # q column should be in the index when calculating multiple quantiles
-        return result.set_index('q')
+        return result.set_index('quantile')
 
     def nunique(self, axis=1, skipna=True, **kwargs):
         """

--- a/bach/bach/operations/concat.py
+++ b/bach/bach/operations/concat.py
@@ -278,10 +278,7 @@ class SeriesConcatOperation(ConcatOperation[Series]):
         """
         dtypes: Set[str] = set(series.dtype for series in self.objects)
 
-        main_series = (
-            self.objects[0]
-            .copy_override_dtype(dtype=_get_merged_series_dtype(dtypes))
-        )
+        main_series = self.objects[0].copy_override_dtype(dtype=_get_merged_series_dtype(dtypes))
         return self._get_result_series([main_series])
 
     def _join_series_expressions(self, obj: Series) -> Expression:

--- a/bach/bach/operations/concat.py
+++ b/bach/bach/operations/concat.py
@@ -276,18 +276,12 @@ class SeriesConcatOperation(ConcatOperation[Series]):
         """
         gets the final data series result
         """
-        all_names = []
-        dtypes: Set[str] = set()
+        dtypes: Set[str] = set(series.dtype for series in self.objects)
 
-        for series in self.objects:
-            if not isinstance(series, Series):
-                continue
-            all_names.append(series.name)
-            dtypes.add(series.dtype)
-
-        main_series = self.objects[0]\
-            .copy_override_dtype(dtype=_get_merged_series_dtype(dtypes))\
-            .copy_override(name='_'.join(all_names))
+        main_series = (
+            self.objects[0]
+            .copy_override_dtype(dtype=_get_merged_series_dtype(dtypes))
+        )
         return self._get_result_series([main_series])
 
     def _join_series_expressions(self, obj: Series) -> Expression:

--- a/bach/bach/operations/describe.py
+++ b/bach/bach/operations/describe.py
@@ -208,7 +208,7 @@ class DescribeOperation:
         percentile_df.reset_index(drop=True, inplace=True)
 
         percentile_df = percentile_df.quantile(q=list(self.percentiles))
-        has_q_index = 'q' in percentile_df.all_series
+        has_q_index = 'quantile' in percentile_df.all_series
 
         columns_rename = {
             col: col.replace('_quantile', '')
@@ -217,10 +217,10 @@ class DescribeOperation:
         percentile_df.reset_index(drop=not has_q_index, inplace=True)
 
         if not has_q_index:
-            percentile_df['q'] = self.percentiles[0]
+            percentile_df['quantile'] = self.percentiles[0]
 
         # original column names should remain
-        columns_rename['q'] = self.STAT_SERIES_NAME
+        columns_rename['quantile'] = self.STAT_SERIES_NAME
         percentile_df.rename(columns=columns_rename, inplace=True)
         current_position = len(SupportedStats)
 

--- a/bach/bach/quantile.py
+++ b/bach/bach/quantile.py
@@ -40,10 +40,10 @@ def calculate_quantiles(
         # a hack in order to avoid calling quantile_df.materialized().
         # Currently doing quantile['q'] = qt
         # will raise some errors since the expression is not an instance of AggregateFunctionExpression
-        quantile_df['q'] = agg_result.copy_override(
+        quantile_df['quantile'] = agg_result.copy_override(
             expression=AggregateFunctionExpression.construct(fmt=f'{qt}'),
         )
-        quantile_df.set_index('q', inplace=True)
+        quantile_df.set_index('quantile', inplace=True)
         quantile_results.append(quantile_df.all_series[series.name])
 
     return SeriesConcatOperation(

--- a/bach/tests/functional/bach/test_series_append.py
+++ b/bach/tests/functional/bach/test_series_append.py
@@ -11,7 +11,7 @@ def test_series_append_same_dtype() -> None:
 
     assert_equals_data(
         result.sort_values(),
-        expected_columns=['_index_skating_order', 'city_skating_order'],
+        expected_columns=['_index_skating_order', 'city'],
         expected_data=[
             [1, '1'],
             [2, '2'],
@@ -32,7 +32,7 @@ def test_series_append_different_dtype() -> None:
 
     assert_equals_data(
         result.sort_values(),
-        expected_columns=['_index_skating_order', 'city_founding'],
+        expected_columns=['_index_skating_order', 'city'],
         expected_data=[
             [3, '1268'],
             [1, '1285'],
@@ -48,7 +48,7 @@ def test_series_append_different_dtype() -> None:
 
     assert_equals_data(
         result2.sort_values(ascending=False),
-        expected_columns=['_index_skating_order', 'inhabitants_founding'],
+        expected_columns=['_index_skating_order', 'inhabitants'],
         expected_data=[
             [1, 93485.],
             [2, 33520.],
@@ -62,7 +62,7 @@ def test_series_append_different_dtype() -> None:
     result3 = bt.city.append([bt.founding, bt.inhabitants])
     assert_equals_data(
         result3.sort_values(),
-        expected_columns=['_index_skating_order', 'city_founding_inhabitants'],
+        expected_columns=['_index_skating_order', 'city'],
         expected_data=[
             [3, '1268'],
             [1, '1285'],
@@ -86,7 +86,7 @@ def test_series_ignore_index() -> None:
 
     assert_equals_data(
         result.sort_values(),
-        expected_columns=['city_skating_order'],
+        expected_columns=['city'],
         expected_data=[
             ['1'],
             ['2'],
@@ -108,7 +108,7 @@ def test_append_w_non_materialized_series() -> None:
 
     assert_equals_data(
         result.sort_values(),
-        expected_columns=['city', 'city_unique_skating_order'],
+        expected_columns=['city', 'city_unique'],
         expected_data=[
             ['Ljouwert', '1'],
             ['Snits', '2'],


### PR DESCRIPTION
SeriesConcatOperation was using all appended series names as name, which generated problems due to long names. Now it uses only the first series name in the operation. Also renamed "q" index to -> "quantile".