### PR TITLE
Use regular properties instead of @property@classmethod for type rela…

### DIFF
--- a/bach/bach/series/series_datetime.py
+++ b/bach/bach/series/series_datetime.py
@@ -4,7 +4,7 @@ Copyright 2021 Objectiv B.V.
 import datetime
 from abc import ABC
 from enum import Enum
-from typing import Union, cast, List
+from typing import Union, cast, List, Tuple
 
 import numpy
 
@@ -12,6 +12,7 @@ from bach import DataFrame
 from bach.series import Series, SeriesString, SeriesBoolean, SeriesFloat64, SeriesInt64
 from bach.expression import Expression
 from bach.series.series import WrappedPartition
+from bach.types import DtypeOrAlias
 
 _SECONDS_IN_DAY = 24 * 60 * 60
 
@@ -200,7 +201,7 @@ class SeriesDate(SeriesAbstractDateTime):
         date
     """
     dtype = 'date'
-    dtype_aliases = tuple()  # type: ignore
+    dtype_aliases: Tuple[DtypeOrAlias, ...] = tuple()
     supported_db_dtype = 'date'
     supported_value_types = (datetime.datetime, datetime.date, str)
 
@@ -260,7 +261,7 @@ class SeriesTime(SeriesAbstractDateTime):
         time without time zone
     """
     dtype = 'time'
-    dtype_aliases = tuple()  # type: ignore
+    dtype_aliases: Tuple[DtypeOrAlias, ...] = tuple()
     supported_db_dtype = 'time without time zone'
     supported_value_types = (datetime.time, str)
 

--- a/bach/bach/series/series_json.py
+++ b/bach/bach/series/series_json.py
@@ -2,12 +2,13 @@
 Copyright 2021 Objectiv B.V.
 """
 import json
-from typing import Optional, Dict, Union, TYPE_CHECKING, List
+from typing import Optional, Dict, Union, TYPE_CHECKING, List, Tuple
 
 from bach.series import Series
 from bach.expression import Expression
 from bach.series.series import WrappedPartition
 from bach.sql_model import BachSqlModel
+from bach.types import DtypeOrAlias
 from sql_models.util import quote_string
 
 if TYPE_CHECKING:
@@ -117,7 +118,7 @@ class SeriesJsonb(Series):
     """
     dtype = 'jsonb'
     # todo can only assign a type to one series type, and object is quite generic
-    dtype_aliases = tuple()  # type: ignore
+    dtype_aliases: Tuple[DtypeOrAlias, ...] = tuple()
     supported_db_dtype = 'jsonb'
     supported_value_types = (dict, list)
     return_dtype = dtype
@@ -352,7 +353,7 @@ class SeriesJson(SeriesJsonb):
 
     """
     dtype = 'json'
-    dtype_aliases = tuple()  # type: ignore
+    dtype_aliases: Tuple[DtypeOrAlias, ...] = tuple()
     supported_db_dtype = 'json'
     return_dtype = 'jsonb'
 


### PR DESCRIPTION
Small change in the Series class: Instead of using `@property` and `@classmethod` as decorators on `dtype_aliases`, `supported_db_dtype`, and `supported_value_types` just define them as class level properties.

Reasons:
1. This is in line with how we already define `Series.dtype`
2. This makes things a bit simpler for the future and easier for `mypy`. Some `cast()` and `type: ignore` could be removed because of this

This should not change any behaviour. No tests were changed.