### PR TITLE
fix order of columns in __getitem__

### DIFF
--- a/bach/bach/dataframe.py
+++ b/bach/bach/dataframe.py
@@ -1039,7 +1039,12 @@ class DataFrame:
             key_set = set(key)
             if not key_set.issubset(set(self.data_columns)):
                 raise KeyError(f"Keys {key_set.difference(set(self.data_columns))} not in data_columns")
-            selected_data = {key: data for key, data in self.data.items() if key in key_set}
+
+            if isinstance(key, set):
+                selected_data = {col: data for col, data in self.data.items() if col in key_set}
+            else:
+                # should change order of columns in select
+                selected_data = {col: self.data[col] for col in key}
 
             return self.copy_override(series=selected_data)
 

--- a/bach/tests/functional/bach/test_df.py
+++ b/bach/tests/functional/bach/test_df.py
@@ -166,3 +166,11 @@ def test_quantile_no_numeric_columns() -> None:
 
     with pytest.raises(ValueError, match=r'DataFrame has no series supporting'):
         bt.quantile()
+
+
+def test__getitem__order_columns(engine) -> None:
+    bt = get_df_with_test_data(engine, full_data_set=True)
+
+    expected_ordered_columns = ['inhabitants', 'municipality']
+    result = bt[expected_ordered_columns]
+    assert ['inhabitants', 'municipality'] == result.data_columns

--- a/bach/tests/functional/bach/test_df_groupby.py
+++ b/bach/tests/functional/bach/test_df_groupby.py
@@ -639,11 +639,12 @@ def test_groupby_frame_split_recombine_aggregation_applied():
     r1 = r1.rename(columns={'inhabitants': 'inhabitants_sum'})
     assert r1.base_node == bt.base_node
 
+    expected_columns = ['inhabitants_sum', 'founding_sum', 'founding_mean']
     for r in [founding_inhabitants_sum, r1]:
         assert_equals_data(
-            r,
+            r[expected_columns],
             order_by=['municipality'],
-            expected_columns=['municipality', 'inhabitants_sum', 'founding_sum', 'founding_mean'],
+            expected_columns=['municipality'] + expected_columns,
 
             expected_data=[
                 ['Leeuwarden', 93485, 1285, 1285],

--- a/bach/tests/functional/bach/test_df_materialize.py
+++ b/bach/tests/functional/bach/test_df_materialize.py
@@ -60,7 +60,7 @@ def test_materialize_with_non_aggregation_series(inplace: bool):
     btg = bt.groupby('municipality')
     assert btg.group_by is not None
     with pytest.raises(ValueError, match="groupby set, but contains Series that have no aggregation func.*"
-                                         "\\['_index_skating_order', 'inhabitants', 'founding'\\]"):
+                                         "\\['_index_skating_order', 'founding', 'inhabitants'\\]"):
         btg.materialize(inplace=inplace)
 
     assert btg.base_node == bt.base_node

--- a/bach/tests/functional/bach/test_df_reset_index.py
+++ b/bach/tests/functional/bach/test_df_reset_index.py
@@ -138,7 +138,7 @@ def test_set_index():
     abt = bt.rename(columns={'city': 'x'})
     xbt = abt.set_index(col, drop=False)
     assert list(xbt.index.keys()) == ['city']
-    assert list(xbt.data.keys()) == ['x', 'municipality', 'inhabitants']
+    assert list(xbt.data.keys()) == ['municipality', 'x', 'inhabitants']
 
     # try to set a series as index
     abt = bt.set_index(bt.municipality.str[:3], drop=True)


### PR DESCRIPTION
DataFrame should respect the order of selected columns in __getitems__ when a list is passed.