### PR TITLE
HttpContext: Make remote_address optional

### DIFF
--- a/backend/objectiv_backend/schema/schema.py
+++ b/backend/objectiv_backend/schema/schema.py
@@ -108,8 +108,8 @@ class HttpContext(AbstractGlobalContext):
     def __init__(self,
                  referrer: str,
                  user_agent: str,
-                 remote_address: str,
                  id: str,
+                 remote_address: str = None,
                  **kwargs: Optional[Any]):
         """
         :param referrer: 

--- a/schema/base_schema.json5
+++ b/schema/base_schema.json5
@@ -179,7 +179,8 @@
         },
         "remote_address": {
           "description": "(public) IP address of the agent that sent the event.",
-          "type": "string"
+          "type": "string",
+          "optional": true
         }
       }
     },

--- a/tracker/core/schema/src/global_contexts.d.ts
+++ b/tracker/core/schema/src/global_contexts.d.ts
@@ -54,7 +54,7 @@ export interface HttpContext extends AbstractGlobalContext {
   /**
    * (public) IP address of the agent that sent the event.
    */
-  remote_address: string;
+  remote_address: string | null;
 }
 
 /**

--- a/tracker/core/tracker/src/ContextFactories.ts
+++ b/tracker/core/tracker/src/ContextFactories.ts
@@ -76,21 +76,21 @@ export const makeExpandableContext = (props: { id: string }): ExpandableContext 
  *         for Context instance uniqueness.
  * @param {string} props.referrer - Full URL to HTTP referrer of the current page.
  * @param {string} props.user_agent - User-agent of the agent that sent the event.
- * @param {string} props.remote_address - (public) IP address of the agent that sent the event.
+ * @param {string | null} props.remote_address - (public) IP address of the agent that sent the event.
  * @returns {HttpContext} - HttpContext: A GlobalContext describing meta information about the agent that sent the event.
  */
 export const makeHttpContext = (props: {
   id: string;
   referrer: string;
   user_agent: string;
-  remote_address: string;
+  remote_address?: string | null;
 }): HttpContext => ({
   __global_context: true,
   _type: 'HttpContext',
   id: props.id,
   referrer: props.referrer,
   user_agent: props.user_agent,
-  remote_address: props.remote_address,
+  remote_address: props.remote_address ?? null,
 });
 
 /** Creates instance of InputContext

--- a/tracker/core/tracker/tests/ContextFactories.test.ts
+++ b/tracker/core/tracker/tests/ContextFactories.test.ts
@@ -65,6 +65,17 @@ describe('Context Factories', () => {
       user_agent: 'ua',
       remote_address: '0.0.0.0',
     });
+
+    expect(
+      makeHttpContext({ id: 'http', referrer: 'referrer', user_agent: 'ua' })
+    ).toStrictEqual({
+      __global_context: true,
+      _type: 'HttpContext',
+      id: 'http',
+      referrer: 'referrer',
+      user_agent: 'ua',
+      remote_address: null
+    });
   });
 
   it('InputContext', () => {

--- a/tracker/plugins/http-context/src/HttpContextPlugin.ts
+++ b/tracker/plugins/http-context/src/HttpContextPlugin.ts
@@ -42,8 +42,7 @@ export class HttpContextPlugin implements TrackerPluginInterface {
     const httpContext = makeHttpContext({
       id: 'http_context',
       referrer: document.referrer ?? '',
-      user_agent: navigator.userAgent ?? '',
-      remote_address: '127.0.0.1',
+      user_agent: navigator.userAgent ?? ''
     });
     tracker.global_contexts.push(httpContext);
   }

--- a/tracker/plugins/http-context/tests/HttpContextPlugin.test.ts
+++ b/tracker/plugins/http-context/tests/HttpContextPlugin.test.ts
@@ -46,7 +46,7 @@ describe('HttpContextPlugin', () => {
           _type: 'HttpContext',
           id: 'http_context',
           referrer: 'MOCK_REFERRER',
-          remote_address: '127.0.0.1',
+          remote_address: null,
           user_agent: 'MOCK_USER_AGENT',
         },
       ])
@@ -79,7 +79,7 @@ describe('HttpContextPlugin', () => {
           _type: 'HttpContext',
           id: 'http_context',
           referrer: '',
-          remote_address: '127.0.0.1',
+          remote_address: null,
           user_agent: '',
         },
       ])


### PR DESCRIPTION
This refactors how HttpContext remote_address gets factored.

Docs update: https://github.com/objectiv/objectiv.io/pull/362