### PR TITLE
fix renaming of other in __set_item_with_merge

### DIFF
--- a/bach/bach/series/series.py
+++ b/bach/bach/series/series.py
@@ -582,7 +582,7 @@ class Series(ABC):
 
         mod_other_name = other.name
         if (
-            other.base_node == right.base_node
+            (other.base_node == right.base_node or not update_column_references)
             and set(df.all_series) & {f'{other.name}__other', f'{other.name}__data_column'}
         ):
             post_fix = '__other' if other.name not in self.index else '__data_column'

--- a/bach/tests/functional/bach/test_series.py
+++ b/bach/tests/functional/bach/test_series.py
@@ -8,7 +8,7 @@ import pytest
 from bach import DataFrame, SeriesString, SeriesInt64, Series
 from bach.expression import Expression
 from tests.functional.bach.test_data_and_utils import get_bt_with_test_data, assert_equals_data, df_to_list, \
-    get_from_df, get_bt_with_railway_data
+    get_from_df, get_bt_with_railway_data, get_bt_with_food_data
 
 
 def test_series__getitem__():
@@ -715,3 +715,60 @@ def test__set_item_with_merge_different_dtypes() -> None:
 
     with pytest.raises(ValueError, match=r'dtypes of indexes to be merged'):
         bt['inhabitants'] + bt2['inhabitants']
+
+
+def test__set_item_with_merge_w_group_shared_name() -> None:
+    bt = get_bt_with_test_data(full_data_set=True)
+    mt = get_bt_with_food_data()
+    mt['inhabitants'] = mt.skating_order
+
+    max_bt_inh = bt.groupby('skating_order').inhabitants.max()
+
+    max_mt_inh = mt.groupby('skating_order').inhabitants.max()
+    min_mt_inh = mt.groupby('skating_order').inhabitants.min()
+
+    result1 = max_bt_inh / max_mt_inh
+    assert_equals_data(
+        result1,
+        expected_columns=['skating_order', 'inhabitants'],
+        expected_data=[
+            [1, 93485.],
+            [2, 16760.],
+            [3, None],
+            [4, 175.],
+            [5, None],
+            [6, None],
+            [7, None],
+            [8, None],
+            [9, None],
+            [10, None],
+            [11, None],
+        ],
+    )
+    result_expression = result1.expression.to_sql(result1.engine)
+    assert 'inhabitants__other' in result_expression
+
+    result2 = result1 - max_mt_inh
+    result_expression2 = result2.expression.to_sql(result2.engine)
+    assert_equals_data(
+        result2,
+        expected_columns=['skating_order', 'inhabitants'],
+        expected_data=[
+            [1, 93484.],
+            [2, 16758.],
+            [3, None],
+            [4, 171.],
+            [5, None],
+            [6, None],
+            [7, None],
+            [8, None],
+            [9, None],
+            [10, None],
+            [11, None],
+        ],
+    )
+    assert 'inhabitants__other' in result_expression2
+
+    grouped_df = mt.groupby('skating_order').agg(['min', 'max']).materialize()
+    result3 = max_bt_inh / grouped_df['inhabitants_max'] - grouped_df['inhabitants_min']
+    pd.testing.assert_series_equal(result2.sort_index().to_pandas(), result3.sort_index().to_pandas())


### PR DESCRIPTION
When calling `__set_item_with_merge` with an aggregated series, the `merge` call materialized `other.base_node`. Therefore it changed the node and the condition in charged of making reference to the correct column name was not working correctly.