### PR TITLE
Update Slack links in READMEs

### DIFF
--- a/analysis/bach_open_taxonomy/README.md
+++ b/analysis/bach_open_taxonomy/README.md
@@ -9,7 +9,7 @@ For examples on how to use the extensions, check out the notebooks in [analysis/
 
 
 ## Support & Troubleshooting
-If you need help using or installing Bach, join our [Slack channel](https://join.slack.com/t/objectiv-io/shared_invite/zt-u6xma89w-DLDvOB7pQer5QUs5B_~5pg) and post your question there. 
+If you need help using or installing Bach, join our [Slack channel](https://objectiv.io/join-slack/) and post your question there. 
 
 ## Bug Reports & Feature Requests
 If you’ve found an issue or have a feature request, please check out the [Contribution Guide](https://objectiv.io/docs/home/the-project/contribute/).

--- a/bach/README.md
+++ b/bach/README.md
@@ -20,7 +20,7 @@ For detailed installation & usage instructions, visit [Objectiv Docs](https://ww
   found in the [`sql_models`](./sql_models/) package
 
 ## Support & Troubleshooting
-If you need help using or installing Bach, join our [Slack channel](https://join.slack.com/t/objectiv-io/shared_invite/zt-u6xma89w-DLDvOB7pQer5QUs5B_~5pg) and post your question there. 
+If you need help using or installing Bach, join our [Slack channel](https://objectiv.io/join-slack/) and post your question there. 
 
 ## Bug Reports & Feature Requests
 If you’ve found an issue or have a feature request, please check out the [Contribution Guide](https://objectiv.io/docs/home/the-project/contribute/).

--- a/backend/README.md
+++ b/backend/README.md
@@ -18,7 +18,7 @@ without verifying passwords. Do not use this in production or on a shared system
 For detailed installation & usage instructions, visit [Objectiv Docs](https://www.objectiv.io/docs/tracking/collector).
 
 ## Support & Troubleshooting
-If you need help using or installing Objectiv, join our [Slack channel](https://join.slack.com/t/objectiv-io/shared_invite/zt-u6xma89w-DLDvOB7pQer5QUs5B_~5pg) and post your question there. 
+If you need help using or installing Objectiv, join our [Slack channel](https://objectiv.io/join-slack/) and post your question there. 
 
 ## Bug Reports & Feature Requests
 If you’ve found an issue or have a feature request, please check out the [Contribution Guide](https://objectiv.io/docs/home/the-project/contribute/).

--- a/schema/README.md
+++ b/schema/README.md
@@ -18,7 +18,7 @@ Objectiv is built around the Open Taxonomy and the Tracker, Collector and Bach u
 For detailed installation & usage instructions of Objectiv, visit [Objectiv Docs](https://www.objectiv.io/docs).
 
 ## Support & Troubleshooting
-If you need help with the Open Taxonomy, join our [Slack channel](https://join.slack.com/t/objectiv-io/shared_invite/zt-u6xma89w-DLDvOB7pQer5QUs5B_~5pg) and post your question there. 
+If you need help with the Open Taxonomy, join our [Slack channel](https://objectiv.io/join-slack/) and post your question there. 
 
 ## Bug Reports & Feature Requests
 If you’ve found an issue or have a feature request, please check out the [Contribution Guide](https://objectiv.io/docs/home/the-project/contribute/).

--- a/tracker/README.md
+++ b/tracker/README.md
@@ -18,7 +18,7 @@ For installation instructions for your preferred platform, please choose a track
 For detailed installation & usage instructions, visit [Objectiv Docs](https://www.objectiv.io/docs/tracking).
 
 ## Support & Troubleshooting
-If you need help using or installing Objectiv's tracker, join our [Slack channel](https://join.slack.com/t/objectiv-io/shared_invite/zt-u6xma89w-DLDvOB7pQer5QUs5B_~5pg) and post your question there. 
+If you need help using or installing Objectiv's tracker, join our [Slack channel](https://objectiv.io/join-slack/) and post your question there. 
 
 ## Bug Reports & Feature Requests
 If you’ve found an issue or have a feature request, please check out the [Contribution Guide](https://objectiv.io/docs/home/the-project/contribute/).


### PR DESCRIPTION
Updates all Slack invite links in READMEs to our new 'Join Slack' page on the website.