### PR TITLE
Binary Operations - Base Node Optimization

### DIFF
--- a/bach/bach/dataframe.py
+++ b/bach/bach/dataframe.py
@@ -1174,7 +1174,7 @@ class DataFrame:
 
     def set_index(
         self,
-        keys: Union[str, 'Series', List[Union[str, 'Series']]],
+        keys: Union[str, 'Series', Sequence[Union[str, 'Series']]],
         drop: bool = True,
         append: bool = False,
     ) -> 'DataFrame':

--- a/bach/bach/expression.py
+++ b/bach/bach/expression.py
@@ -2,9 +2,8 @@
 Copyright 2021 Objectiv B.V.
 """
 import re
-from collections import defaultdict
 from dataclasses import dataclass
-from typing import Optional, Union, TYPE_CHECKING, List, Dict, Tuple, Set
+from typing import Optional, Union, TYPE_CHECKING, List, Dict, Tuple, Set, Sequence
 
 from sqlalchemy.engine import Dialect
 
@@ -141,7 +140,7 @@ class Expression:
     For special type Expressions, this class is subclassed to assign special properties to a subexpression.
     """
 
-    def __init__(self, data: Union['Expression', List[Union[ExpressionToken, 'Expression']]] = None):
+    def __init__(self, data: Union['Expression', Sequence[Union[ExpressionToken, 'Expression']]] = None):
         if not data:
             data = []
         if isinstance(data, Expression):
@@ -319,6 +318,18 @@ class Expression:
             else:
                 result.append(data_item)
         return self.__class__(result)
+
+    def replace_column_references(self, old_column_name: str, new_column_name: str) -> 'Expression':
+        """
+        replaces all ColumnReferenceToken where old_column_name is present with another ColumnReferenceToken
+        """
+        replaced_tokens = []
+        for token in self.get_all_tokens():
+            if not isinstance(token, ColumnReferenceToken) or token.column_name != old_column_name:
+                replaced_tokens.append(token)
+                continue
+            replaced_tokens.append(ColumnReferenceToken(new_column_name))
+        return self.__class__(replaced_tokens)
 
     def remove_table_column_references(self) -> Tuple[str, str, 'Expression']:
         """

--- a/bach/bach/series/series.py
+++ b/bach/bach/series/series.py
@@ -570,8 +570,11 @@ class Series(ABC):
         df = left.merge(right, on=right.index_columns, how='outer', suffixes=('', '__other'))
 
         mod_other_name = other.name
-        if other.base_node == right.base_node and other.name == self.name or other.name in self.index:
-            post_fix = '__other' if other.name == self.name else '__data_column'
+        if (
+            other.base_node == right.base_node
+            and set(df.all_series) & {f'{other.name}__other', f'{other.name}__data_column'}
+        ):
+            post_fix = '__other' if other.name not in self.index else '__data_column'
             mod_other_name = f'{other.name}{post_fix}'
 
         if not update_column_references:

--- a/bach/tests/functional/bach/test_series.py
+++ b/bach/tests/functional/bach/test_series.py
@@ -675,3 +675,17 @@ def test__set_item_with_merge_different_dtypes() -> None:
 
     with pytest.raises(ValueError, match=r'dtypes of indexes to be merged'):
         bt['inhabitants'] + bt2['inhabitants']
+
+
+def test_binary_operation() -> None:
+    pdf1 = pd.DataFrame(data={'a': [1, 2, 3], 'b': [2, 2, 2], 'c': [3, 3, 3]}, )
+    pdf2 = pd.DataFrame(data={'a': [1, 2, 3, 4], 'b': [1, 1, 1, 1], 'd': [1, 2, 3, 4], 'e': [1, 2, 3, 4]})
+
+    df1 = get_from_df('binary_operation1', pdf1)
+    df2 = get_from_df('binary_operation2', pdf2)
+    df1 = df1.set_index(['a'])
+    df2 = df2.set_index(['a'])
+
+    result = (df1['b'] + df2['d'] - df1['c']) / df2['e'] + df2['b']
+
+    print('hola')

--- a/bach/tests/functional/bach/test_series.py
+++ b/bach/tests/functional/bach/test_series.py
@@ -690,7 +690,7 @@ def test__set_item_with_merge_w_conflict_names() -> None:
     result2 = (result + df1['c']) * df1['c'] - df2['c']
     assert result2.base_node.references['left_node'] == df1.base_node
     assert result2.base_node.references['right_node'] == df2.base_node
-    assert '(((("b" - "a__data_column") - "c__other") + "c") * "c") - "c"' == result2.expression.to_sql(dialect)
+    assert '(((("b" - "a__data_column") - "c__other") + "c") * "c") - "c__other"' == result2.expression.to_sql(dialect)
     assert {'a', 'b', 'a__data_column', 'c', 'c__other'} == set(result2.base_node.columns)
     assert Expression.table_column_reference('l', 'c') == result2.base_node.column_expressions['c']
     assert Expression.table_column_reference('r', 'c') == result2.base_node.column_expressions['c__other']


### PR DESCRIPTION
Uses revert_merge to keep both nodes involved in binary_operation as leaves of MergeSqlModel