### PR TITLE
Ignore index attribute in `CutOperation`

### DIFF
--- a/bach/bach/operations/cut.py
+++ b/bach/bach/operations/cut.py
@@ -57,9 +57,10 @@ class CutOperation:
         bucket_properties_df = self._calculate_bucket_properties()
         range_series = self._calculate_bucket_ranges(bucket_properties_df)
 
-        final_index_keys = [self.series.name]
+        final_index_keys = []
         if not self.ignore_index:
-            final_index_keys.extend(self.series.index.keys())
+            final_index_keys = list(self.series.index.keys())
+        final_index_keys += [self.series.name]
 
         df = self.series.to_frame().reset_index(drop=self.ignore_index)
         df[self.RANGE_SERIES_NAME] = df[self.series.name].copy_override(

--- a/bach/tests/functional/bach/test_cut.py
+++ b/bach/tests/functional/bach/test_cut.py
@@ -51,12 +51,10 @@ def test_cut_w_ignore_index() -> None:
     series = get_from_df('cut_df', p_series.to_frame()).a
 
     result = CutOperation(series=series, bins=bins, right=True, ignore_index=False)()
-    assert 'a' in result.index
-    assert '_index_0' in result.index
+    assert ['_index_0', 'a'] == list(result.index.keys())
 
     result_w_ignore = CutOperation(series=series, bins=bins, right=True, ignore_index=True)()
-    assert 'a' in result_w_ignore.index
-    assert '_index_0' not in result_w_ignore.index
+    assert ['a'] == list(result_w_ignore.index.keys())
 
 
 def test_cut_w_include_empty_bins() -> None:

--- a/bach/tests/functional/bach/test_cut.py
+++ b/bach/tests/functional/bach/test_cut.py
@@ -45,6 +45,20 @@ def test_cut_operation_boundary() -> None:
     compare_boundaries(expected, result)
 
 
+def test_cut_w_ignore_index() -> None:
+    bins = 3
+    p_series = pd.Series(data=[1, 2, 3, 4], name='a')
+    series = get_from_df('cut_df', p_series.to_frame()).a
+
+    result = CutOperation(series=series, bins=bins, right=True, ignore_index=False)()
+    assert 'a' in result.index
+    assert '_index_0' in result.index
+
+    result_w_ignore = CutOperation(series=series, bins=bins, right=True, ignore_index=True)()
+    assert 'a' in result_w_ignore.index
+    assert '_index_0' not in result_w_ignore.index
+
+
 def test_cut_w_include_empty_bins() -> None:
     bins = 3
     p_series = pd.Series(data=[1, 1, 2, 3, 6, 7, 8], name='a')


### PR DESCRIPTION
For plotting a hist, we need to preserve the index (contains the label of the numerical columns).