### PR TITLE
Bach BQ: int small improvements

### DIFF
--- a/bach/bach/series/series_numeric.py
+++ b/bach/bach/series/series_numeric.py
@@ -224,18 +224,7 @@ class SeriesInt64(SeriesAbstractNumeric):
         return super()._arithmetic_operation(other, operation, fmt_str, other_dtypes, type_mapping)
 
     def __truediv__(self, other) -> 'Series':
-        # What we do below is essentially the same as: return self.astype('float64') / other
-        # But somehow that fails some test cases and the below code works. The generated sql for the 'nice'
-        # code above doesn't seem to make sense in the broken cases. TODO: look into this
-
-        db_dialect = DBDialect.from_dialect(self.engine.dialect)
-        float_db_type = SeriesFloat64.supported_db_dtype[db_dialect]
-        return self._arithmetic_operation(
-            other=other,
-            operation='div',
-            fmt_str=f'cast({{}} as {float_db_type}) / ({{}})',
-            dtype='float64'
-        )
+        return self.astype('float64') / other
 
     def __rshift__(self, other):
         if is_postgres(self.engine):

--- a/bach/bach/series/series_numeric.py
+++ b/bach/bach/series/series_numeric.py
@@ -238,12 +238,18 @@ class SeriesInt64(SeriesAbstractNumeric):
         )
 
     def __rshift__(self, other):
-        return self._arithmetic_operation(other, 'lshift', '({}) >> cast({} as int)',
-                                          other_dtypes=tuple(['int64']))
+        if is_postgres(self.engine):
+            # Postgres expects the argument to a bitshift to be a regular int, not bigint.
+            return self._arithmetic_operation(other, 'rshift', '({}) >> cast({} as int)',
+                                              other_dtypes=tuple(['int64']))
+        return self._arithmetic_operation(other, 'rshift', '({}) >> ({})', other_dtypes=tuple(['int64']))
 
     def __lshift__(self, other):
-        return self._arithmetic_operation(other, 'lshift', '({}) << cast({} as int)',
-                                          other_dtypes=tuple(['int64']))
+        if is_postgres(self.engine):
+            # Postgres expects the argument to a bitshift to be a regular int, not bigint.
+            return self._arithmetic_operation(other, 'lshift', '({}) << cast({} as int)',
+                                              other_dtypes=tuple(['int64']))
+        return self._arithmetic_operation(other, 'lshift', '({}) << ({})', other_dtypes=tuple(['int64']))
 
     def sum(self, partition: WrappedPartition = None, skipna: bool = True, min_count: int = None):
         # sum() has the tendency to return float on bigint arguments. Cast it back.

--- a/bach/tests/functional/bach/test_series_int.py
+++ b/bach/tests/functional/bach/test_series_int.py
@@ -189,18 +189,17 @@ def test_int_float_arithmetic(engine):
     helper_test_simple_arithmetic(engine=engine, a=10, b=2.25)
 
 
-def test_int_shifts(pg_engine):
-    # TODO: BigQuery
-    bt = get_df_with_test_data(pg_engine, full_data_set=True)[['inhabitants']]
-    expected = [8, 3]
+def test_int_shifts(engine):
+    bt = get_df_with_test_data(engine, full_data_set=True)[['inhabitants']]
     bt['a'] = 8
     bt['b'] = 3
     bt['lshift'] = bt.a << bt.b
     bt['rshift'] = bt.a >> bt.b
-    expected.extend([64, 1])
+    expected = [8, 3, 64, 1]
 
+    bt = bt.sort_index()[:1]  # Only get the first row
     assert_equals_data(
-        bt[:1],
+        bt,
         expected_columns=list(bt.all_series.keys()),
         expected_data=[
             [1, 93485, *expected],


### PR DESCRIPTION
Small fixes to `SeriesInt64`:
* support bit shifts on BQ
* simplify true division