### PR TITLE
React trackers LocationTree console tweaks

### DIFF
--- a/tracker/core/react/src/common/LocationTree.ts
+++ b/tracker/core/react/src/common/LocationTree.ts
@@ -3,7 +3,13 @@
  */
 
 import { AbstractLocationContext } from '@objectiv/schema';
-import { generateUUID, getLocationPath, Tracker } from '@objectiv/tracker-core';
+import {
+  generateUUID,
+  getLocationPath,
+  NoopConsoleImplementation,
+  Tracker,
+  TrackerConsole
+} from '@objectiv/tracker-core';
 import { LocationContext } from '../types';
 
 /**
@@ -87,10 +93,22 @@ export const LocationTree = {
   initialize: (tracker: Tracker) => {
     LocationTree.clear();
 
-    // Clone the given Tracker into a new one with only plugins configured and run their lifecycles
-    const trackerClone = new Tracker({ applicationId: tracker.applicationId, plugins: tracker.plugins });
+    // Clone the given Tracker into a new one with only plugins configured
+    const trackerClone = new Tracker({
+      applicationId: tracker.applicationId,
+      plugins: tracker.plugins
+    });
+
+    // Disable Console while we replay `initialize` and `enrich` lifecycle methods
+    const previousConsoleImplementation = TrackerConsole.implementation;
+    TrackerConsole.setImplementation(NoopConsoleImplementation);
+
+    // Replay plugins lifecycle methods
     trackerClone.plugins.initialize(trackerClone);
     trackerClone.plugins.enrich(trackerClone);
+
+    // Restore console
+    TrackerConsole.setImplementation(previousConsoleImplementation);
 
     // Convert AbstractLocationContext[] to LocationContext<AbstractLocationContext>[]
     const locationStack: LocationContext<AbstractLocationContext>[] = trackerClone.location_stack.map(

--- a/tracker/core/react/src/common/LocationTree.ts
+++ b/tracker/core/react/src/common/LocationTree.ts
@@ -8,7 +8,7 @@ import {
   getLocationPath,
   NoopConsoleImplementation,
   Tracker,
-  TrackerConsole
+  TrackerConsole,
 } from '@objectiv/tracker-core';
 import { LocationContext } from '../types';
 
@@ -96,7 +96,7 @@ export const LocationTree = {
     // Clone the given Tracker into a new one with only plugins configured
     const trackerClone = new Tracker({
       applicationId: tracker.applicationId,
-      plugins: tracker.plugins
+      plugins: tracker.plugins,
     });
 
     // Disable Console while we replay `initialize` and `enrich` lifecycle methods


### PR DESCRIPTION
LocationTree is responsible for keeping track of where Components are rendering, including their LocationStacks. To do so it also replays Plugins lifecycle methods to be aware of any enrichment they may have done to the Tracker's location stack, e.g. like RootLocationContextFromURLPlugin does.

While we replay Plugins lifecycles it's not necessary to log anything to the console, as this is an internal operation that the actual Tracker will perform anyway.

This PR disabled logging while we replay Plugins lifecycles and restores it immediately afterwards.
