### PR TITLE
Bach bq set item prep tests

### DIFF
--- a/bach/tests/functional/bach/test_data_and_utils.py
+++ b/bach/tests/functional/bach/test_data_and_utils.py
@@ -279,13 +279,13 @@ def _get_to_pandas_data(df: DataFrame):
     return column_names, db_values
 
 
-def assert_db_type(
+def assert_postgres_type(
         series: Series,
         expected_db_type: str,
         expected_series_type: Type[Series]
 ):
     """
-    Check that the given Series has the expected data type in the database, and that it has the
+    Check that the given Series has the expected data type in the Postgres database, and that it has the
     expected Series type after being read back from the database.
     :param series: Series object to check the type of
     :param expected_db_type: one of the types listed on https://www.postgresql.org/docs/current/datatype.html

--- a/bach/tests/functional/bach/test_df_setitem.py
+++ b/bach/tests/functional/bach/test_df_setitem.py
@@ -12,7 +12,7 @@ from bach import SeriesInt64, SeriesString, SeriesFloat64, SeriesDate, SeriesTim
     SeriesJsonb, SeriesBoolean
 from sql_models.util import is_postgres
 from tests.conftest import get_postgres_engine_dialect
-from tests.functional.bach.test_data_and_utils import get_bt_with_test_data, assert_db_type, \
+from tests.functional.bach.test_data_and_utils import get_bt_with_test_data, assert_postgres_type, \
     assert_equals_data, CITIES_INDEX_AND_COLUMNS, get_bt_with_railway_data, get_df_with_test_data
 
 
@@ -22,7 +22,7 @@ def check_set_const(engine, constant, expected_series: Type[Series], pg_db_type:
 
     if is_postgres(engine):
         # we don't have an easy way to get the database type in BigQuery, so only support that check for PG
-        assert_db_type(bt['new_column'], pg_db_type, expected_series)
+        assert_postgres_type(bt['new_column'], pg_db_type, expected_series)
 
     assert_equals_data(
         bt,
@@ -107,7 +107,7 @@ def test_set_const_int_from_series():
     max_series = max['founding_sum']
     max_value = max_series.value
     bt['max_founding'] = max_value
-    assert_db_type(bt['max_founding'], 'bigint', SeriesInt64, )
+    assert_postgres_type(bt['max_founding'], 'bigint', SeriesInt64, )
 
     assert_equals_data(
         bt,
@@ -126,7 +126,7 @@ def test_set_const_int_from_series():
 def test_set_series_column():
     bt = get_bt_with_test_data()
     bt['duplicated_column'] = bt['founding']
-    assert_db_type(bt['duplicated_column'], 'bigint', SeriesInt64)
+    assert_postgres_type(bt['duplicated_column'], 'bigint', SeriesInt64)
     assert_equals_data(
         bt,
         expected_columns=[
@@ -191,7 +191,7 @@ def test_set_multiple():
 def test_set_existing():
     bt = get_bt_with_test_data()
     bt['city'] = bt['founding']
-    assert_db_type(bt['city'], 'bigint', SeriesInt64)
+    assert_postgres_type(bt['city'], 'bigint', SeriesInt64)
     assert_equals_data(
         bt,
         expected_columns=CITIES_INDEX_AND_COLUMNS,
@@ -227,7 +227,7 @@ def test_set_different_base_node():
     bt = get_bt_with_test_data()
     mt = get_bt_with_railway_data()
     bt['skating_order'] = mt['station']
-    assert_db_type(bt['skating_order'], 'text', SeriesString)
+    assert_postgres_type(bt['skating_order'], 'text', SeriesString)
     assert_equals_data(
         bt,
         expected_columns=CITIES_INDEX_AND_COLUMNS,
@@ -289,7 +289,7 @@ def test_set_different_group_by():
 def test_set_existing_referencing_other_column_experience():
     bt = get_bt_with_test_data()
     bt['city'] = bt['city'] + ' test'
-    assert_db_type(bt['city'], 'text', SeriesString)
+    assert_postgres_type(bt['city'], 'text', SeriesString)
     assert_equals_data(
         bt,
         expected_columns=CITIES_INDEX_AND_COLUMNS,
@@ -318,8 +318,8 @@ def test_set_existing_referencing_other_column_experience():
     )
     bt['skating_order'] = c
     bt['city'] = a + ' - ' + b
-    assert_db_type(bt['skating_order'], 'bigint', SeriesInt64)
-    assert_db_type(bt['city'], 'text', SeriesString)
+    assert_postgres_type(bt['skating_order'], 'bigint', SeriesInt64)
+    assert_postgres_type(bt['city'], 'text', SeriesString)
     assert_equals_data(
         bt,
         expected_columns=CITIES_INDEX_AND_COLUMNS,
@@ -336,7 +336,7 @@ def test_set_existing_referencing_other_column_experience():
 def test_set_series_expression():
     bt = get_bt_with_test_data()
     bt['time_travel'] = bt['founding'] + 1000
-    assert_db_type(bt['time_travel'], 'bigint', SeriesInt64, )
+    assert_postgres_type(bt['time_travel'], 'bigint', SeriesInt64, )
     assert_equals_data(
         bt,
         expected_columns=CITIES_INDEX_AND_COLUMNS + ['time_travel'],
@@ -402,7 +402,7 @@ def test_set_pandas_series():
     bt = get_bt_with_test_data()
     pandas_series = bt['founding'].to_pandas()
     bt['duplicated_column'] = pandas_series
-    assert_db_type(bt['duplicated_column'], 'bigint', SeriesInt64)
+    assert_postgres_type(bt['duplicated_column'], 'bigint', SeriesInt64)
     assert_equals_data(
         bt,
         expected_columns=[
@@ -421,7 +421,7 @@ def test_set_pandas_series_different_shape():
     bt = get_bt_with_test_data()
     pandas_series = bt['founding'].to_pandas()[1:]
     bt['duplicated_column'] = pandas_series
-    assert_db_type(bt['duplicated_column'], 'bigint', SeriesInt64)
+    assert_postgres_type(bt['duplicated_column'], 'bigint', SeriesInt64)
     assert_equals_data(
         bt,
         expected_columns=[
@@ -441,7 +441,7 @@ def test_set_pandas_series_different_shape_and_name():
     bt2 = get_bt_with_railway_data()  # has more rows and different name index
     pandas_series = bt2['town'].to_pandas()
     bt['the_town'] = pandas_series
-    assert_db_type(bt['the_town'], 'text', SeriesString)
+    assert_postgres_type(bt['the_town'], 'text', SeriesString)
     assert_equals_data(
         bt,
         expected_columns=[

--- a/bach/tests/functional/bach/test_df_setitem.py
+++ b/bach/tests/functional/bach/test_df_setitem.py
@@ -103,8 +103,8 @@ def test_set_const_json():
 
 def test_set_const_int_from_series():
     bt = get_bt_with_test_data()[['founding']]
-    max = bt.groupby()[['founding']].sum()
-    max_series = max['founding_sum']
+    max_df = bt.groupby()[['founding']].sum()
+    max_series = max_df['founding_sum']
     max_value = max_series.value
     bt['max_founding'] = max_value
     assert_postgres_type(bt['max_founding'], 'bigint', SeriesInt64, )
@@ -168,6 +168,7 @@ def test_set_series_column():
         ]
     )
     assert filtered_bt.town == filtered_bt['town']
+
 
 def test_set_multiple():
     bt = get_bt_with_test_data()
@@ -241,7 +242,7 @@ def test_set_different_base_node():
     # set dataframe
     bt = get_bt_with_test_data()
     mt = get_bt_with_railway_data()
-    bt[['a','city']] = mt[['town','station']]
+    bt[['a', 'city']] = mt[['town', 'station']]
     assert_equals_data(
         bt,
         expected_columns=CITIES_INDEX_AND_COLUMNS + ['a'],
@@ -360,7 +361,6 @@ def test_set_series_single_value():
     assert bt.maxi.expression.is_single_value
     # should recycle the same subquery
     assert bt.maxi.expression.get_references() == bt.maxii.expression.get_references()
-
 
     bt['moremax'] = bt.maxi + 5
     bt['constmoremax'] = bt.maxi + bt.const

--- a/bach/tests/functional/bach/test_df_setitem.py
+++ b/bach/tests/functional/bach/test_df_setitem.py
@@ -22,7 +22,7 @@ def check_set_const(engine, constant, expected_series: Type[Series], expected_pg
 
     if is_postgres(engine):
         # we don't have an easy way to get the database type in BigQuery, so only support that check for PG
-        assert_postgres_type(bt['new_column'], pg_db_type, expected_series)
+        assert_postgres_type(bt['new_column'], expected_pg_db_type, expected_series)
 
     assert_equals_data(
         bt,

--- a/bach/tests/functional/bach/test_df_setitem.py
+++ b/bach/tests/functional/bach/test_df_setitem.py
@@ -16,7 +16,7 @@ from tests.functional.bach.test_data_and_utils import get_bt_with_test_data, ass
     assert_equals_data, CITIES_INDEX_AND_COLUMNS, get_bt_with_railway_data, get_df_with_test_data
 
 
-def check_set_const(engine, constant, expected_series: Type[Series], pg_db_type: str):
+def check_set_const(engine, constant, expected_series: Type[Series], expected_pg_db_type: str):
     bt = get_df_with_test_data(engine)
     bt['new_column'] = constant
 

--- a/bach/tests/functional/bach/test_df_setitem.py
+++ b/bach/tests/functional/bach/test_df_setitem.py
@@ -10,14 +10,20 @@ import numpy as np
 from bach import SeriesInt64, SeriesString, SeriesFloat64, SeriesDate, SeriesTimestamp, \
     SeriesTime, SeriesTimedelta, Series, \
     SeriesJsonb, SeriesBoolean
+from sql_models.util import is_postgres
+from tests.conftest import get_postgres_engine_dialect
 from tests.functional.bach.test_data_and_utils import get_bt_with_test_data, assert_db_type, \
-    assert_equals_data, CITIES_INDEX_AND_COLUMNS, get_bt_with_railway_data
+    assert_equals_data, CITIES_INDEX_AND_COLUMNS, get_bt_with_railway_data, get_df_with_test_data
 
 
-def check_set_const(constant, db_type: str, expected_series: Type[Series]):
-    bt = get_bt_with_test_data()
+def check_set_const(engine, constant, expected_series: Type[Series], pg_db_type: str):
+    bt = get_df_with_test_data(engine)
     bt['new_column'] = constant
-    assert_db_type(bt['new_column'], db_type, expected_series)
+
+    if is_postgres(engine):
+        # we don't have an easy way to get the database type in BigQuery, so only support that check for PG
+        assert_db_type(bt['new_column'], pg_db_type, expected_series)
+
     assert_equals_data(
         bt,
         expected_columns=[
@@ -34,53 +40,65 @@ def check_set_const(constant, db_type: str, expected_series: Type[Series]):
     assert bt.new_column == bt['new_column']
 
 
-def test_set_const_int():
-    check_set_const(np.int64(4), 'bigint', SeriesInt64)
-    check_set_const(5, 'bigint', SeriesInt64)
-    check_set_const(2147483647, 'bigint', SeriesInt64)
-    check_set_const(2147483648, 'bigint', SeriesInt64)
+def test_set_const_int(engine):
+    check_set_const(engine, np.int64(4), SeriesInt64, 'bigint')
+    check_set_const(engine, 5, SeriesInt64, 'bigint')
+    check_set_const(engine, 2147483647, SeriesInt64, 'bigint')
+    check_set_const(engine, 2147483648, SeriesInt64, 'bigint')
 
 
 def test_set_const_float():
-    check_set_const(5.1, 'double precision', SeriesFloat64)
+    engine = get_postgres_engine_dialect().engine  # TODO: BigQuery
+    check_set_const(engine, 5.1, SeriesFloat64, 'double precision')
 
 
-def test_set_const_bool():
-    check_set_const(True, 'boolean', SeriesBoolean)
+def test_set_const_bool(engine):
+    check_set_const(engine, True, SeriesBoolean, 'boolean')
 
 
-def test_set_const_str():
-    check_set_const('keatsen', 'text', SeriesString)
+def test_set_const_str(engine):
+    check_set_const(engine, 'keatsen', SeriesString, 'text')
 
 
-def test_set_const_date():
-    check_set_const(datetime.date(2019, 1, 5), 'date', SeriesDate)
+def test_set_const_date(engine):
+    check_set_const(engine, datetime.date(2019, 1, 5), SeriesDate, 'date')
 
 
 def test_set_const_datetime():
-    check_set_const(datetime.datetime.now(), 'timestamp without time zone', SeriesTimestamp)
+    engine = get_postgres_engine_dialect().engine  # TODO: BigQuery
+    check_set_const(engine, datetime.datetime.now(), SeriesTimestamp, 'timestamp without time zone')
 
 
 def test_set_const_time():
-    check_set_const(datetime.time.fromisoformat('00:05:23.283'), 'time without time zone', SeriesTime)
+    engine = get_postgres_engine_dialect().engine  # TODO: BigQuery
+    check_set_const(
+        engine,
+        datetime.time.fromisoformat('00:05:23.283'),
+        SeriesTime,
+        'time without time zone'
+    )
 
 
 def test_set_const_timedelta():
+    engine = get_postgres_engine_dialect().engine  # TODO: BigQuery
     check_set_const(
+        engine,
         np.datetime64('2005-02-25T03:30') - np.datetime64('2005-01-25T03:30'),
-        'interval',
-        SeriesTimedelta
+        SeriesTimedelta,
+        'interval'
     )
     check_set_const(
+        engine,
         datetime.datetime.now() - datetime.datetime(2015, 4, 6),
-        'interval',
-        SeriesTimedelta
+        SeriesTimedelta,
+        'interval'
     )
 
 
 def test_set_const_json():
-    check_set_const(['a', 'b', 'c'], 'jsonb', SeriesJsonb)
-    check_set_const({'a': 'b', 'c': 'd'}, 'jsonb', SeriesJsonb)
+    engine = get_postgres_engine_dialect().engine  # TODO: BigQuery
+    check_set_const(engine, ['a', 'b', 'c'], SeriesJsonb, 'jsonb')
+    check_set_const(engine, {'a': 'b', 'c': 'd'}, SeriesJsonb, 'jsonb')
 
 
 def test_set_const_int_from_series():

--- a/bach/tests/functional/bach/test_pandas_loading.py
+++ b/bach/tests/functional/bach/test_pandas_loading.py
@@ -3,7 +3,7 @@ Copyright 2021 Objectiv B.V.
 """
 from bach import SeriesBoolean, SeriesInt64, SeriesString, \
     SeriesFloat64, SeriesTimestamp
-from tests.functional.bach.test_data_and_utils import get_bt, assert_db_type
+from tests.functional.bach.test_data_and_utils import get_bt, assert_postgres_type
 
 import datetime
 
@@ -17,11 +17,11 @@ def test_all_supported_types():
                 ['float', 'int', 'timestamp', 'string', 'bool'],
                 convert_objects=True)
 
-    assert_db_type(bt['float'], 'double precision', SeriesFloat64)
-    assert_db_type(bt['int'], 'bigint', SeriesInt64)
-    assert_db_type(bt['timestamp'], 'timestamp without time zone', SeriesTimestamp)
-    assert_db_type(bt['string'], 'text', SeriesString)
-    assert_db_type(bt['bool'], 'boolean', SeriesBoolean)
+    assert_postgres_type(bt['float'], 'double precision', SeriesFloat64)
+    assert_postgres_type(bt['int'], 'bigint', SeriesInt64)
+    assert_postgres_type(bt['timestamp'], 'timestamp without time zone', SeriesTimestamp)
+    assert_postgres_type(bt['string'], 'text', SeriesString)
+    assert_postgres_type(bt['bool'], 'boolean', SeriesBoolean)
 
 
 def test_string_as_index():
@@ -33,11 +33,11 @@ def test_string_as_index():
                 ['string', 'float', 'int', 'timestamp', 'bool'],
                 convert_objects=True)
 
-    assert_db_type(bt['float'], 'double precision', SeriesFloat64)
-    assert_db_type(bt['int'], 'bigint', SeriesInt64)
-    assert_db_type(bt['timestamp'], 'timestamp without time zone', SeriesTimestamp)
-    assert_db_type(bt['string'], 'text', SeriesString)
-    assert_db_type(bt['bool'], 'boolean', SeriesBoolean)
+    assert_postgres_type(bt['float'], 'double precision', SeriesFloat64)
+    assert_postgres_type(bt['int'], 'bigint', SeriesInt64)
+    assert_postgres_type(bt['timestamp'], 'timestamp without time zone', SeriesTimestamp)
+    assert_postgres_type(bt['string'], 'text', SeriesString)
+    assert_postgres_type(bt['bool'], 'boolean', SeriesBoolean)
 
 
 def test_load_df_without_conversion():
@@ -49,7 +49,7 @@ def test_load_df_without_conversion():
                 ['float', 'int', 'timestamp', 'bool'],
                 convert_objects=False)
 
-    assert_db_type(bt['float'], 'double precision', SeriesFloat64)
-    assert_db_type(bt['int'], 'bigint', SeriesInt64)
-    assert_db_type(bt['timestamp'], 'timestamp without time zone', SeriesTimestamp)
-    assert_db_type(bt['bool'], 'boolean', SeriesBoolean)
+    assert_postgres_type(bt['float'], 'double precision', SeriesFloat64)
+    assert_postgres_type(bt['int'], 'bigint', SeriesInt64)
+    assert_postgres_type(bt['timestamp'], 'timestamp without time zone', SeriesTimestamp)
+    assert_postgres_type(bt['bool'], 'boolean', SeriesBoolean)

--- a/bach/tests/functional/bach/test_series_date.py
+++ b/bach/tests/functional/bach/test_series_date.py
@@ -7,7 +7,7 @@ import pytest
 
 from bach import SeriesDate
 from tests.functional.bach.test_data_and_utils import assert_equals_data, get_bt_with_food_data, \
-    assert_db_type, get_bt_with_test_data
+    assert_postgres_type, get_bt_with_test_data
 from tests.functional.bach.test_series_timestamp import types_plus_min
 
 
@@ -18,7 +18,7 @@ def test_date_comparator(asstring: bool):
     # import code has no means to distinguish between date and timestamp
     mt['date'] = mt['date'].astype('date')
 
-    assert_db_type(mt['date'], 'date', SeriesDate)
+    assert_postgres_type(mt['date'], 'date', SeriesDate)
 
     from datetime import date
     dt = date(2021, 5, 3)

--- a/bach/tests/functional/bach/test_series_int.py
+++ b/bach/tests/functional/bach/test_series_int.py
@@ -3,7 +3,7 @@ Copyright 2021 Objectiv B.V.
 """
 from bach import Series, SeriesInt64
 from tests.functional.bach.test_data_and_utils import get_bt_with_test_data, assert_equals_data, \
-    assert_db_type
+    assert_postgres_type
 from tests.functional.bach.test_series_numeric import _test_simple_arithmetic
 
 
@@ -11,7 +11,7 @@ def test_add_int_constant():
     bt = get_bt_with_test_data()
     bts = bt['founding'] + 200
     assert isinstance(bts, Series)
-    assert_db_type(bt['founding'], 'bigint', SeriesInt64)
+    assert_postgres_type(bt['founding'], 'bigint', SeriesInt64)
     assert_equals_data(
         bts,
         expected_columns=['_index_skating_order', 'founding'],
@@ -34,7 +34,7 @@ def test_create_big_int_constant():
     bt['calc'] = bt['new'] + 100
     # Add something to new_big, the number still fits into 8 bytes.
     bt['calc_big'] = bt['new_big'] + 100000
-    assert_db_type(bt['calc_big'], 'bigint', SeriesInt64)
+    assert_postgres_type(bt['calc_big'], 'bigint', SeriesInt64)
     assert_equals_data(
         bt,
         expected_columns=['_index_skating_order', 'city', 'new', 'new_big', 'calc', 'calc_big'],


### PR DESCRIPTION
Changes: 
* Make tests in test_df_setitem.py multi-database for tests that work out of the box, and prepare changing others
* Renamed test function `assert_db_type` to `assert_postgres_type`, as that won't be trivial to do on BigQuery (and not that important)

Impact:
* No actual Bach code has changed, only test code changed.
* No tests were removed.
* Some tests now run for BigQuery too