### PR TITLE
Overload typing of `DataFrame.__get_item__`

### DIFF
--- a/bach/bach/dataframe.py
+++ b/bach/bach/dataframe.py
@@ -7,7 +7,7 @@ from datetime import date, datetime, time
 
 from typing import (
     List, Set, Union, Dict, Any, Optional, Tuple,
-    cast, NamedTuple, TYPE_CHECKING, Callable, Hashable, Sequence,
+    cast, NamedTuple, TYPE_CHECKING, Callable, Hashable, Sequence, overload,
 )
 from uuid import UUID
 
@@ -861,8 +861,15 @@ class DataFrame:
         from bach.sample import get_unsampled
         return get_unsampled(df=self)
 
-    def __getitem__(self,
-                    key: Union[str, List[str], Set[str], slice, 'SeriesBoolean']) -> DataFrameOrSeries:
+    @overload
+    def __getitem__(self, key: str) -> 'Series':
+        ...
+
+    @overload
+    def __getitem__(self, key: Union[List[str], Set[str], slice, 'SeriesBoolean']) -> 'DataFrame':
+        ...
+
+    def __getitem__(self, key):
         """
         For usage see general introduction DataFrame class.
         """

--- a/bach/bach/operations/describe.py
+++ b/bach/bach/operations/describe.py
@@ -165,11 +165,11 @@ class DescribeOperation:
         series_to_aggregate = []
         for s in self.series_to_describe:
             # check one: function exists on Series
-            if not hasattr(self.df.all_series[s], stat.value):
+            if not hasattr(self.df[s], stat.value):
                 continue
             # check two: function doesn't raise NotImplementedError
             try:
-                self.df.all_series[s].apply_func(stat.value)
+                self.df[s].apply_func(stat.value)
             except NotImplementedError:
                 continue
             series_to_aggregate.append(s)
@@ -179,7 +179,7 @@ class DescribeOperation:
 
         stat_df = self.df.copy_override(
             series={
-                s: self.df.all_series[s].copy_override(index={})
+                s: self.df[s].copy_override(index={})
                 for s in series_to_aggregate
             }, index={}
 
@@ -201,8 +201,7 @@ class DescribeOperation:
         """
         # filter series that can perform the aggregation 'quantile' operation
         series_to_aggregate = {
-            s: self.df.all_series[s]
-            for s in self.series_to_describe if hasattr(self.df.all_series[s], 'quantile')
+            s: self.df[s] for s in self.series_to_describe if hasattr(self.df[s], 'quantile')
         }
         if not series_to_aggregate:
             return None


### PR DESCRIPTION
Used typing's [overload](https://docs.python.org/3/library/typing.html#typing.overload) decorator. This way mypy can stop complaining about smth like `df['a']` being a DataFrame.  

Just changed the `df.all_series[..]` in some places for testing purposes, in theory using it is not wrong.