### PR TITLE
to make the docker image work better with heroku

### DIFF
--- a/backend/docker/Dockerfile
+++ b/backend/docker/Dockerfile
@@ -89,7 +89,6 @@ WORKDIR /services
 # entrypoint scripts
 COPY docker/*.sh /services/
 COPY docker/gunicorn.conf.py /etc/
-CMD /services/entry_point.sh
 
 # python requirements
 # we use requirement.in, because the list with hashes is not cross-platform compatible
@@ -104,3 +103,7 @@ RUN \
 COPY --from=builder /build_dir/dist/* /tmp/
 RUN pip --no-cache-dir install /tmp/objectiv_backend-*-py3-none-any.whl && \
     rm /tmp/*
+
+USER www-data
+CMD /services/entry_point.sh
+ENTRYPOINT /services/entry_point.sh

--- a/backend/docker/entry_point.sh
+++ b/backend/docker/entry_point.sh
@@ -21,5 +21,4 @@ echo "starting gunicorn"
 # Run gunicorn. $USER and $PORT are set in the Dockerfile
 exec gunicorn --config /etc/gunicorn.conf.py \
 --access-logformat '%(h)s %(l)s %(u)s %(t)s "%(r)s" %(s)s %(b)s "%(f)s" "%(a)s" %(l)s' \
---user ${USER-"www-data"} \
 objectiv_backend.wsgi


### PR DESCRIPTION
- change the user in the dockerfile, rather than at runtime
- properly set entrypoint