### PR TITLE
Fix merge on series boolean with renamed serie

### DIFF
--- a/bach/bach/merge.py
+++ b/bach/bach/merge.py
@@ -583,7 +583,14 @@ def _resolve_merge_expression_references(
                     df_series = right
                     table_alias = 'r'
 
-                resolved_expr = _get_expression(df_series=df_series, label=nested_token.column_name)
+                # nested_token.column_name might not be the same to token.column_name
+                # since series can be renamed
+                expr_label = (
+                    nested_token.column_name
+                    if nested_token.column_name == cond.name
+                    else token.column_name
+                )
+                resolved_expr = _get_expression(df_series=df_series, label=expr_label)
                 resolved_expr = resolved_expr.resolve_column_references(dialect, table_alias)
                 resolved_nested_tokens.append(resolved_expr)
 

--- a/bach/tests/functional/bach/test_df_merge.py
+++ b/bach/tests/functional/bach/test_df_merge.py
@@ -570,6 +570,25 @@ def test_merge_on_conditions_w_on_data_columns() -> None:
     )
 
 
+def test_merge_on_conditions_renamed_column() -> None:
+    pdf1 = pd.DataFrame({
+        'A': ['b', 'a', 'c', 'd'],
+        'B': [100, 25, 250, 500],
+    })
+    pdf2 = pd.DataFrame({
+        'A': ['a', 'a', 'c', 'c', 'c'],
+        'B': [20, 5, 50, 20, 100],
+    })
+
+    df1 = get_from_df('merge_on_condition1', pdf1)
+    df2 = get_from_df('merge_on_condition2', pdf2)
+
+    df1 = df1.rename(columns={'B': 'C'})
+    on_condition = df1['C'] > df2['B']
+
+    result = df1.merge(df2, on=on_condition)
+
+
 def test_merge_on_conditions_w_index() -> None:
     pdf1 = pd.DataFrame({
         'A': ['a', 'b', 'c', 'd'],


### PR DESCRIPTION
`_get_expression` raises an exception when the conditional makes referenced to renamed series, as original series name is found only in base node