### PR TITLE
Support `from_table()` for BigQuery basic data types

### DIFF
--- a/bach/bach/series/series.py
+++ b/bach/bach/series/series.py
@@ -23,7 +23,7 @@ from bach.expression import Expression, NonAtomicExpression, ConstValueExpressio
 from bach.sql_model import BachSqlModel
 
 from bach.types import value_to_dtype, DtypeOrAlias
-from sql_models.constants import NotSet, not_set
+from sql_models.constants import NotSet, not_set, DBDialect
 
 if TYPE_CHECKING:
     from bach.partitioning import GroupBy, Window
@@ -82,10 +82,10 @@ class Series(ABC):
     Subclasses can override this value to indicate what strings they consider aliases for their dtype.
     """
 
-    supported_db_dtype: Optional[str] = None
+    supported_db_dtype: Mapping[DBDialect, str] = {}
     """
-    INTERNAL: Database level data type, that can be expressed using this Series type.
-    Example: 'double precision' for a float in Postgres
+    INTERNAL: Per supported database, the database's data type that can be expressed using this Series type.
+    Example: {DBDialect.POSTGRES: 'double precision'} for a float in Postgres
 
     Subclasses should override this value if they intend to be the default class to handle such types.
     When creating a DataFrame from existing data in a database, this field will be used to

--- a/bach/bach/series/series_boolean.py
+++ b/bach/bach/series/series_boolean.py
@@ -7,6 +7,7 @@ from typing import cast
 from bach.series import Series, const_to_series
 from bach.expression import Expression
 from bach.series.series import WrappedPartition
+from sql_models.constants import DBDialect
 
 
 class SeriesBoolean(Series, ABC):
@@ -30,7 +31,10 @@ class SeriesBoolean(Series, ABC):
     """
     dtype = 'bool'
     dtype_aliases = ('boolean', '?', bool)
-    supported_db_dtype = 'boolean'
+    supported_db_dtype = {
+        DBDialect.POSTGRES: 'boolean',
+        DBDialect.BIGQUERY: 'boolean',
+    }
     supported_value_types = (bool, )
 
     # Notes for supported_value_to_literal() and supported_literal_to_expression():

--- a/bach/bach/series/series_json.py
+++ b/bach/bach/series/series_json.py
@@ -9,6 +9,7 @@ from bach.expression import Expression
 from bach.series.series import WrappedPartition
 from bach.sql_model import BachSqlModel
 from bach.types import DtypeOrAlias
+from sql_models.constants import DBDialect
 from sql_models.util import quote_string
 
 if TYPE_CHECKING:
@@ -119,7 +120,9 @@ class SeriesJsonb(Series):
     dtype = 'jsonb'
     # todo can only assign a type to one series type, and object is quite generic
     dtype_aliases: Tuple[DtypeOrAlias, ...] = tuple()
-    supported_db_dtype = 'jsonb'
+    supported_db_dtype = {
+        DBDialect.POSTGRES: 'jsonb',
+    }
     supported_value_types = (dict, list)
     return_dtype = dtype
 
@@ -356,7 +359,9 @@ class SeriesJson(SeriesJsonb):
     """
     dtype = 'json'
     dtype_aliases: Tuple[DtypeOrAlias, ...] = tuple()
-    supported_db_dtype = 'json'
+    supported_db_dtype = {
+        DBDialect.POSTGRES: 'json',
+    }
     return_dtype = 'jsonb'
 
     def __init__(self,

--- a/bach/bach/series/series_numeric.py
+++ b/bach/bach/series/series_numeric.py
@@ -9,6 +9,7 @@ import numpy
 from bach.series import Series
 from bach.expression import Expression, AggregateFunctionExpression
 from bach.series.series import WrappedPartition
+from sql_models.constants import DBDialect
 
 if TYPE_CHECKING:
     from bach.series import SeriesBoolean
@@ -179,7 +180,10 @@ class SeriesAbstractNumeric(Series, ABC):
 class SeriesInt64(SeriesAbstractNumeric):
     dtype = 'int64'
     dtype_aliases = ('integer', 'bigint', 'i8', int, numpy.int64, 'int32')
-    supported_db_dtype = 'bigint'
+    supported_db_dtype = {
+        DBDialect.POSTGRES: 'bigint',
+        DBDialect.BIGQUERY: 'INT64'
+    }
     supported_value_types = (int, numpy.int64, numpy.int32)
 
     # Notes for supported_value_to_literal() and supported_literal_to_expression():
@@ -237,7 +241,10 @@ class SeriesInt64(SeriesAbstractNumeric):
 class SeriesFloat64(SeriesAbstractNumeric):
     dtype = 'float64'
     dtype_aliases = ('float', 'double', 'f8', float, numpy.float64, 'double precision')
-    supported_db_dtype = 'double precision'
+    supported_db_dtype = {
+        DBDialect.POSTGRES: 'double precision',
+        DBDialect.BIGQUERY: 'FLOAT64'
+    }
     supported_value_types = (float, numpy.float64)
 
     # Notes for supported_value_to_literal() and supported_literal_to_expression():

--- a/bach/bach/series/series_string.py
+++ b/bach/bach/series/series_string.py
@@ -5,6 +5,7 @@ from typing import Union, TYPE_CHECKING
 
 from bach.series import Series
 from bach.expression import Expression
+from sql_models.constants import DBDialect
 
 if TYPE_CHECKING:
     from bach.series import SeriesBoolean
@@ -110,7 +111,10 @@ class SeriesString(Series):
 
     dtype = 'string'
     dtype_aliases = ('text', str)
-    supported_db_dtype = 'text'
+    supported_db_dtype = {
+        DBDialect.POSTGRES: 'text',
+        DBDialect.BIGQUERY: 'STRING'
+    }
     supported_value_types = (str, type(None))  # NoneType ends up as a string for now
 
     @classmethod

--- a/bach/bach/series/series_uuid.py
+++ b/bach/bach/series/series_uuid.py
@@ -8,6 +8,7 @@ from bach import DataFrameOrSeries
 from bach.series import Series, const_to_series
 from bach.expression import Expression
 from bach.series.series import WrappedPartition
+from sql_models.constants import DBDialect
 
 
 class SeriesUuid(Series):
@@ -16,7 +17,10 @@ class SeriesUuid(Series):
     """
     dtype = 'uuid'
     dtype_aliases = ()
-    supported_db_dtype = 'uuid'
+    supported_db_dtype = {
+        DBDialect.POSTGRES: 'uuid',
+    }
+
     supported_value_types = (UUID, str)
 
     @classmethod

--- a/bach/sql_models/constants.py
+++ b/bach/sql_models/constants.py
@@ -31,7 +31,7 @@ class DBDialect(Enum):
     POSTGRES = 'postgresql'  # value of PGDialect.name
     BIGQUERY = 'bigquery'  # value of BigQueryDialect.name
 
-    def is_dialect(self, dialect_engine: Union[Dialect, Engine]):
+    def is_dialect(self, dialect_engine: Union[Dialect, Engine]) -> bool:
         return dialect_engine.name == self.value
 
     @classmethod

--- a/bach/sql_models/constants.py
+++ b/bach/sql_models/constants.py
@@ -1,4 +1,7 @@
 from enum import Enum
+from typing import Union
+
+from sqlalchemy.engine import Dialect, Engine
 
 
 class NotSet(Enum):
@@ -10,3 +13,31 @@ class NotSet(Enum):
 
 
 not_set: NotSet = NotSet.token
+
+
+class DBDialect(Enum):
+    """
+    Supported database dialects.
+
+    The values are equal to Dialect.name for specific SqlAlchemy Dialect classes e.g.
+        DBDialects.POSTGRES.value == PGDialect.name
+
+    Generally we'll use the sqlalchemy.engine.Dialect class to define a certain database type (e.g. when
+    passing as a parameter). However, when needing to specify a database type in generic code, then use this
+    class. This class hardcodes the values, and thus does not depend on any specific python packages being
+    installed. i.e. accessing DBDialect.BIGQUERY works even if the 'sqlalchemy-bigquery' package is not
+    installed.
+    """
+    POSTGRES = 'postgresql'  # value of PGDialect.name
+    BIGQUERY = 'bigquery'  # value of BigQueryDialect.name
+
+    def is_dialect(self, dialect_engine: Union[Dialect, Engine]):
+        return dialect_engine.name == self.value
+
+    @classmethod
+    def from_engine(cls, engine: Engine) -> 'DBDialect':
+        return DBDialect(engine.name)
+
+    @classmethod
+    def from_dialect(cls, dialect: Dialect) -> 'DBDialect':
+        return DBDialect(dialect.name)

--- a/bach/sql_models/util.py
+++ b/bach/sql_models/util.py
@@ -6,6 +6,8 @@ from typing import Set, Union
 
 from sqlalchemy.engine import Dialect, Engine
 
+from sql_models.constants import DBDialect
+
 
 def extract_format_fields(format_string: str, nested=1) -> Set[str]:
     """
@@ -88,13 +90,11 @@ def quote_string(value: str) -> str:
 
 
 def is_postgres(dialect_engine: Union[Dialect, Engine]) -> bool:
-    return dialect_engine.name == 'postgresql'  # value of PGDialect.name
+    return DBDialect.POSTGRES.is_dialect(dialect_engine)
 
 
 def is_bigquery(dialect_engine: Union[Dialect, Engine]) -> bool:
-    # We hardcode the string value here instead of comparing against BigQueryDialect.name
-    # This way this code path will work, even if the BigQuery python package is not installed
-    return dialect_engine.name == 'bigquery'
+    return DBDialect.BIGQUERY.is_dialect(dialect_engine)
 
 
 class DatabaseNotSupportedException(Exception):

--- a/bach/tests/functional/bach/test_bt_custom_types.py
+++ b/bach/tests/functional/bach/test_bt_custom_types.py
@@ -6,6 +6,7 @@ import pytest
 from bach import Series
 from bach.expression import Expression
 from bach.types import register_dtype, get_series_type_from_dtype, value_to_dtype, TypeRegistry
+from sql_models.constants import DBDialect
 from tests.functional.bach.test_data_and_utils import get_bt_with_test_data, assert_equals_data
 
 
@@ -17,7 +18,7 @@ def test_custom_type_register(monkeypatch):
         """ Test class for custom types. """
         dtype = 'test_type'
         dtype_aliases = ('test_type_1337', )
-        supported_db_dtype = 'test_type'
+        supported_db_dtype = {DBDialect.POSTGRES: 'test_type'}
         supported_value_types = (str, int)
 
     # 'test_type' should not yet exist as dtype
@@ -32,7 +33,7 @@ def test_custom_type_register(monkeypatch):
         """ Test class for custom types. """
         dtype = 'test_type'
         dtype_aliases = ('test_type_1337',)
-        supported_db_dtype = 'test_type'
+        supported_db_dtype = {DBDialect.POSTGRES: 'test_type'}
         supported_value_types = (str, int)
 
     assert get_series_type_from_dtype('test_type') is TestStringType
@@ -45,7 +46,7 @@ def test_custom_type_register(monkeypatch):
         """ Test class for custom types. """
         dtype = 'test_type'
         dtype_aliases = ('test_type_1337',)
-        supported_db_dtype = 'test_type'
+        supported_db_dtype = {DBDialect.POSTGRES: 'test_type'}
         supported_value_types = (str, int)
 
     assert get_series_type_from_dtype('test_type') is TestStringType
@@ -58,7 +59,9 @@ class ReversedStringType(Series):
     """ Test class for custom types. """
     dtype = 'reversed_string'
     dtype_aliases = ('reversed_text', 'backwards_string')
-    supported_db_dtype = 'text'
+    supported_db_dtype = {
+        DBDialect.POSTGRES: 'text'
+    }
     supported_value_types = (str,)
 
     @classmethod
@@ -92,7 +95,7 @@ def test_custom_type(monkeypatch):
         bt_city.astype('reversed_string')
 
     # the db_dtype 'text' is already taken, so registering ReversedStringType should give an error
-    with pytest.raises(Exception, match='db_dtype text, which is already assigned'):
+    with pytest.raises(Exception, match='db_dtype text for postgresql, which is already assigned'):
         _registry.register_dtype_series(ReversedStringType, [], False)
     # with override_dtype=True, the error should disappear and 'reversed_string' should be registered
     _registry.register_dtype_series(ReversedStringType, [], override_registered_types=True)

--- a/bach/tests/functional/bach/test_data_and_utils.py
+++ b/bach/tests/functional/bach/test_data_and_utils.py
@@ -15,6 +15,7 @@ from sqlalchemy.engine import ResultProxy, Engine
 
 from bach import DataFrame, Series
 from bach.types import get_series_type_from_db_dtype
+from sql_models.constants import DBDialect
 from sql_models.util import is_bigquery, is_postgres
 from tests.conftest import DB_PG_TEST_URL
 
@@ -298,5 +299,5 @@ def assert_postgres_type(
     db_type = db_values[0][0]
     if expected_db_type:
         assert db_type == expected_db_type
-    series_type = get_series_type_from_db_dtype(db_type)
+    series_type = get_series_type_from_db_dtype(DBDialect.POSTGRES, db_type)
     assert series_type == expected_series_type

--- a/bach/tests/functional/bach/test_df_from.py
+++ b/bach/tests/functional/bach/test_df_from.py
@@ -12,17 +12,23 @@ from sqlalchemy.engine import Engine
 from bach import DataFrame
 from sql_models.model import CustomSqlModelBuilder, SqlModel
 from tests.functional.bach.test_data_and_utils import DB_PG_TEST_URL
+from sql_models.util import is_postgres, is_bigquery
 
 
 def _create_test_table(engine: Engine, table_name: str):
-    sql = f'drop table if exists {table_name}; ' \
-          f'create table {table_name}(a bigint, b text, c double precision, d date, e timestamp); '
+    if is_postgres(engine):
+        sql = f'drop table if exists {table_name}; ' \
+              f'create table {table_name}(a bigint, b text, c double precision, d date, e timestamp); '
+    elif is_bigquery(engine):
+        sql = f'drop table if exists {table_name}; ' \
+              f'create table {table_name}(a int64, b string, c float64, d date, e datetime); '
+    else:
+        raise Exception('Incomplete tests')
     with engine.connect() as conn:
         conn.execute(sql)
 
 
-def test_from_table_basic():
-    engine = sqlalchemy.create_engine(DB_PG_TEST_URL)
+def test_from_table_basic(engine):
     table_name = 'test_df_from_table'
     _create_test_table(engine, table_name)
 
@@ -72,9 +78,8 @@ def test_from_model_basic():
     assert df == df_all_dtypes
 
 
-def test_from_table_column_ordering():
+def test_from_table_column_ordering(engine):
     # Create a Dataframe in which the index is not the first column in the table.
-    engine = sqlalchemy.create_engine(DB_PG_TEST_URL)
     table_name = 'test_df_from_table'
     _create_test_table(engine, table_name)
 

--- a/modelhub/modelhub/modelhub.py
+++ b/modelhub/modelhub/modelhub.py
@@ -8,7 +8,7 @@ import bach
 from modelhub.aggregate import Aggregate
 from modelhub.map import Map
 from modelhub.series.series_objectiv import MetaBase
-from sql_models.constants import NotSet
+from sql_models.constants import NotSet, DBDialect
 from modelhub.stack.util import sessionized_data_model
 
 if TYPE_CHECKING:
@@ -126,7 +126,11 @@ class ModelHub():
 
         with engine.connect() as conn:
             res = conn.execute(sql)
-        dtypes = {x[0]: bach.types.get_dtype_from_db_dtype(x[1]) for x in res.fetchall()}
+        db_dialect = DBDialect.from_engine(engine)
+        dtypes = {
+            x[0]: bach.types.get_dtype_from_db_dtype(db_dialect=db_dialect, db_dtype=x[1])
+            for x in res.fetchall()
+        }
 
         expected_columns = {'event_id': 'uuid',
                             'day': 'date',


### PR DESCRIPTION
Changes:
* In `Series`: instead of a single `supported_db_dtype` have a db_dtype for each supported database
  * For the most basic types we have defined the BigQuery type. Not all are yet supported
* `DataFrame.from_table()` can determine the column types automatically on BigQuery, for the basic types