### PR TITLE
Consistently use Postgres specific test url in tests

### DIFF
--- a/.github/workflows/bach-tests.yml
+++ b/.github/workflows/bach-tests.yml
@@ -33,7 +33,7 @@ jobs:
           - 5432:5432
     env:
       # tell tests to use the above defined postgres service
-      OBJ_DB_TEST_URL: 'postgresql://objectiv:no_password_set@localhost:5432/objectiv'
+      OBJ_DB_PG_TEST_URL: 'postgresql://objectiv:no_password_set@localhost:5432/objectiv'
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/modelhub_tests.yml
+++ b/.github/workflows/modelhub_tests.yml
@@ -34,7 +34,7 @@ jobs:
           - 5432:5432
     env:
       # tell tests to use the above defined postgres service
-      OBJ_DB_TEST_URL: 'postgresql://objectiv:no_password_set@localhost:5432/objectiv'
+      OBJ_DB_PG_TEST_URL: 'postgresql://objectiv:no_password_set@localhost:5432/objectiv'
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/bach/docs/source/conf.py
+++ b/bach/docs/source/conf.py
@@ -25,8 +25,8 @@ import pandas as pd
 try:
     import os
     import sqlalchemy
-    DB_TEST_URL = os.environ.get('OBJ_DB_TEST_URL', 'postgresql://objectiv:@localhost:5432/objectiv')
-    engine = sqlalchemy.create_engine(DB_TEST_URL)
+    DB_PG_TEST_URL = os.environ.get('OBJ_DB_PG_TEST_URL', 'postgresql://objectiv:@localhost:5432/objectiv')
+    engine = sqlalchemy.create_engine(DB_PG_TEST_URL)
 except Exception:
     engine = None
 '''

--- a/bach/tests/conftest.py
+++ b/bach/tests/conftest.py
@@ -5,10 +5,14 @@ There is some pytest 'magic' here that automatically fills out the 'engine' and 
 test functions that have either of those.
 By default such a test function will get a Postgres dialect or engine. But if --big-query or --all is
 specified on the commandline, then it will (also) get a BigQuery dialect or engine.
+
+Additionally we define a 'pg_engine' fixture here that always return a Postgres engine.
 """
 import os
 from typing import NamedTuple, Optional
 
+import pytest
+import sqlalchemy
 from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine, Dialect
 
@@ -18,6 +22,11 @@ DB_BQ_CREDENTIALS_PATH = os.environ.get(
     'OBJ_DB_BQ_CREDENTIALS_PATH',
     os.path.dirname(os.path.dirname(os.path.realpath(__file__))) + '/.secrets/bach-big-query-testing.json'
 )
+
+
+@pytest.fixture()
+def pg_engine() -> Engine:
+    return sqlalchemy.create_engine(DB_PG_TEST_URL)
 
 
 def pytest_addoption(parser):

--- a/bach/tests/functional/bach/test_data_and_utils.py
+++ b/bach/tests/functional/bach/test_data_and_utils.py
@@ -16,8 +16,8 @@ from sqlalchemy.engine import ResultProxy, Engine
 from bach import DataFrame, Series
 from bach.types import get_series_type_from_db_dtype
 from sql_models.util import is_bigquery, is_postgres
+from tests.conftest import DB_PG_TEST_URL
 
-DB_TEST_URL = os.environ.get('OBJ_DB_TEST_URL', 'postgresql://objectiv:@localhost:5432/objectiv')
 
 # Three data tables for testing are defined here that can be used in tests
 # 1. cities: 3 rows (or 11 for the full dataset) of data on cities
@@ -135,7 +135,7 @@ def get_pandas_df(dataset: List[List[Any]], columns: List[str]) -> pandas.DataFr
 
 def get_from_df(table: str, df: pandas.DataFrame, convert_objects=True) -> DataFrame:
     """ Create a database table with the data from the data-frame. """
-    engine = sqlalchemy.create_engine(DB_TEST_URL)
+    engine = sqlalchemy.create_engine(DB_PG_TEST_URL)
     buh_tuh = DataFrame.from_pandas(
         engine=engine,
         df=df,
@@ -293,7 +293,7 @@ def assert_postgres_type(
     """
     sql = series.to_frame().view_sql()
     sql = f'with check_type as ({sql}) select pg_typeof("{series.name}") from check_type limit 1'
-    db_rows = run_query(sqlalchemy.create_engine(DB_TEST_URL), sql)
+    db_rows = run_query(sqlalchemy.create_engine(DB_PG_TEST_URL), sql)
     db_values = [list(row) for row in db_rows]
     db_type = db_values[0][0]
     if expected_db_type:

--- a/bach/tests/functional/bach/test_df_from.py
+++ b/bach/tests/functional/bach/test_df_from.py
@@ -11,7 +11,7 @@ from sqlalchemy.engine import Engine
 
 from bach import DataFrame
 from sql_models.model import CustomSqlModelBuilder, SqlModel
-from tests.functional.bach.test_data_and_utils import DB_TEST_URL
+from tests.functional.bach.test_data_and_utils import DB_PG_TEST_URL
 
 
 def _create_test_table(engine: Engine, table_name: str):
@@ -22,7 +22,7 @@ def _create_test_table(engine: Engine, table_name: str):
 
 
 def test_from_table_basic():
-    engine = sqlalchemy.create_engine(DB_TEST_URL)
+    engine = sqlalchemy.create_engine(DB_PG_TEST_URL)
     table_name = 'test_df_from_table'
     _create_test_table(engine, table_name)
 
@@ -48,7 +48,7 @@ def test_from_table_basic():
 def test_from_model_basic():
     # This is essentially the same test as test_from_table_basic(), but tests creating the dataframe with
     # from_model instead of from_table
-    engine = sqlalchemy.create_engine(DB_TEST_URL)
+    engine = sqlalchemy.create_engine(DB_PG_TEST_URL)
     table_name = 'test_df_from_table'
     _create_test_table(engine, table_name)
     sql_model: SqlModel = CustomSqlModelBuilder(sql=f'select * from {table_name}')()
@@ -74,7 +74,7 @@ def test_from_model_basic():
 
 def test_from_table_column_ordering():
     # Create a Dataframe in which the index is not the first column in the table.
-    engine = sqlalchemy.create_engine(DB_TEST_URL)
+    engine = sqlalchemy.create_engine(DB_PG_TEST_URL)
     table_name = 'test_df_from_table'
     _create_test_table(engine, table_name)
 
@@ -101,7 +101,7 @@ def test_from_model_column_ordering():
     # from_model instead of from_table
 
     # Create a Dataframe in which the index is not the first column in the table.
-    engine = sqlalchemy.create_engine(DB_TEST_URL)
+    engine = sqlalchemy.create_engine(DB_PG_TEST_URL)
     table_name = 'test_df_from_table'
     _create_test_table(engine, table_name)
     sql_model: SqlModel = CustomSqlModelBuilder(sql=f'select * from {table_name}')()

--- a/bach/tests/functional/bach/test_df_from.py
+++ b/bach/tests/functional/bach/test_df_from.py
@@ -6,12 +6,10 @@ tests for:
  * DataFrame.from_model()
 
 """
-import sqlalchemy
 from sqlalchemy.engine import Engine
 
 from bach import DataFrame
 from sql_models.model import CustomSqlModelBuilder, SqlModel
-from tests.functional.bach.test_data_and_utils import DB_PG_TEST_URL
 
 
 def _create_test_table(engine: Engine, table_name: str):
@@ -21,8 +19,8 @@ def _create_test_table(engine: Engine, table_name: str):
         conn.execute(sql)
 
 
-def test_from_table_basic():
-    engine = sqlalchemy.create_engine(DB_PG_TEST_URL)
+def test_from_table_basic(pg_engine):
+    engine = pg_engine
     table_name = 'test_df_from_table'
     _create_test_table(engine, table_name)
 
@@ -45,10 +43,10 @@ def test_from_table_basic():
     assert df == df_all_dtypes
 
 
-def test_from_model_basic():
+def test_from_model_basic(pg_engine):
     # This is essentially the same test as test_from_table_basic(), but tests creating the dataframe with
     # from_model instead of from_table
-    engine = sqlalchemy.create_engine(DB_PG_TEST_URL)
+    engine = pg_engine
     table_name = 'test_df_from_table'
     _create_test_table(engine, table_name)
     sql_model: SqlModel = CustomSqlModelBuilder(sql=f'select * from {table_name}')()
@@ -72,9 +70,9 @@ def test_from_model_basic():
     assert df == df_all_dtypes
 
 
-def test_from_table_column_ordering():
+def test_from_table_column_ordering(pg_engine):
     # Create a Dataframe in which the index is not the first column in the table.
-    engine = sqlalchemy.create_engine(DB_PG_TEST_URL)
+    engine = pg_engine
     table_name = 'test_df_from_table'
     _create_test_table(engine, table_name)
 
@@ -96,12 +94,12 @@ def test_from_table_column_ordering():
     assert df == df_all_dtypes
 
 
-def test_from_model_column_ordering():
+def test_from_model_column_ordering(pg_engine):
     # This is essentially the same test as test_from_table_model_ordering(), but tests creating the dataframe with
     # from_model instead of from_table
 
     # Create a Dataframe in which the index is not the first column in the table.
-    engine = sqlalchemy.create_engine(DB_PG_TEST_URL)
+    engine = pg_engine
     table_name = 'test_df_from_table'
     _create_test_table(engine, table_name)
     sql_model: SqlModel = CustomSqlModelBuilder(sql=f'select * from {table_name}')()

--- a/bach/tests/functional/bach/test_df_from_pandas.py
+++ b/bach/tests/functional/bach/test_df_from_pandas.py
@@ -5,8 +5,9 @@ import pytest
 import sqlalchemy
 
 from bach import DataFrame
+from tests.conftest import DB_PG_TEST_URL
 from tests.functional.bach.test_data_and_utils import get_pandas_df, TEST_DATA_CITIES, CITIES_COLUMNS, \
-    DB_TEST_URL, assert_equals_data
+    assert_equals_data
 import datetime
 from uuid import UUID
 import pandas as pd
@@ -51,7 +52,7 @@ TYPES_COLUMNS = ['int_column', 'float_column', 'bool_column', 'datetime_column',
 
 def test_from_pandas_table():
     pdf = get_pandas_df(TEST_DATA_CITIES, CITIES_COLUMNS)
-    engine = sqlalchemy.create_engine(DB_TEST_URL)
+    engine = sqlalchemy.create_engine(DB_PG_TEST_URL)
     bt = DataFrame.from_pandas(
         engine=engine,
         df=pdf,
@@ -65,7 +66,7 @@ def test_from_pandas_table():
 
 def test_from_pandas_table_injection():
     pdf = get_pandas_df(TEST_DATA_INJECTION, COLUMNS_INJECTION)
-    engine = sqlalchemy.create_engine(DB_TEST_URL)
+    engine = sqlalchemy.create_engine(DB_PG_TEST_URL)
     bt = DataFrame.from_pandas(
         engine=engine,
         df=pdf,
@@ -79,7 +80,7 @@ def test_from_pandas_table_injection():
 
 def test_from_pandas_ephemeral_basic():
     pdf = get_pandas_df(TEST_DATA_CITIES, CITIES_COLUMNS)
-    engine = sqlalchemy.create_engine(DB_TEST_URL)
+    engine = sqlalchemy.create_engine(DB_PG_TEST_URL)
     bt = DataFrame.from_pandas(
         engine=engine,
         df=pdf,
@@ -92,7 +93,7 @@ def test_from_pandas_ephemeral_basic():
 
 def test_from_pandas_ephemeral_injection():
     pdf = get_pandas_df(TEST_DATA_INJECTION, COLUMNS_INJECTION)
-    engine = sqlalchemy.create_engine(DB_TEST_URL)
+    engine = sqlalchemy.create_engine(DB_PG_TEST_URL)
     bt = DataFrame.from_pandas(
         engine=engine,
         df=pdf,
@@ -105,7 +106,7 @@ def test_from_pandas_ephemeral_injection():
 
 def test_from_pandas_non_happy_path():
     pdf = get_pandas_df(TEST_DATA_CITIES, CITIES_COLUMNS)
-    engine = sqlalchemy.create_engine(DB_TEST_URL)
+    engine = sqlalchemy.create_engine(DB_PG_TEST_URL)
     with pytest.raises(TypeError):
         # if convert_objects is false, we'll get an error, because pdf's dtype for 'city' and 'municipality'
         # is 'object
@@ -140,7 +141,7 @@ def test_from_pandas_non_happy_path():
 def test_from_pandas_index(materialization: str):
     # test multilevel index
     pdf = get_pandas_df(TEST_DATA_CITIES, CITIES_COLUMNS).set_index(['skating_order', 'city'])
-    engine = sqlalchemy.create_engine(DB_TEST_URL)
+    engine = sqlalchemy.create_engine(DB_PG_TEST_URL)
     bt = DataFrame.from_pandas(
         engine=engine,
         df=pdf,
@@ -161,7 +162,7 @@ def test_from_pandas_index(materialization: str):
 
     # test nameless index
     pdf.reset_index(inplace=True)
-    engine = sqlalchemy.create_engine(DB_TEST_URL)
+    engine = sqlalchemy.create_engine(DB_PG_TEST_URL)
     bt = DataFrame.from_pandas(
         engine=engine,
         df=pdf,
@@ -186,7 +187,7 @@ def test_from_pandas_index(materialization: str):
 def test_from_pandas_types(materialization: str):
     pdf = pd.DataFrame.from_records(TYPES_DATA, columns=TYPES_COLUMNS)
     pdf.set_index(pdf.columns[0], drop=True, inplace=True)
-    engine = sqlalchemy.create_engine(DB_TEST_URL)
+    engine = sqlalchemy.create_engine(DB_PG_TEST_URL)
     df = DataFrame.from_pandas(
         engine=engine,
         df=pdf.loc[:, :'string_column'],
@@ -240,7 +241,7 @@ def test_from_pandas_types(materialization: str):
 def test_from_pandas_types_cte():
     pdf = pd.DataFrame.from_records(TYPES_DATA, columns=TYPES_COLUMNS)
     pdf.set_index(pdf.columns[0], drop=True, inplace=True)
-    engine = sqlalchemy.create_engine(DB_TEST_URL)
+    engine = sqlalchemy.create_engine(DB_PG_TEST_URL)
     df = DataFrame.from_pandas(
         engine=engine,
         df=pdf.loc[:, :'timedelta_column'],

--- a/bach/tests/functional/sql_models/test_sql_generator_materialization.py
+++ b/bach/tests/functional/sql_models/test_sql_generator_materialization.py
@@ -10,10 +10,8 @@ from sqlalchemy.dialects.postgresql.base import PGDialect
 from sql_models.graph_operations import find_node, replace_node_in_graph
 from sql_models.model import Materialization
 from sql_models.sql_generator import to_sql_materialized_nodes
+from tests.conftest import DB_PG_TEST_URL
 from tests.unit.sql_models.util import ValueModel, RefModel, JoinModel, RefValueModel
-
-
-DB_TEST_URL = os.environ.get('OBJ_DB_TEST_URL', 'postgresql://objectiv:@localhost:5432/objectiv')
 
 
 def test_execute_multi_statement_sql_materialization():
@@ -165,7 +163,7 @@ def run_queries(sql_statements: Dict[str, str]) -> Dict[str, Optional[Tuple[List
         raise ValueError('Expected non-empty dictionary')
     result = {}
 
-    engine = sqlalchemy.create_engine(DB_TEST_URL)
+    engine = sqlalchemy.create_engine(DB_PG_TEST_URL)
     with engine.connect() as conn:
         with conn.begin() as transaction:
             for name, sql in sql_statements.items():

--- a/bach/tests/functional/sql_models/test_sql_generator_materialization.py
+++ b/bach/tests/functional/sql_models/test_sql_generator_materialization.py
@@ -1,20 +1,19 @@
 """
 Copyright 2021 Objectiv B.V.
 """
-import os
 from typing import List, Any, Tuple, Dict, Optional
 
 import sqlalchemy
 from sqlalchemy.dialects.postgresql.base import PGDialect
+from sqlalchemy.engine import Engine
 
 from sql_models.graph_operations import find_node, replace_node_in_graph
 from sql_models.model import Materialization
 from sql_models.sql_generator import to_sql_materialized_nodes
-from tests.conftest import DB_PG_TEST_URL
 from tests.unit.sql_models.util import ValueModel, RefModel, JoinModel, RefValueModel
 
 
-def test_execute_multi_statement_sql_materialization():
+def test_execute_multi_statement_sql_materialization(pg_engine):
     # Graph, with values calculated by the query shown above each node
     #
     #                                              16
@@ -46,7 +45,7 @@ def test_execute_multi_statement_sql_materialization():
     # Verify that the model's query gives the expected output
     sql_statements = to_sql_materialized_nodes(dialect=dialect, start_node=graph, include_start_node=True)
     assert len(sql_statements) == 1
-    result = run_queries(sql_statements)
+    result = run_queries(engine=pg_engine, sql_statements=sql_statements)
     assert result['graph'] == expected
 
     # Test: modify materialization of node 'jm2' in the graph
@@ -60,7 +59,7 @@ def test_execute_multi_statement_sql_materialization():
     # Verify that the model's query gives the expected output
     sql_statements = to_sql_materialized_nodes(dialect, graph)
     assert len(sql_statements) == 2
-    result = run_queries(sql_statements)
+    result = run_queries(engine=pg_engine, sql_statements=sql_statements)
     assert result['graph'] == expected
 
     # Test: modify materialization of nodes 'jm1' and 'rvm2' in the graph
@@ -77,7 +76,7 @@ def test_execute_multi_statement_sql_materialization():
     # Verify that the model's query gives the expected output
     sql_statements = to_sql_materialized_nodes(dialect, graph)
     assert len(sql_statements) == 4
-    result = run_queries(sql_statements)
+    result = run_queries(engine=pg_engine, sql_statements=sql_statements)
     assert result['graph'] == expected
 
     # Test: modify materialization of nodes 'rvm1' in the graph, to 'QUERY' meaning it should be a separate
@@ -90,7 +89,7 @@ def test_execute_multi_statement_sql_materialization():
     # Verify that the model's query gives the expected output
     sql_statements = to_sql_materialized_nodes(dialect, graph)
     assert len(sql_statements) == 5
-    result = run_queries(sql_statements)
+    result = run_queries(engine=pg_engine, sql_statements=sql_statements)
     assert result == {
         'JoinModel___e0bab08e339f02ef255537649ef13be1': None,
         'JoinModel___e716b40925362305c0dda48e7bb5bd06': None,
@@ -106,7 +105,7 @@ def test_execute_multi_statement_sql_materialization():
     }
 
 
-def test_materialized_shared_ctes():
+def test_materialized_shared_ctes(pg_engine):
     # Graph: jm1 and jm2 are materialized, vm2 is shared between the two
     #    1
     #   vm1 <---\     3
@@ -133,7 +132,7 @@ def test_materialized_shared_ctes():
     # Verify that the model's query gives the expected output
     sql_statements = to_sql_materialized_nodes(dialect, graph)
     assert len(sql_statements) == 3
-    result = run_queries(sql_statements)
+    result = run_queries(engine=pg_engine, sql_statements=sql_statements)
     assert result == {
         'graph': (
             ['key', 'value'],
@@ -144,7 +143,10 @@ def test_materialized_shared_ctes():
     }
 
 
-def run_queries(sql_statements: Dict[str, str]) -> Dict[str, Optional[Tuple[List[str], List[List[Any]]]]]:
+def run_queries(
+    engine: Engine,
+    sql_statements: Dict[str, str]
+) -> Dict[str, Optional[Tuple[List[str], List[List[Any]]]]]:
     """
     Execute all sql statements and return a dictionary with the result of each. The statements will be
     executed inside a transaction that will be rolled back, which will any table/view create statements.
@@ -163,7 +165,6 @@ def run_queries(sql_statements: Dict[str, str]) -> Dict[str, Optional[Tuple[List
         raise ValueError('Expected non-empty dictionary')
     result = {}
 
-    engine = sqlalchemy.create_engine(DB_PG_TEST_URL)
     with engine.connect() as conn:
         with conn.begin() as transaction:
             for name, sql in sql_statements.items():

--- a/modelhub/tests_modelhub/functional/modelhub/data_and_utils.py
+++ b/modelhub/tests_modelhub/functional/modelhub/data_and_utils.py
@@ -10,7 +10,7 @@ from bach import DataFrame
 import sqlalchemy
 import os
 
-DB_TEST_URL = os.environ.get('OBJ_DB_TEST_URL', 'postgresql://objectiv:@localhost:5432/objectiv')
+DB_TEST_URL = os.environ.get('OBJ_DB_PG_TEST_URL', 'postgresql://objectiv:@localhost:5432/objectiv')
 
 # all data below is generated dummy data
 TEST_DATA_JSON_REAL = [
@@ -49,6 +49,7 @@ TEST_DATA_OBJECTIV = '''
     ('12b55ed5-4295-4fc1-bf1f-88d64d1ac312','2021-11-29','2021-11-29 10:23:36.287','b2df75d2-d7ca-48ac-9747-af47d7a4a2b2','{"_type": "ClickEvent", "location_stack": [{"_type": "WebDocumentContext", "id": "#document", "url": "https://objectiv.io/docs/taxonomy/", "_types": ["AbstractContext", "AbstractLocationContext", "SectionContext", "WebDocumentContext"]}, {"_type": "SectionContext", "id": "navbar-top", "_types": ["AbstractContext", "AbstractLocationContext", "SectionContext"]}, {"_type": "LinkContext", "id": "logo", "text": "Objectiv Documentation Logo", "href": "/docs/", "_types": ["AbstractContext", "AbstractLocationContext", "ActionContext", "ItemContext", "LinkContext"]}], "global_contexts": [{"_type": "ApplicationContext", "id": "objectiv-docs", "_types": ["AbstractContext", "AbstractGlobalContext", "ApplicationContext"]}, {"id": "http_context", "referrer": "https://objectiv.io/", "user_agent": "Mozilla/5.0 (Linux; Android 11; SM-G986B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.74 Mobile Safari/537.36", "_type": "HttpContext", "_types": ["AbstractContext", "AbstractGlobalContext", "HttpContext"]}, {"id": "81a8ace2-273b-4b95-b6a6-0fba33858a22", "cookie_id": "81a8ace2-273b-4b95-b6a6-0fba33858a22", "_type": "CookieIdContext", "_types": ["AbstractContext", "AbstractGlobalContext", "CookieIdContext"]}], "id": "e2445152-327a-466f-a2bf-116f0146ab7a", "time": 1636476196460, "_types": ["AbstractEvent", "ClickEvent", "InteractiveEvent"]}')
 '''
 
+
 def get_bt_with_json_data_real() -> DataFrame:
     bt = get_bt('test_json_table_real', TEST_DATA_JSON_REAL, JSON_COLUMNS_REAL, True)
     bt['global_contexts'] = bt.global_contexts.astype('jsonb')
@@ -78,7 +79,7 @@ def get_objectiv_dataframe_test(time_aggregation=None):
 
     kwargs = {}
     if time_aggregation:
-        kwargs = {'time_aggregation':time_aggregation}
+        kwargs = {'time_aggregation': time_aggregation}
     modelhub = ModelHub(**kwargs)
 
     return modelhub.get_objectiv_dataframe(DB_TEST_URL, table_name='objectiv_data'), modelhub


### PR DESCRIPTION
In an earlier PR, I introduced a new DB URL in `conftest.py` to distinguish Postgres from BigQuery (https://github.com/objectiv/objectiv-analytics/pull/517/files#diff-ac4981ffe5414f6a0da82969dd8fea67abe29feb825bbaa985495b5aefb35b23). I forgot to use that consistently tho. This PR changes that.