### PR TITLE
Change TrackedHeader and TrackedFooter to wrap in ContentContexts

### DIFF
--- a/tracker/trackers/react/src/trackedElements/TrackedFooter.tsx
+++ b/tracker/trackers/react/src/trackedElements/TrackedFooter.tsx
@@ -3,12 +3,12 @@
  */
 
 import React from 'react';
-import { TrackedNavigationContext } from '../trackedContexts/TrackedNavigationContext';
+import { TrackedContentContext } from '../trackedContexts/TrackedContentContext';
 import { SingletonTrackedElementProps } from '../types';
 
 /**
- * Generates a TrackedNavigationContext preconfigured with a <footer> Element as Component.
+ * Generates a TrackedContentContext preconfigured with a <footer> Element as Component.
  */
 export const TrackedFooter = React.forwardRef<HTMLDivElement, SingletonTrackedElementProps>((props, ref) => (
-  <TrackedNavigationContext {...props} id={props.id ?? 'footer'} Component={'footer'} ref={ref} />
+  <TrackedContentContext {...props} id={props.id ?? 'footer'} Component={'footer'} ref={ref} />
 ));

--- a/tracker/trackers/react/src/trackedElements/TrackedHeader.tsx
+++ b/tracker/trackers/react/src/trackedElements/TrackedHeader.tsx
@@ -3,12 +3,12 @@
  */
 
 import React from 'react';
-import { TrackedNavigationContext } from '../trackedContexts/TrackedNavigationContext';
+import { TrackedContentContext } from '../trackedContexts/TrackedContentContext';
 import { SingletonTrackedElementProps } from '../types';
 
 /**
- * Generates a TrackedNavigationContext preconfigured with a <header> Element as Component.
+ * Generates a TrackedContentContext preconfigured with a <header> Element as Component.
  */
 export const TrackedHeader = React.forwardRef<HTMLDivElement, SingletonTrackedElementProps>((props, ref) => (
-  <TrackedNavigationContext {...props} id={props.id ?? 'header'} Component={'header'} ref={ref} />
+  <TrackedContentContext {...props} id={props.id ?? 'header'} Component={'header'} ref={ref} />
 ));

--- a/tracker/trackers/react/tests/TrackedFooter.test.tsx
+++ b/tracker/trackers/react/tests/TrackedFooter.test.tsx
@@ -20,7 +20,7 @@ describe('TrackedFooter', () => {
     jest.resetAllMocks();
   });
 
-  it('should wrap the given Component in a NavigationContext', () => {
+  it('should wrap the given Component in a ContentContext', () => {
     const spyTransport = new SpyTransport();
     jest.spyOn(spyTransport, 'handle');
     const tracker = new ReactTracker({ applicationId: 'app-id', transport: spyTransport });
@@ -48,7 +48,7 @@ describe('TrackedFooter', () => {
         _type: 'PressEvent',
         location_stack: expect.arrayContaining([
           expect.objectContaining({
-            _type: 'NavigationContext',
+            _type: 'ContentContext',
             id: 'footer',
           }),
         ]),
@@ -84,7 +84,7 @@ describe('TrackedFooter', () => {
         _type: 'PressEvent',
         location_stack: expect.arrayContaining([
           expect.objectContaining({
-            _type: 'NavigationContext',
+            _type: 'ContentContext',
             id: 'secondary-footer',
           }),
         ]),

--- a/tracker/trackers/react/tests/TrackedHeader.test.tsx
+++ b/tracker/trackers/react/tests/TrackedHeader.test.tsx
@@ -20,7 +20,7 @@ describe('TrackedHeader', () => {
     jest.resetAllMocks();
   });
 
-  it('should wrap the given Component in a NavigationContext', () => {
+  it('should wrap the given Component in a ContentContext', () => {
     const spyTransport = new SpyTransport();
     jest.spyOn(spyTransport, 'handle');
     const tracker = new ReactTracker({ applicationId: 'app-id', transport: spyTransport });
@@ -48,7 +48,7 @@ describe('TrackedHeader', () => {
         _type: 'PressEvent',
         location_stack: expect.arrayContaining([
           expect.objectContaining({
-            _type: 'NavigationContext',
+            _type: 'ContentContext',
             id: 'header',
           }),
         ]),
@@ -84,7 +84,7 @@ describe('TrackedHeader', () => {
         _type: 'PressEvent',
         location_stack: expect.arrayContaining([
           expect.objectContaining({
-            _type: 'NavigationContext',
+            _type: 'ContentContext',
             id: 'secondary-header',
           }),
         ]),


### PR DESCRIPTION
Both Tracked components are currently wrapping in NavigationContext which is not semantically accurate.

Source (see ARIA notes):
- https://developer.mozilla.org/en-US/docs/Web/HTML/Element/header
- https://developer.mozilla.org/en-US/docs/Web/HTML/Element/footer