### PR TITLE
Support `astype()` on BigQuery for basic types

### DIFF
--- a/bach/bach/series/series.py
+++ b/bach/bach/series/series.py
@@ -228,11 +228,15 @@ class Series(ABC):
 
     @classmethod
     @abstractmethod
-    def dtype_to_expression(cls, source_dtype: str, expression: Expression) -> Expression:
+    def dtype_to_expression(cls, dialect: Dialect, source_dtype: str, expression: Expression) -> Expression:
         """
         INTERNAL: Give the sql expression to convert the given expression, of the given source dtype to the
         dtype of this Series.
-        :return: sql expression
+
+        :param dialect: Database dialect
+        :param source_dtype: dtype of the expression parameter
+        :param expression: expression to cast
+        :return: a new expression that converts the given expression to the dtype of this class
         """
         raise NotImplementedError()
 
@@ -816,7 +820,11 @@ class Series(ABC):
         if dtype == self.dtype or dtype in self.dtype_aliases:
             return self
         series_type = get_series_type_from_dtype(dtype)
-        expression = series_type.dtype_to_expression(self.dtype, self.expression)
+        expression = series_type.dtype_to_expression(
+            dialect=self.engine.dialect,
+            source_dtype=self.dtype,
+            expression=self.expression
+        )
         new_dtype = series_type.dtype
         return self.copy_override_dtype(dtype=new_dtype).copy_override(expression=expression)
 

--- a/bach/bach/series/series.py
+++ b/bach/bach/series/series.py
@@ -236,7 +236,8 @@ class Series(ABC):
         :param dialect: Database dialect
         :param source_dtype: dtype of the expression parameter
         :param expression: expression to cast
-        :return: a new expression that converts the given expression to the dtype of this class
+        :return: a new expression that casts the given expression to the dialect's db type for the dtype of
+        this class
         """
         raise NotImplementedError()
 

--- a/bach/bach/series/series_boolean.py
+++ b/bach/bach/series/series_boolean.py
@@ -52,7 +52,7 @@ class SeriesBoolean(Series, ABC):
         return Expression.raw(str(value))
 
     @classmethod
-    def dtype_to_expression(cls, source_dtype: str, expression: Expression) -> Expression:
+    def dtype_to_expression(cls, dialect: Dialect, source_dtype: str, expression: Expression) -> Expression:
         if source_dtype == 'bool':
             return expression
         if source_dtype not in ['int64', 'string']:

--- a/bach/bach/series/series_datetime.py
+++ b/bach/bach/series/series_datetime.py
@@ -179,7 +179,7 @@ class SeriesTimestamp(SeriesAbstractDateTime):
         return Expression.string_value(str_value)
 
     @classmethod
-    def dtype_to_expression(cls, source_dtype: str, expression: Expression) -> Expression:
+    def dtype_to_expression(cls, dialect: Dialect, source_dtype: str, expression: Expression) -> Expression:
         if source_dtype == 'timestamp':
             return expression
         else:
@@ -228,7 +228,7 @@ class SeriesDate(SeriesAbstractDateTime):
         return Expression.string_value(value)
 
     @classmethod
-    def dtype_to_expression(cls, source_dtype: str, expression: Expression) -> Expression:
+    def dtype_to_expression(cls, dialect: Dialect, source_dtype: str, expression: Expression) -> Expression:
         if source_dtype == 'date':
             return expression
         else:
@@ -293,7 +293,7 @@ class SeriesTime(SeriesAbstractDateTime):
         return Expression.string_value(value)
 
     @classmethod
-    def dtype_to_expression(cls, source_dtype: str, expression: Expression) -> Expression:
+    def dtype_to_expression(cls, dialect: Dialect, source_dtype: str, expression: Expression) -> Expression:
         if source_dtype == 'time':
             return expression
         else:
@@ -332,7 +332,7 @@ class SeriesTimedelta(SeriesAbstractDateTime):
         return Expression.string_value(value)
 
     @classmethod
-    def dtype_to_expression(cls, source_dtype: str, expression: Expression) -> Expression:
+    def dtype_to_expression(cls, dialect: Dialect, source_dtype: str, expression: Expression) -> Expression:
         if source_dtype == 'timedelta':
             return expression
         else:

--- a/bach/bach/series/series_datetime.py
+++ b/bach/bach/series/series_datetime.py
@@ -334,7 +334,7 @@ class SeriesTimedelta(SeriesAbstractDateTime):
         else:
             if not source_dtype == 'string':
                 raise ValueError(f'cannot convert {source_dtype} to timedelta')
-            return Expression.construct('cast({} as interval)', expression)
+            return Expression.construct(f'cast({{}} as {cls.get_db_dtype(dialect)})', expression)
 
     def _comparator_operation(self, other, comparator,
                               other_dtypes=('timedelta', 'string')) -> SeriesBoolean:

--- a/bach/bach/series/series_datetime.py
+++ b/bach/bach/series/series_datetime.py
@@ -185,8 +185,7 @@ class SeriesTimestamp(SeriesAbstractDateTime):
         else:
             if source_dtype not in ['string', 'date']:
                 raise ValueError(f'cannot convert {source_dtype} to timestamp')
-            db_dtype = 'timestamp without time zone'
-            return Expression.construct(f'cast({{}} as {db_dtype})', expression)
+            return Expression.construct(f'cast({{}} as {cls.get_db_dtype(dialect)})', expression)
 
     def __add__(self, other) -> 'Series':
         return self._arithmetic_operation(other, 'add', '({}) + ({})', other_dtypes=tuple(['timedelta']))
@@ -234,8 +233,7 @@ class SeriesDate(SeriesAbstractDateTime):
         else:
             if source_dtype not in ['string', 'timestamp']:
                 raise ValueError(f'cannot convert {source_dtype} to date')
-            db_dtype = 'date'
-            return Expression.construct(f'cast({{}} as {db_dtype})', expression)
+            return Expression.construct(f'cast({{}} as {cls.get_db_dtype(dialect)})', expression)
 
     def __add__(self, other) -> 'Series':
         type_mapping = {
@@ -299,8 +297,7 @@ class SeriesTime(SeriesAbstractDateTime):
         else:
             if source_dtype not in ['string', 'timestamp']:
                 raise ValueError(f'cannot convert {source_dtype} to time')
-            db_dtype = 'time without time zone'
-            return Expression.construct(f'cast({{}} as {db_dtype})', expression)
+            return Expression.construct(f'cast({{}} as {cls.get_db_dtype(dialect)})', expression)
 
     # python supports no arithmetic on Time
 

--- a/bach/bach/series/series_json.py
+++ b/bach/bach/series/series_json.py
@@ -321,7 +321,7 @@ class SeriesJsonb(Series):
         return Expression.string_value(json_value)
 
     @classmethod
-    def dtype_to_expression(cls, source_dtype: str, expression: Expression) -> Expression:
+    def dtype_to_expression(cls, dialect: Dialect, source_dtype: str, expression: Expression) -> Expression:
         if source_dtype in ['jsonb', 'json']:
             return expression
         if source_dtype != 'string':

--- a/bach/bach/series/series_json.py
+++ b/bach/bach/series/series_json.py
@@ -328,7 +328,7 @@ class SeriesJsonb(Series):
             return expression
         if source_dtype != 'string':
             raise ValueError(f'cannot convert {source_dtype} to jsonb')
-        return Expression.construct('cast({} as jsonb)', expression)
+        return Expression.construct(f'cast({{}} as {cls.get_db_dtype(dialect)})', expression)
 
     def _comparator_operation(self, other, comparator, other_dtypes=('json', 'jsonb')):
         return self._binary_operation(

--- a/bach/bach/series/series_string.py
+++ b/bach/bach/series/series_string.py
@@ -128,10 +128,12 @@ class SeriesString(Series):
         return Expression.string_value(value)
 
     @classmethod
-    def dtype_to_expression(cls, source_dtype: str, expression: Expression) -> Expression:
+    def dtype_to_expression(cls, dialect: Dialect, source_dtype: str, expression: Expression) -> Expression:
         if source_dtype == 'string':
             return expression
-        return Expression.construct('cast(({}) as text)', expression)
+        db_dialect = DBDialect.from_dialect(dialect)
+        db_dtype = cls.supported_db_dtype[db_dialect]
+        return Expression.construct(f'cast({{}} as {db_dtype})', expression)
 
     @property
     def str(self) -> StringOperation:

--- a/bach/bach/series/series_string.py
+++ b/bach/bach/series/series_string.py
@@ -131,9 +131,7 @@ class SeriesString(Series):
     def dtype_to_expression(cls, dialect: Dialect, source_dtype: str, expression: Expression) -> Expression:
         if source_dtype == 'string':
             return expression
-        db_dialect = DBDialect.from_dialect(dialect)
-        db_dtype = cls.supported_db_dtype[db_dialect]
-        return Expression.construct(f'cast({{}} as {db_dtype})', expression)
+        return Expression.construct(f'cast({{}} as {cls.get_db_dtype(dialect)})', expression)
 
     @property
     def str(self) -> StringOperation:

--- a/bach/bach/series/series_uuid.py
+++ b/bach/bach/series/series_uuid.py
@@ -38,7 +38,7 @@ class SeriesUuid(Series):
         return Expression.string_value(uuid_as_str)
 
     @classmethod
-    def dtype_to_expression(cls, source_dtype: str, expression: Expression) -> Expression:
+    def dtype_to_expression(cls, dialect: Dialect, source_dtype: str, expression: Expression) -> Expression:
         if source_dtype == 'uuid':
             return expression
         if source_dtype == 'string':

--- a/bach/bach/series/series_uuid.py
+++ b/bach/bach/series/series_uuid.py
@@ -47,7 +47,7 @@ class SeriesUuid(Series):
         if source_dtype == 'string':
             # If the format is wrong, then this will give an error later on, but there is not much we can
             # do about that here.
-            return Expression.construct('cast(({}) as uuid)', expression)
+            return Expression.construct(f'cast({{}} as {cls.get_db_dtype(dialect)})', expression)
         # As far as we know the other types we support cannot be directly cast to uuid.
         raise ValueError(f'cannot convert {source_dtype} to uuid.')
 

--- a/bach/tests/functional/bach/test_bt_custom_types.py
+++ b/bach/tests/functional/bach/test_bt_custom_types.py
@@ -74,7 +74,7 @@ class ReversedStringType(Series):
         return Expression.string_value(str(reversed(value)))
 
     @classmethod
-    def dtype_to_expression(cls, source_dtype: str, expression: Expression) -> Expression:
+    def dtype_to_expression(cls, dialect: Dialect, source_dtype: str, expression: Expression) -> Expression:
         if source_dtype == 'reversed_string':
             return expression
         elif source_dtype == 'String':

--- a/bach/tests/functional/bach/test_df_astype.py
+++ b/bach/tests/functional/bach/test_df_astype.py
@@ -2,12 +2,12 @@
 Copyright 2021 Objectiv B.V.
 """
 from tests.functional.bach.test_data_and_utils import get_bt_with_test_data, assert_equals_data, \
-    get_bt_with_json_data, CITIES_INDEX_AND_COLUMNS
+    get_bt_with_json_data, CITIES_INDEX_AND_COLUMNS, get_df_with_test_data
 
 
-def test_astype_dtypes():
+def test_astype_dtypes(engine):
     # case 1: cast all columns to a type
-    bt = get_bt_with_test_data()
+    bt = get_df_with_test_data(engine)
     bt_int = bt[['inhabitants', 'founding']]
     bt_float = bt_int.astype('float64')
     assert bt_int.dtypes == {'founding': 'int64', 'inhabitants': 'int64'}
@@ -67,8 +67,8 @@ def test_astype_dtypes():
     )
 
 
-def test_astype_to_int():
-    bt = get_bt_with_test_data()
+def test_astype_to_int(engine):
+    bt = get_df_with_test_data(engine)
     bt = bt[['inhabitants']]
     bt['inhabitants'] = bt['inhabitants'] / 1000
     bt_int = bt.astype('int64')

--- a/bach/tests/functional/bach/test_df_astype.py
+++ b/bach/tests/functional/bach/test_df_astype.py
@@ -1,8 +1,10 @@
 """
 Copyright 2021 Objectiv B.V.
 """
-from tests.functional.bach.test_data_and_utils import get_bt_with_test_data, assert_equals_data, \
-    get_bt_with_json_data, CITIES_INDEX_AND_COLUMNS, get_df_with_test_data
+from datetime import date, datetime, time
+
+from tests.functional.bach.test_data_and_utils import assert_equals_data, get_bt_with_json_data,\
+    CITIES_INDEX_AND_COLUMNS, get_df_with_test_data
 
 
 def test_astype_dtypes(engine):
@@ -91,6 +93,70 @@ def test_astype_to_int(engine):
             [1, 93],
             [2, 34],
             [3, 3]
+        ]
+    )
+
+
+def test_astype_to_bool(engine):
+    bt = get_df_with_test_data(engine)
+    bt = bt[['skating_order']]
+    bt['skating_order'] = bt['skating_order'] - 1
+    bt['t'] = 'True'
+    bt['f'] = 'False'
+    bt = bt.astype('bool')
+    assert_equals_data(
+        bt,
+        expected_columns=['_index_skating_order', 'skating_order', 't', 'f'],
+        expected_data=[
+            [1, False, True, False],
+            [2, True, True, False ],
+            [3, True, True, False ]
+        ]
+    )
+
+
+def test_astype_to_date(engine):
+    bt = get_df_with_test_data(engine)
+    bt = bt[[]]
+    bt['d'] = '1999-12-31'
+    bt = bt.astype('date')
+    assert_equals_data(
+        bt,
+        expected_columns=['_index_skating_order', 'd'],
+        expected_data=[[1, date(1999, 12, 31)], [2, date(1999, 12, 31)], [3, date(1999, 12, 31)]]
+    )
+
+
+def test_astype_to_timestamp(engine):
+    bt = get_df_with_test_data(engine)
+    bt = bt[[]]
+    bt['d'] = date(2022, 3, 31)
+    bt['s'] = '2022-02-15 13:37:00'
+    bt = bt.astype('timestamp')
+    assert_equals_data(
+        bt,
+        expected_columns=['_index_skating_order', 'd', 's'],
+        expected_data=[
+            [1, datetime(2022, 3, 31, 0, 0), datetime(2022, 2, 15, 13, 37)],
+            [2, datetime(2022, 3, 31, 0, 0), datetime(2022, 2, 15, 13, 37)],
+            [3, datetime(2022, 3, 31, 0, 0), datetime(2022, 2, 15, 13, 37)]
+        ]
+    )
+
+
+def test_astype_to_time(engine):
+    bt = get_df_with_test_data(engine)
+    bt = bt[[]]
+    bt['a'] = '03:04:00'
+    bt['b'] = '23:25:59'
+    bt = bt.astype('time')
+    assert_equals_data(
+        bt,
+        expected_columns=['_index_skating_order', 'a', 'b'],
+        expected_data=[
+            [1, time(3, 4, 0), time(23, 25, 59)],
+            [2, time(3, 4, 0), time(23, 25, 59)],
+            [3, time(3, 4, 0), time(23, 25, 59)]
         ]
     )
 


### PR DESCRIPTION
Change:
* Support astype() on BigQuery for basic types
* more tests for astype()