### PR TITLE
fix append in _resolve_merge_expression_references

### DIFF
--- a/bach/bach/merge.py
+++ b/bach/bach/merge.py
@@ -585,7 +585,7 @@ def _resolve_merge_expression_references(
 
                 resolved_expr = _get_expression(df_series=df_series, label=nested_token.column_name)
                 resolved_expr = resolved_expr.resolve_column_references(dialect, table_alias)
-                new_tokens.append(resolved_expr)
+                resolved_nested_tokens.append(resolved_expr)
 
             new_tokens.extend(resolved_nested_tokens)
 


### PR DESCRIPTION
Small bug in _resolve_merge_expression_references, this was actually changing the order of tokens. Noticed thanks from this branch https://github.com/objectiv/objectiv-analytics/pull/601 since the expression structure changed for binary operations.