### PR TITLE
Use react-native-get-random-values polyfill for React Native Tracker

### DIFF
--- a/tracker/trackers/react-native/package.json
+++ b/tracker/trackers/react-native/package.json
@@ -69,7 +69,8 @@
   "dependencies": {
     "@objectiv/tracker-core": "~0.0.15",
     "@objectiv/tracker-react-core": "~0.0.15",
-    "@objectiv/transport-fetch": "^0.0.15"
+    "@objectiv/transport-fetch": "^0.0.15",
+    "react-native-get-random-values": "^1.7.2"
   },
   "peerDependencies": {
     "react": ">=16.8",

--- a/tracker/trackers/react-native/src/index.ts
+++ b/tracker/trackers/react-native/src/index.ts
@@ -1,6 +1,7 @@
 /*
  * Copyright 2022 Objectiv B.V.
  */
+import 'react-native-get-random-values';
 
 export * from '@objectiv/tracker-react-core';
 

--- a/tracker/yarn.lock
+++ b/tracker/yarn.lock
@@ -1715,6 +1715,7 @@ __metadata:
     jest-standard-reporter: ^2.0.0
     prettier: ^2.5.1
     react-native: ^0.67.3
+    react-native-get-random-values: ^1.7.2
     react-test-renderer: ^17.0.2
     shx: ^0.3.4
     tsup: ^5.12.0
@@ -4675,6 +4676,13 @@ __metadata:
     snapdragon: ^0.8.1
     to-regex: ^3.0.1
   checksum: a41531b8934735b684cef5e8c5a01d0f298d7d384500ceca38793a9ce098125aab04ee73e2d75d5b2901bc5dddd2b64e1b5e3bf19139ea48bac52af4a92f1d00
+  languageName: node
+  linkType: hard
+
+"fast-base64-decode@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "fast-base64-decode@npm:1.0.0"
+  checksum: 4c59eb1775a7f132333f296c5082476fdcc8f58d023c42ed6d378d2e2da4c328c7a71562f271181a725dd17cdaa8f2805346cc330cdbad3b8e4b9751508bd0a3
   languageName: node
   linkType: hard
 
@@ -8668,6 +8676,17 @@ fsevents@~2.1.2:
     jscodeshift: ^0.11.0
     nullthrows: ^1.1.1
   checksum: c5ccdcb2a2f249756aca8e729cf96737368c8d33673b08d4c928a469bcb58ff37fbf3c7a070398f33b19846c4261948e2c5107c561934a41ac034620f7207bbd
+  languageName: node
+  linkType: hard
+
+"react-native-get-random-values@npm:^1.7.2":
+  version: 1.7.2
+  resolution: "react-native-get-random-values@npm:1.7.2"
+  dependencies:
+    fast-base64-decode: ^1.0.0
+  peerDependencies:
+    react-native: ">=0.56"
+  checksum: 45782003973b2ceca90b1f73462021e1aa2fc7e00c830ccafbb6f8a6ef7de34989cfc05d49b0f670b399ba1ead5de117a9c69d250fdc0390ca54e38b9f828385
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
React Native doesn't support [crypto.getRandomValues()](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/getRandomValues). Our UUID generation library requires it.

In this PR we simply include a react-native polyfill as suggested in [uuidjs docs](https://github.com/uuidjs/uuid#getrandomvalues-not-supported).

