### PR TITLE
fix non-deterministic sorting in tests

### DIFF
--- a/analysis/bach_open_taxonomy/tests_bach_open_taxonomy/functional/objectiv_bach/test_model_hub.py
+++ b/analysis/bach_open_taxonomy/tests_bach_open_taxonomy/functional/objectiv_bach/test_model_hub.py
@@ -16,19 +16,18 @@ def test_get_objectiv_stack():
 def test_filter():
     df = get_objectiv_frame()
     fdf = df.mh.filter(df.session_id == df[df.session_id<=4].session_id).session_id
-
     assert_equals_data(
         fdf,
         expected_columns=['event_id', 'session_id'],
         expected_data=[
+            [UUID('12b55ed5-4295-4fc1-bf1f-88d64d1ac301'), 3],
+            [UUID('12b55ed5-4295-4fc1-bf1f-88d64d1ac302'), 3],
+            [UUID('12b55ed5-4295-4fc1-bf1f-88d64d1ac303'), 3],
             [UUID('12b55ed5-4295-4fc1-bf1f-88d64d1ac304'), 2],
             [UUID('12b55ed5-4295-4fc1-bf1f-88d64d1ac305'), 4],
             [UUID('12b55ed5-4295-4fc1-bf1f-88d64d1ac306'), 4],
             [UUID('12b55ed5-4295-4fc1-bf1f-88d64d1ac311'), 1],
-            [UUID('12b55ed5-4295-4fc1-bf1f-88d64d1ac312'), 1],
-            [UUID('12b55ed5-4295-4fc1-bf1f-88d64d1ac301'), 3],
-            [UUID('12b55ed5-4295-4fc1-bf1f-88d64d1ac302'), 3],
-            [UUID('12b55ed5-4295-4fc1-bf1f-88d64d1ac303'), 3]
+            [UUID('12b55ed5-4295-4fc1-bf1f-88d64d1ac312'), 1]
         ]
     )
 

--- a/bach/tests/functional/bach/test_data_and_utils.py
+++ b/bach/tests/functional/bach/test_data_and_utils.py
@@ -207,6 +207,8 @@ def assert_equals_data(
 
     if order_by:
         bt = bt.sort_values(order_by)
+    elif not bt.order_by:
+        bt = bt.sort_index()
 
     if not use_to_pandas:
         column_names, db_values = _get_view_sql_data(bt)

--- a/bach/tests/functional/bach/test_df_fillna.py
+++ b/bach/tests/functional/bach/test_df_fillna.py
@@ -56,6 +56,7 @@ def test_fillna_w_methods() -> None:
     result_ffill = df.fillna(
         method='ffill', sort_by=['A', 'B', 'C'], ascending=[False, True, False],
     )
+    result_ffill = result_ffill.sort_values(['A', 'B', 'C'], ascending=[False, True, False])
     assert_equals_data(
         result_ffill,
         expected_columns=['_index_0', 'A', 'B', 'C', 'D', 'E', 'F', 'G'],

--- a/bach/tests/functional/bach/test_df_merge.py
+++ b/bach/tests/functional/bach/test_df_merge.py
@@ -347,12 +347,12 @@ def test_merge_outer_join():
         expected_data=[
             [1, 1, 1, 'Ljouwert', 'IJlst', 1],
             [1, 2, 1, 'Ljouwert', 'Heerenveen', 1],
-            [2, 3, 2, 'Snits', 'Heerenveen IJsstadion', 2],
-            [None, 4, None, None, 'Leeuwarden', 4],
             [1, 5, 1, 'Ljouwert', 'Camminghaburen', 1],
+            [2, 3, 2, 'Snits', 'Heerenveen IJsstadion', 2],
             [2, 6, 2, 'Snits', 'Sneek', 2],
             [2, 7, 2, 'Snits', 'Sneek Noord', 2],
             [3, None, 3, 'Drylts', None, None],
+            [None, 4, None, None, 'Leeuwarden', 4],
         ],
     )
 
@@ -371,8 +371,8 @@ def test_merge_outer_join_shared_on() -> None:
             'city',
         ],
         expected_data=[
-            [None, 1, 1, 'Ljouwert'],
             [2, 2, 2, 'Snits'],
+            [None, 1, 1, 'Ljouwert'],
             [None, 3, 3, 'Drylts'],
         ],
     )

--- a/bach/tests/functional/bach/test_df_setitem.py
+++ b/bach/tests/functional/bach/test_df_setitem.py
@@ -252,17 +252,18 @@ def test_set_different_group_by():
         bt_g,
         expected_columns=['city', 'inhabitants_max', 'founding_max', 'a'],
         expected_data=[
-            ['Harns', 14740, 1234, None],
-            ['Dokkum', 12675, 1298, None],
-            ['Snits', 33520, 1456, 2],
             ['Boalsert', 10120, 1455, None],
+            ['Dokkum', 12675, 1298, None],
+            ['Drylts', 3055, 1268, 1],
+            ['Frjentsjer', 12760, 1374, None],
+            ['Harns', 14740, 1234, None],
+            ['Hylpen', 870, 1225, None],
+            ['Ljouwert', 93485, 1285, 2],
+            ['Sleat', 700, 1426, None],
+            ['Snits', 33520, 1456, 2],
             ['Starum', 960, 1061, None],
             ['Warkum', 4440, 1399, None],
-            ['Sleat', 700, 1426, None],
-            ['Ljouwert', 93485, 1285, 2],
-            ['Frjentsjer', 12760, 1374, None],
-            ['Drylts', 3055, 1268, 1],
-            ['Hylpen', 870, 1225, None]
+
         ]
     )
 

--- a/bach/tests/functional/bach/test_series.py
+++ b/bach/tests/functional/bach/test_series.py
@@ -278,9 +278,12 @@ def test_unique():
         uq,
         expected_columns=['municipality', 'municipality_unique'],
         expected_data=[
-            ['Noardeast-Fryslân', 'Noardeast-Fryslân'], ['Leeuwarden', 'Leeuwarden'],
-            ['Súdwest-Fryslân', 'Súdwest-Fryslân'], ['Harlingen', 'Harlingen'], ['Waadhoeke', 'Waadhoeke'],
-            ['De Friese Meren', 'De Friese Meren']
+            ['De Friese Meren', 'De Friese Meren'],
+            ['Harlingen', 'Harlingen'],
+            ['Leeuwarden', 'Leeuwarden'],
+            ['Noardeast-Fryslân', 'Noardeast-Fryslân'],
+            ['Súdwest-Fryslân', 'Súdwest-Fryslân'],
+            ['Waadhoeke', 'Waadhoeke'],
         ]
     )
 

--- a/bach/tests/functional/bach/test_series_describe.py
+++ b/bach/tests/functional/bach/test_series_describe.py
@@ -17,10 +17,10 @@ def test_categorical_describe() -> None:
         ],
         expected_data=[
             ['count', '3'],
-            ['min', 'Drylts'],
             ['max', 'Snits'],
-            ['nunique', '3'],
+            ['min', 'Drylts'],
             ['mode', 'Drylts'],
+            ['nunique', '3'],
         ],
     )
 


### PR DESCRIPTION
In most tests we didn't force a certain sorting. This PR makes it so that `assert_equals_data()` always sorts the data. Forcing a sorting changed the sorting of result data for some tests with Postgres; those tests are fixed too.

This should get rid of a lot of non-determinism in tests, but probably doesn't fix everything. 