### PR TITLE
Bach check valid column names

### DIFF
--- a/bach/bach/series/series.py
+++ b/bach/bach/series/series.py
@@ -11,8 +11,7 @@ from uuid import UUID
 
 import numpy
 import pandas
-from sqlalchemy.engine import Dialect
-from sqlalchemy.future import Engine
+from sqlalchemy.engine import Dialect, Engine
 
 from bach import DataFrame, SortColumn, DataFrameOrSeries, get_series_type_from_dtype
 
@@ -24,6 +23,7 @@ from bach.expression import Expression, NonAtomicExpression, ConstValueExpressio
 from bach.sql_model import BachSqlModel
 
 from bach.types import value_to_dtype, DtypeOrAlias
+from bach.utils import is_valid_column_name
 from sql_models.constants import NotSet, not_set, DBDialect
 
 if TYPE_CHECKING:
@@ -103,7 +103,7 @@ class Series(ABC):
     """
 
     def __init__(self,
-                 engine,
+                 engine: Engine,
                  base_node: BachSqlModel,
                  index: Dict[str, 'Series'],
                  name: str,
@@ -170,6 +170,8 @@ class Series(ABC):
         if index_sorting and len(index_sorting) != len(index):
             raise ValueError(f'Length of index_sorting ({len(index_sorting)}) should match '
                              f'length of index ({len(index)}).')
+        if not is_valid_column_name(dialect=engine.dialect, name=name):
+            raise ValueError(f'Column name "{name}" is not valid for SQL dialect {engine.dialect}')
 
         self._engine = engine
         self._base_node = base_node

--- a/bach/bach/utils.py
+++ b/bach/bach/utils.py
@@ -1,7 +1,9 @@
+import re
 from typing import NamedTuple, Dict, List, Set
-from sqlalchemy.engine import Connection
+from sqlalchemy.engine import Connection, Dialect
 
 from bach.expression import Expression
+from sql_models.util import is_postgres, DatabaseNotSupportedException, is_bigquery
 
 
 class ResultSeries(NamedTuple):
@@ -44,3 +46,30 @@ def escape_parameter_characters(conn: Connection, raw_sql: str) -> str:
     # When we support more databases we'll need to do something smarter, see
     # https://www.python.org/dev/peps/pep-0249/#paramstyle
     return raw_sql.replace('%', '%%')
+
+
+def is_valid_column_name(dialect: Dialect, name: str) -> bool:
+    if is_postgres(dialect):
+        # Identifiers longer than 63 characters are not necessarily wrong, but they will be truncated which
+        # could lead to identifier collisions, so we just disallow it.
+        # source: https://www.postgresql.org/docs/14/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
+        result = len(name) < 64
+        return result
+    if is_bigquery(dialect):
+        # sources:
+        #  https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical#column_names
+        #  https://cloud.google.com/bigquery/docs/schemas#column_names
+        regex = '^[a-zA-Z_][a-zA-Z0-9_]*$'
+        reserved_prefixes = [
+            '_TABLE_',
+            '_FILE_',
+            '_PARTITION',
+            '_ROW_TIMESTAMP',
+            '__ROOT__',
+            '_COLIDENTIFIER'
+        ]
+        len_ok = len(name) <= 300
+        pattern_ok = bool(re.match(pattern=regex, string=name))
+        prefix_ok = not any(name.startswith(prefix) for prefix in reserved_prefixes)
+        return len_ok and pattern_ok and prefix_ok
+    raise DatabaseNotSupportedException(dialect)

--- a/bach/bach/utils.py
+++ b/bach/bach/utils.py
@@ -53,8 +53,7 @@ def is_valid_column_name(dialect: Dialect, name: str) -> bool:
         # Identifiers longer than 63 characters are not necessarily wrong, but they will be truncated which
         # could lead to identifier collisions, so we just disallow it.
         # source: https://www.postgresql.org/docs/14/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
-        result = len(name) < 64
-        return result
+        return len(name) < 64
     if is_bigquery(dialect):
         # sources:
         #  https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical#column_names

--- a/bach/tests/functional/bach/test_injection_column_name_escaping.py
+++ b/bach/tests/functional/bach/test_injection_column_name_escaping.py
@@ -1,11 +1,21 @@
 """
 Copyright 2021 Objectiv B.V.
 """
-from tests.functional.bach.test_data_and_utils import get_bt_with_test_data, assert_equals_data
+import pytest
+from sqlalchemy.engine import Engine
+
+from sql_models.util import is_bigquery
+from tests.functional.bach.test_data_and_utils import assert_equals_data, get_df_with_test_data
 
 
-def test_column_names():
-    bt = _get_dataframe_with_weird_column_names()
+def test_column_names(engine):
+    # BigQuery doesn't allow 'weird' characters, so we just expect an error about the names.
+    if is_bigquery(engine):
+        with pytest.raises(ValueError, match='Column name ".*" is not valid for SQL dialect'):
+            bt = _get_dataframe_with_weird_column_names(engine)
+        return
+    # Postgres does allow 'weird' characters, if properly escaped. Test the escaping
+    bt = _get_dataframe_with_weird_column_names(engine)
     expected_columns = ['_index_skating_order',
                         'city', 'With_Capitals', 'with_capitals',
                         'With A Space Too', '""with"_quotes""', 'with%percentage',
@@ -21,10 +31,15 @@ def test_column_names():
     assert_equals_data(bt, expected_columns=expected_columns, expected_data=expected_data)
 
 
-def test_column_names_merge():
+def test_column_names_merge(engine):
     # When merging we construct a specific sql query that names each column, so test that separately here
-    bt = _get_dataframe_with_weird_column_names()
-    bt2 = get_bt_with_test_data()[['city']]
+
+    # Don't test this for BigQuery, as it won't allow the weird names. See test_column_names() above.
+    if is_bigquery(engine):
+        return
+
+    bt = _get_dataframe_with_weird_column_names(engine)
+    bt2 = get_df_with_test_data(engine)[['city']]
     bt = bt.merge(bt2, on='city')
     expected_columns = ['_index_skating_order_x', '_index_skating_order_y',
                         'city', 'With_Capitals', 'with_capitals',
@@ -38,8 +53,8 @@ def test_column_names_merge():
     assert_equals_data(bt, expected_columns=expected_columns, expected_data=expected_data)
 
 
-def _get_dataframe_with_weird_column_names():
-    bt = get_bt_with_test_data()[['city']]
+def _get_dataframe_with_weird_column_names(engine: Engine):
+    bt = get_df_with_test_data(engine)[['city']]
     bt['With_Capitals'] = 1
     bt['with_capitals'] = 1
     bt['With A Space Too'] = 1

--- a/bach/tests/unit/bach/test_df_rename.py
+++ b/bach/tests/unit/bach/test_df_rename.py
@@ -95,7 +95,7 @@ def test_rename_ignore_errors(dialect):
 
 
 def test_rename_fail_on_duplicate_columns(dialect):
-    bt = get_fake_df(['i', 'ii'], ['a', 'b'])
+    bt = get_fake_df(['i', 'ii'], ['a', 'b'], dialect=dialect)
 
     with pytest.raises(ValueError, match='column name already exists'):
         bt.rename(columns={'a': 'b'})
@@ -105,3 +105,10 @@ def test_rename_fail_on_duplicate_columns(dialect):
         bt.rename(columns={'a': 'c', 'b': 'c'})
     with pytest.raises(ValueError, match='column name already exists'):
         bt.rename(columns={'a': 'i'})
+
+
+def test_rename_invalid_column_name(dialect):
+    bt = get_fake_df(['i'], ['a', 'b'], dialect=dialect)
+    too_long_name = 'test' * 100
+    with pytest.raises(ValueError, match='Column name ".*" is not valid for SQL dialect'):
+        bt.rename(columns={'a': too_long_name})

--- a/bach/tests/unit/bach/test_df_setitem.py
+++ b/bach/tests/unit/bach/test_df_setitem.py
@@ -16,3 +16,15 @@ def test_set_existing_index(dialect):
     # should not work: override index. Cannot set index, and cannot have same column
     with pytest.raises(ValueError, match='already exists as index'):
         bt['_index_skating_order'] = 1
+
+
+def test_set_invalid_column_name(dialect):
+    # Test that we get an appropriate error when we try to set an index column
+    bt = get_fake_df_test_data(dialect)
+    # should work: new column
+    name = 'test'
+    bt[name] = 1
+    # should not work: column name is too long for all supported databases.
+    name = 'test' * 100
+    with pytest.raises(ValueError, match='Column name .* is not valid'):
+        bt[name] = 1

--- a/bach/tests/unit/bach/test_series.py
+++ b/bach/tests/unit/bach/test_series.py
@@ -4,12 +4,13 @@ Copyright 2021 Objectiv B.V.
 from bach import get_series_type_from_dtype
 from bach.expression import Expression
 from bach.partitioning import GroupBy
-from tests.unit.bach.util import get_fake_df
+from tests.unit.bach.util import get_fake_df, FakeEngine
 
 
 def test_equals():
     left = get_fake_df(['a'], ['b', 'c'])
     right = get_fake_df(['a'], ['b', 'c'])
+
     result = left['b'].equals(left['b'])
     # assert result is a boolean (for e.g.  '==') this is not the case
     assert result is True
@@ -30,59 +31,62 @@ def test_equals():
     right = get_fake_df(['b', 'a'], ['c'])
     assert not left['c'].equals(right['c'])
 
+    engine = left.engine
+    engine_other = FakeEngine(dialect=engine.dialect, url='sql://some_other_string')
+
     int_type = get_series_type_from_dtype('int64')
     float_type = get_series_type_from_dtype('float64')
 
     expr_test = Expression.construct('test')
     expr_other = Expression.construct('test::text')
 
-    sleft = int_type(engine=None, base_node=None, index={}, name='test',
+    sleft = int_type(engine=engine, base_node=None, index={}, name='test',
                      expression=expr_test, group_by=None, sorted_ascending=None, index_sorting=[])
-    sright = int_type(engine=None, base_node=None, index={}, name='test',
+    sright = int_type(engine=engine, base_node=None, index={}, name='test',
                       expression=expr_test, group_by=None, sorted_ascending=None, index_sorting=[])
     assert sleft.equals(sright)
 
     # different expression
-    sright = int_type(engine=None, base_node=None, index={}, name='test',
+    sright = int_type(engine=engine, base_node=None, index={}, name='test',
                       expression=expr_other, group_by=None, sorted_ascending=None, index_sorting=[])
     assert not sleft.equals(sright)
 
     # different name
-    sright = int_type(engine=None, base_node=None, index={}, name='test_2',
+    sright = int_type(engine=engine, base_node=None, index={}, name='test_2',
                       expression=expr_test, group_by=None, sorted_ascending=None, index_sorting=[])
     assert not sleft.equals(sright)
 
     # different base_node
-    sright = int_type(engine=None, base_node='test', index={}, name='test',
+    sright = int_type(engine=engine, base_node='test', index={}, name='test',
                       expression=expr_test, group_by=None, sorted_ascending=None, index_sorting=[])
     assert not sleft.equals(sright)
 
     # different engine
-    sright = int_type(engine='test', base_node=None, index={}, name='test',
+    sright = int_type(engine=engine_other, base_node=None, index={}, name='test',
                       expression=expr_test, group_by=None, sorted_ascending=None, index_sorting=[])
     assert not sleft.equals(sright)
 
     # different type
-    sright = float_type(engine=None, base_node=None, index={}, name='test',
+    sright = float_type(engine=engine, base_node=None, index={}, name='test',
                         expression=expr_test, group_by=None, sorted_ascending=None, index_sorting=[])
     assert not sleft.equals(sright)
 
     # different group_by
-    sright = int_type(engine=None, base_node=None, index={}, name='test', expression=expr_test,
+    sright = int_type(engine=engine, base_node=None, index={}, name='test', expression=expr_test,
                       group_by=GroupBy(group_by_columns=[]), sorted_ascending=None, index_sorting=[])
     assert not sleft.equals(sright)
 
     # different sorting
-    sright = int_type(engine=None, base_node=None, index={}, name='test', expression=expr_test,
+    sright = int_type(engine=engine, base_node=None, index={}, name='test', expression=expr_test,
                       group_by=None, sorted_ascending=True, index_sorting=[])
     assert not sleft.equals(sright)
     sright = sright.copy_override(sorted_ascending=None)
     assert sleft.equals(sright)
 
     index_series = sleft
-    sleft = int_type(engine=None, base_node=None, index={'a': index_series}, name='test',
+    sleft = int_type(engine=engine, base_node=None, index={'a': index_series}, name='test',
                      expression=expr_test, group_by=None, sorted_ascending=None, index_sorting=[])
-    sright = int_type(engine=None, base_node=None, index={'a': index_series}, name='test',
+    sright = int_type(engine=engine, base_node=None, index={'a': index_series}, name='test',
                       expression=expr_test, group_by=None, sorted_ascending=None, index_sorting=[])
     assert sleft.equals(sright)
     sright = sright.copy_override(index_sorting=[True])

--- a/bach/tests/unit/bach/test_utils.py
+++ b/bach/tests/unit/bach/test_utils.py
@@ -1,7 +1,44 @@
-from bach.utils import get_merged_series_dtype
+from typing import NamedTuple
+
+from bach.utils import get_merged_series_dtype, is_valid_column_name
 
 
 def test_get_merged_series_dtype() -> None:
     assert get_merged_series_dtype({'string', 'int64'}) == 'string'
     assert get_merged_series_dtype({'int64'}) == 'int64'
     assert get_merged_series_dtype({'float64', 'int64'}) == 'float64'
+
+
+class ColNameValid(NamedTuple):
+    name: str
+    postgresql: bool
+    bigquery: bool
+
+
+def test_is_valid_column_name(dialect):
+    tests = [
+        #            column name                              PG     BQ
+        ColNameValid('test',                                  True,  True),
+        ColNameValid('test' * 15 + 'tes',                     True,  True),   # 63 characters
+        ColNameValid('test' * 15 + 'test',                    False, True),   # 64 characters
+        ColNameValid('abcdefghij' * 30 ,                      False, True),   # 300 characters
+        ColNameValid('abcdefghij' * 30 + 'a',                 False, False),  # 301 characters
+        ColNameValid('_index_skating_order',                  True,  True),
+        ColNameValid('1234',                                  True,  False),
+        ColNameValid('1234_test_test',                        True, False),
+        ColNameValid('With_Capitals',                         True,  True),
+        ColNameValid('__SADHDasdfasfASAUIJLKJKAHK',           True,  True),
+        ColNameValid('with{format}{{strings}}{{}%%@#KLJLC',   True,  False),
+        ColNameValid('Aa_!#!$*(aA®Řﬦ‎	⛔',                  True,  False),
+        # Reserved prefixes in BigQuery
+        ColNameValid('_TABLE_test',                           True,  False),
+        ColNameValid('_FILE_test',                            True,  False),
+        ColNameValid('_PARTITIONtest',                        True,  False),
+        ColNameValid('_ROW_TIMESTAMPtest',                    True,  False),
+        ColNameValid('__ROOT__test',                          True,  False),
+        ColNameValid('_COLIDENTIFIERtest',                    True,  False),
+    ]
+    for test in tests:
+        expected = getattr(test, dialect.name)
+        column_name = test.name
+        assert is_valid_column_name(dialect, column_name) is expected

--- a/bach/tests/unit/bach/util.py
+++ b/bach/tests/unit/bach/util.py
@@ -18,6 +18,7 @@ class FakeEngine:
     """ Helper class that serves as a mock for SqlAlchemy Engine objects """
     dialect: Dialect
     name: str = field(init=False)
+    url: str = 'postgresql://user@host:5432/db'
 
     def __post_init__(self):
         super().__setattr__('name', self.dialect.name)  # set the 'frozen' attribute self.name


### PR DESCRIPTION
## Changes
* main change: in `Series.__init__()` we check that the `name` is something that that database allows for column names
* supporting changes:
  * added `is_valid_column_name()` function
  * added/updated tests

## Impact
Creating a series with a 'wrong' name now leads to an error directly, instead of when the sql runs.
