### PR TITLE
stack implementation

### DIFF
--- a/bach/bach/dataframe.py
+++ b/bach/bach/dataframe.py
@@ -2775,12 +2775,12 @@ class DataFrame:
         """
         df = self.copy()
         if df.group_by:
-            df = df.materialize()
+            df = df.materialize('stack')
 
         dc_dfs = []
         # convert each data column series to DataFrame and use series name as new index value
-        for series_name, series in df._data.items():
-            dc_df = df.all_series[series_name].copy_override(name='__stacked').to_frame()
+        for series_name, series in df.data.items():
+            dc_df = series.copy_override(name='__stacked').to_frame()
             dc_df['__stacked_index'] = series_name
             dc_dfs.append(dc_df)
 

--- a/bach/bach/dataframe.py
+++ b/bach/bach/dataframe.py
@@ -2768,8 +2768,8 @@ class DataFrame:
             at least an index series, this might generate different combinations between
             the index and the stacked values.
 
-        :return: a reshaped series that includes a new index containing the caller's column labels as values.
-
+        :return: a reshaped series that includes a new index (named "__stacked_index")
+            containing the caller's column labels as values.
         .. note::
             ``level`` parameter is not supported since multilevel columns are not allowed.
         """

--- a/bach/docs/source/DataFrame.rst
+++ b/bach/docs/source/DataFrame.rst
@@ -162,6 +162,7 @@ Reshaping, indexing, sorting & merging
     DataFrame.fillna
     DataFrame.ffill
     DataFrame.bfill
+    DataFrame.stack
 
 Aggregation & windowing
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/bach/tests/functional/bach/test_df_stack.py
+++ b/bach/tests/functional/bach/test_df_stack.py
@@ -62,3 +62,27 @@ def test_stack() -> None:
         ],
     )
 
+
+def test_stack_diff_types() -> None:
+    bt = get_bt_with_test_data(full_data_set=False)[['city', 'inhabitants']]
+    pbt = bt.to_pandas()
+
+    result = bt.stack().sort_index()
+    pd.testing.assert_series_equal(
+        pbt.stack().sort_index().astype(str),
+        result.to_pandas(),
+        check_names=False,
+    )
+
+    assert_equals_data(
+        result,
+        expected_columns=['_index_skating_order', '__stacked_index', '__stacked'],
+        expected_data=[
+            [1, 'city', 'Ljouwert'],
+            [1, 'inhabitants', '93485'],
+            [2, 'city', 'Snits'],
+            [2, 'inhabitants', '33520'],
+            [3, 'city', 'Drylts'],
+            [3, 'inhabitants', '3055'],
+        ],
+    )

--- a/bach/tests/functional/bach/test_df_stack.py
+++ b/bach/tests/functional/bach/test_df_stack.py
@@ -1,0 +1,56 @@
+import pandas as pd
+import pytest
+
+from tests.functional.bach.test_data_and_utils import get_bt_with_test_data, assert_equals_data
+
+
+def test_stack() -> None:
+    bt = get_bt_with_test_data(full_data_set=True)[['city', 'municipality', 'inhabitants']]
+    bt = bt.groupby(['municipality', 'city'])['inhabitants'].sum()
+
+    unstacked_bt = bt.unstack()
+
+    pbt = unstacked_bt.to_pandas()
+    expected = pbt.stack()
+    result = unstacked_bt.stack()
+
+    pd.testing.assert_series_equal(
+        expected.sort_index(),
+        result.sort_index().to_pandas(),
+        check_names=False,
+        check_dtype=False,
+    )
+    assert_equals_data(
+        result.sort_index(),
+        expected_columns=['municipality', '__stacked_index', '__stacked'],
+        expected_data=[
+            ['De Friese Meren', 'Sleat', 700],
+            ['Harlingen', 'Harns', 14740],
+            ['Leeuwarden', 'Ljouwert', 93485],
+            ['Noardeast-Fryslân', 'Dokkum', 12675],
+            ['Súdwest-Fryslân', 'Boalsert', 10120],
+            ['Súdwest-Fryslân', 'Drylts', 3055],
+            ['Súdwest-Fryslân', 'Hylpen', 870],
+            ['Súdwest-Fryslân', 'Snits', 33520],
+            ['Súdwest-Fryslân', 'Starum', 960],
+            ['Súdwest-Fryslân', 'Warkum', 4440],
+            ['Waadhoeke', 'Frjentsjer', 12760],
+        ],
+    )
+
+    expected_w_na = pbt.stack(dropna=False)
+    result_w_na = unstacked_bt.stack(dropna=False)
+    pd.testing.assert_series_equal(
+        expected_w_na.sort_index(),
+        result_w_na.sort_index().to_pandas(),
+        check_names=False,
+        check_dtype=False,
+    )
+
+
+def test_stack_error() -> None:
+    bt = get_bt_with_test_data(full_data_set=True)[['city', 'municipality', 'inhabitants']]
+    bt = bt.set_index(['city', 'municipality'])['inhabitants'].unstack()
+
+    with pytest.raises(NotImplementedError, match='column axis supports only one level.'):
+        bt.stack(level=0)

--- a/bach/tests/functional/bach/test_df_stack.py
+++ b/bach/tests/functional/bach/test_df_stack.py
@@ -38,19 +38,27 @@ def test_stack() -> None:
         ],
     )
 
-    expected_w_na = pbt.stack(dropna=False)
-    result_w_na = unstacked_bt.stack(dropna=False)
+    stacked_bt_w_na = unstacked_bt['Snits'].to_frame()
+    expected_w_na = pbt[['Snits']].stack(dropna=False)
+    result_w_na = stacked_bt_w_na.stack(dropna=False)
     pd.testing.assert_series_equal(
         expected_w_na.sort_index(),
-        result_w_na.sort_index().to_pandas(),
+        # TODO: fix sorting with a constant
+        result_w_na.to_frame().sort_index(level=0).to_pandas()['__stacked'],
         check_names=False,
         check_dtype=False,
     )
 
+    assert_equals_data(
+        result_w_na.to_frame().sort_index(level=0),
+        expected_columns=['municipality', '__stacked_index', '__stacked'],
+        expected_data=[
+            ['De Friese Meren', 'Snits', None],
+            ['Harlingen', 'Snits', None],
+            ['Leeuwarden', 'Snits', None],
+            ['Noardeast-Fryslân', 'Snits', None],
+            ['Súdwest-Fryslân', 'Snits', 33520],
+            ['Waadhoeke', 'Snits', None],
+        ],
+    )
 
-def test_stack_error() -> None:
-    bt = get_bt_with_test_data(full_data_set=True)[['city', 'municipality', 'inhabitants']]
-    bt = bt.set_index(['city', 'municipality'])['inhabitants'].unstack()
-
-    with pytest.raises(NotImplementedError, match='column axis supports only one level.'):
-        bt.stack(level=0)

--- a/bach/tests/functional/bach/test_series.py
+++ b/bach/tests/functional/bach/test_series.py
@@ -491,7 +491,7 @@ def test_series_dropna() -> None:
 def test_series_unstack():
     bt = get_bt_with_test_data(full_data_set=True)
     bt['municipality_none'] = bt[bt.skating_order < 10].municipality
-    stacked_bt = bt.groupby(['city','municipality_none']).inhabitants.sum()
+    stacked_bt = bt.groupby(['city', 'municipality_none']).inhabitants.sum()
 
     with pytest.raises(Exception, match='index contains empty values, cannot be unstacked'):
         stacked_bt.unstack()


### PR DESCRIPTION
In order to implement `DataFrame.loc`, `DataFrame.stack`, since from cases (accessing index value), the DataFrame's columns are stacked into a new index.