### PR TITLE
Bach categorize unittests: mutli-db or db-independent

### DIFF
--- a/bach/Makefile
+++ b/bach/Makefile
@@ -3,7 +3,7 @@
 tests:
 	mypy --check-untyped-defs bach sql_models
 	pycodestyle bach sql_models
-	pytest tests/ -W error::DeprecationWarning
+	pytest tests/
 
 
 tests-bigquery:

--- a/bach/Makefile
+++ b/bach/Makefile
@@ -3,7 +3,7 @@
 tests:
 	mypy --check-untyped-defs bach sql_models
 	pycodestyle bach sql_models
-	pytest tests/
+	pytest tests/unit tests/functional tests/
 
 
 tests-bigquery:
@@ -12,7 +12,7 @@ tests-bigquery:
 # against Postgres
 	mypy --check-untyped-defs bach sql_models
 	pycodestyle bach sql_models
-	pytest --big-query tests/unit tests/functional -W error::DeprecationWarning
+	pytest --big-query tests/unit tests/functional tests/
 
 
 tests-all:
@@ -21,4 +21,4 @@ tests-all:
 # run against Postgres
 	mypy --check-untyped-defs bach sql_models
 	pycodestyle bach sql_models
-	pytest --all tests/unit tests/functional -W error::DeprecationWarning
+	pytest --all tests/unit tests/functional tests/

--- a/bach/pytest.ini
+++ b/bach/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    db_independent: mark a test as testing code that is not database specific. This helps us in verifying that all our tests work on either all databases, or that that tests are independent from databases. All tests need to either 1) be marker as 'db_independent', or 2) have a parameter 'dialect' or 3) have a parameter 'engine'

--- a/bach/pytest.ini
+++ b/bach/pytest.ini
@@ -1,3 +1,11 @@
 [pytest]
+# See https://docs.pytest.org/en/6.2.x/reference.html#ini-options-ref
+
+# Pytest commandline parameters that we always set
+# --strict-markers: Fail if a test function has an unknown marker (e.g. is decorated with @pytest.mark.not_existing)
+# -W error::DeprecationWarning: Raise an error if we encounter a DeprecationWarning
+addopts = --strict-markers -W error::DeprecationWarning
+
+# markers defines our custom markers
 markers =
     db_independent: mark a test as testing code that is not database specific. This helps us in verifying that all our tests work on either all databases, or that that tests are independent from databases. All tests need to either 1) be marker as 'db_independent', or 2) have a parameter 'dialect' or 3) have a parameter 'engine'

--- a/bach/tests/unit/bach/test_concat.py
+++ b/bach/tests/unit/bach/test_concat.py
@@ -5,6 +5,7 @@ from bach.expression import Expression
 from tests.unit.bach.util import get_fake_df
 
 
+@pytest.mark.db_independent
 def test_concat_empty_objects() -> None:
     with pytest.raises(ValueError, match=r'no objects to concat'):
         DataFrameConcatOperation(objects=[])()
@@ -13,8 +14,8 @@ def test_concat_empty_objects() -> None:
         SeriesConcatOperation(objects=[])()
 
 
-def test_concat_one_object() -> None:
-    df = get_fake_df([], ['b', 'c'])
+def test_concat_one_object(dialect) -> None:
+    df = get_fake_df(dialect, [], ['b', 'c'])
     result = DataFrameConcatOperation(objects=[df])()
 
     assert df.all_series == result.all_series
@@ -25,9 +26,8 @@ def test_concat_one_object() -> None:
     assert df.b.expression == result2.expression
 
 
-def test_get_overridden_objects_error() -> None:
-    df = get_fake_df([], ['c', 'd'])
-
+def test_get_overridden_objects_error(dialect) -> None:
+    df = get_fake_df(dialect, [], ['c', 'd'])
     with pytest.raises(Exception, match='Cannot concat Series to DataFrame'):
         DataFrameConcatOperation(objects=[df, df.c])._get_overridden_objects()
 
@@ -35,18 +35,18 @@ def test_get_overridden_objects_error() -> None:
         SeriesConcatOperation(objects=[df, df.c])._get_overridden_objects()
 
 
-def test_dataframe_concat_join_series_expressions() -> None:
-    df1 = get_fake_df(['a'], ['b'])
-    df2 = get_fake_df(['a'], ['b', 'e'])
+def test_dataframe_concat_join_series_expressions(dialect) -> None:
+    df1 = get_fake_df(dialect, ['a'], ['b'])
+    df2 = get_fake_df(dialect, ['a'], ['b', 'e'])
     result = DataFrameConcatOperation(objects=[df1, df2])._join_series_expressions(df1)
 
     assert isinstance(result, Expression)
     assert len(result.data) == 5
 
 
-def test_dataframe_concat_get_indexes() -> None:
-    df1 = get_fake_df(['a'], ['b'])
-    df2 = get_fake_df(['a', 'b'], ['c', 'd'])
+def test_dataframe_concat_get_indexes(dialect) -> None:
+    df1 = get_fake_df(dialect, ['a'], ['b'])
+    df2 = get_fake_df(dialect, ['a', 'b'], ['c', 'd'])
 
     with pytest.raises(ValueError, match=r'concatenation with diff'):
         DataFrameConcatOperation(objects=[df1, df2])._get_indexes()
@@ -56,9 +56,9 @@ def test_dataframe_concat_get_indexes() -> None:
     assert set(result.keys()) == {'a'}
 
 
-def test_dataframe_concat_get_series() -> None:
-    df1 = get_fake_df([], ['a', 'x', 'y'])
-    df2 = get_fake_df([], ['c', 'd'])
+def test_dataframe_concat_get_series(dialect) -> None:
+    df1 = get_fake_df(dialect, [], ['a', 'x', 'y'])
+    df2 = get_fake_df(dialect, [], ['c', 'd'])
 
     result = DataFrameConcatOperation(objects=[df1, df2])._get_series()
     assert set(result.keys()) == {'a', 'x', 'y', 'c', 'd'}

--- a/bach/tests/unit/bach/test_describe.py
+++ b/bach/tests/unit/bach/test_describe.py
@@ -7,10 +7,10 @@ from bach.operations.describe import DescribeOperation
 from tests.unit.bach.util import get_fake_df
 
 
-def test_process_params_percentile_error() -> None:
+def test_process_params_percentile_error(dialect) -> None:
     with pytest.raises(ValueError, match=r'percentiles should'):
         DescribeOperation(
-            obj=get_fake_df(['a'], ['b']),
+            obj=get_fake_df(dialect, ['a'], ['b']),
             include=None,
             exclude=(),
             datetime_is_numeric=False,
@@ -18,10 +18,10 @@ def test_process_params_percentile_error() -> None:
         )
 
 
-def test_process_params_empty_df() -> None:
+def test_process_params_empty_df(dialect) -> None:
     with pytest.raises(ValueError, match=r'Cannot describe a Dataframe'):
         DescribeOperation(
-            obj=get_fake_df([], []),
+            obj=get_fake_df(dialect, [], []),
             include=(),
             exclude=(),
             datetime_is_numeric=False,
@@ -29,8 +29,9 @@ def test_process_params_empty_df() -> None:
         )
 
 
-def test_include_exclude() -> None:
+def test_include_exclude(dialect) -> None:
     df = get_fake_df(
+        dialect=dialect,
         index_names=[],
         data_names=['a', 'b', 'c', 'd'],
         dtype={'a': 'json', 'b': 'int64', 'c': 'float64', 'd': 'timestamp'}

--- a/bach/tests/unit/bach/test_df_rename.py
+++ b/bach/tests/unit/bach/test_df_rename.py
@@ -95,7 +95,7 @@ def test_rename_ignore_errors(dialect):
 
 
 def test_rename_fail_on_duplicate_columns(dialect):
-    bt = get_fake_df(['i', 'ii'], ['a', 'b'], dialect=dialect)
+    bt = get_fake_df(dialect, ['i', 'ii'], ['a', 'b'])
 
     with pytest.raises(ValueError, match='column name already exists'):
         bt.rename(columns={'a': 'b'})
@@ -108,7 +108,7 @@ def test_rename_fail_on_duplicate_columns(dialect):
 
 
 def test_rename_invalid_column_name(dialect):
-    bt = get_fake_df(['i'], ['a', 'b'], dialect=dialect)
+    bt = get_fake_df(dialect, ['i'], ['a', 'b'])
     too_long_name = 'test' * 100
     with pytest.raises(ValueError, match='Column name ".*" is not valid for SQL dialect'):
         bt.rename(columns={'a': too_long_name})

--- a/bach/tests/unit/bach/test_display_formats.py
+++ b/bach/tests/unit/bach/test_display_formats.py
@@ -1,4 +1,5 @@
 import builtins
+
 from IPython import display
 from _pytest.monkeypatch import MonkeyPatch
 
@@ -6,8 +7,8 @@ from bach.display_formats import display_sql_as_markdown
 from tests.unit.bach.util import get_fake_df
 
 
-def test_display_sql_as_markdown(monkeypatch: MonkeyPatch) -> None:
-    df = get_fake_df(['a'], ['b', 'c'])
+def test_display_sql_as_markdown(monkeypatch: MonkeyPatch, dialect) -> None:
+    df = get_fake_df(dialect, ['a'], ['b', 'c'])
     expected_sql = 'select * from fake_table'
     displayed_calls = 0
 

--- a/bach/tests/unit/bach/test_expression.py
+++ b/bach/tests/unit/bach/test_expression.py
@@ -37,7 +37,7 @@ def test_construct(dialect):
 
 
 def test_construct_series(dialect):
-    df = get_fake_df(['i'], ['a', 'b'])
+    df = get_fake_df(dialect, ['i'], ['a', 'b'])
     result1 = Expression.construct('cast({} as text)', df.a)
     assert result1 == Expression([
         RawToken('cast('),
@@ -78,7 +78,7 @@ def test_string(dialect):
 
 
 def test_combined(dialect):
-    df = get_fake_df(['i'], ['duration', 'irrelevant'])
+    df = get_fake_df(dialect, ['i'], ['duration', 'irrelevant'])
     expr1 = Expression.column_reference('year')
     expr2 = Expression.construct('cast({} as bigint)', df.duration)
     expr_sum = Expression.construct('{} + {}', expr1, expr2)
@@ -114,8 +114,8 @@ def test_non_atomic(dialect):
     assert NonAtomicExpression.construct('{} & {}', na1, e2).to_sql(dialect) == '(a or ~c) & ~a or b'
 
 
-def test_is_constant():
-    df = get_fake_df(['i'], ['duration', 'irrelevant'])
+def test_is_constant(dialect):
+    df = get_fake_df(dialect, ['i'], ['duration', 'irrelevant'])
     notconst1 = Expression.column_reference('year')
     notconst2 = Expression.construct('cast({} as bigint)', df.duration)
     assert not notconst1.is_constant
@@ -157,8 +157,8 @@ def test_is_constant():
     assert not WindowFunctionExpression.construct('agg({}, {}, {})', const1, const2, const3).is_constant
 
 
-def test_is_single_value():
-    df = get_fake_df(['i'], ['duration', 'irrelevant'])
+def test_is_single_value(dialect):
+    df = get_fake_df(dialect, ['i'], ['duration', 'irrelevant'])
     notsingle1 = Expression.column_reference('year')
     notsingle2 = Expression.construct('cast({} as bigint)', df.duration)
     assert not notsingle1.is_single_value
@@ -220,6 +220,7 @@ def test_table_column_reference(dialect) -> None:
         assert expr.to_sql(dialect, 'tab') == '`random`.`city`'
 
 
+@pytest.mark.db_independent
 def test_remove_table_column_references() -> None:
     expr = Expression.table_column_reference('random', 'city')
 
@@ -235,6 +236,7 @@ def test_remove_table_column_references() -> None:
     assert result_expr == Expression.column_reference('city')
 
 
+@pytest.mark.db_independent
 def test_remove_table_column_references_error() -> None:
     expr = Expression(
         [Expression.table_column_reference('random', 'city'), Expression.table_column_reference('random2', 'city')],
@@ -244,6 +246,7 @@ def test_remove_table_column_references_error() -> None:
         expr.remove_table_column_references()
 
 
+@pytest.mark.db_independent
 def test_has_table_column_reference() -> None:
     expr = Expression.table_column_reference('random', 'city')
     assert expr.has_table_column_references

--- a/bach/tests/unit/bach/test_merge.py
+++ b/bach/tests/unit/bach/test_merge.py
@@ -13,24 +13,24 @@ from sql_models.util import is_bigquery, is_postgres
 from tests.unit.bach.util import get_fake_df
 
 
-def test__determine_merge_on_simple_df_df_happy():
-    left = get_fake_df(['a'], ['b', 'c'])
-    right = get_fake_df(['a'], ['c', 'd'])
+def test__determine_merge_on_simple_df_df_happy(dialect):
+    left = get_fake_df(dialect, ['a'], ['b', 'c'])
+    right = get_fake_df(dialect, ['a'], ['c', 'd'])
     assert call__determine_merge_on(left, right) == MergeOn(['c'], ['c'], [])
 
 
-def test__determine_merge_on_simple_df_df_non_happy():
-    left = get_fake_df(['a'], ['b', 'c'])
-    right = get_fake_df(['a'], ['d', 'e'])
+def test__determine_merge_on_simple_df_df_non_happy(dialect):
+    left = get_fake_df(dialect, ['a'], ['b', 'c'])
+    right = get_fake_df(dialect, ['a'], ['d', 'e'])
     with pytest.raises(ValueError):
         # TODO: should we match on index in this case? That seems to make sense
         # there are no columns in left and right with the same name
         call__determine_merge_on(left, right)
 
 
-def test__determine_merge_on_on_df_df_happy():
-    left = get_fake_df(['a'], ['b', 'c'])
-    right = get_fake_df(['a'], ['c', 'd'])
+def test__determine_merge_on_on_df_df_happy(dialect):
+    left = get_fake_df(dialect, ['a'], ['b', 'c'])
+    right = get_fake_df(dialect, ['a'], ['c', 'd'])
     assert call__determine_merge_on(left, right, on='c') == MergeOn(['c'], ['c'], [])
     assert call__determine_merge_on(left, right, on=['c']) == MergeOn(['c'], ['c'], [])
     assert call__determine_merge_on(left, right, on='a') == MergeOn(['a'], ['a'], [])
@@ -38,9 +38,9 @@ def test__determine_merge_on_on_df_df_happy():
     assert call__determine_merge_on(left, right, on=['a', 'c']) == MergeOn(['a', 'c'], ['a', 'c'], [])
 
 
-def test__determine_merge_on_on_df_df_non_happy():
-    left = get_fake_df(['a'], ['b', 'c'])
-    right = get_fake_df(['a'], ['c', 'd'])
+def test__determine_merge_on_on_df_df_non_happy(dialect):
+    left = get_fake_df(dialect, ['a'], ['b', 'c'])
+    right = get_fake_df(dialect, ['a'], ['c', 'd'])
     with pytest.raises(ValueError):
         # 'x' does not exist in either of the dfs
         call__determine_merge_on(left, right, on='x')
@@ -55,9 +55,9 @@ def test__determine_merge_on_on_df_df_non_happy():
         call__determine_merge_on(left, right, How.cross, on='c')
 
 
-def test__determine_merge_on_left_on_right_on_df_df_happy():
-    left = get_fake_df(['a'], ['b', 'c'])
-    right = get_fake_df(['a'], ['c', 'd'])
+def test__determine_merge_on_left_on_right_on_df_df_happy(dialect):
+    left = get_fake_df(dialect, ['a'], ['b', 'c'])
+    right = get_fake_df(dialect, ['a'], ['c', 'd'])
     assert call__determine_merge_on(left, right, left_on='c', right_on='c') == MergeOn(['c'], ['c'], [])
     assert call__determine_merge_on(left, right, left_on=['c'], right_on='c') == MergeOn(['c'], ['c'], [])
     assert call__determine_merge_on(left, right, left_on='c', right_on=['c']) == MergeOn(['c'], ['c'], [])
@@ -70,9 +70,9 @@ def test__determine_merge_on_left_on_right_on_df_df_happy():
            == MergeOn(['a', 'b'], ['a', 'd'], [])
 
 
-def test__determine_merge_on_left_on_right_on_df_df_non_happy():
-    left = get_fake_df(['a'], ['b', 'c'])
-    right = get_fake_df(['a'], ['c', 'd'])
+def test__determine_merge_on_left_on_right_on_df_df_non_happy(dialect):
+    left = get_fake_df(dialect, ['a'], ['b', 'c'])
+    right = get_fake_df(dialect, ['a'], ['c', 'd'])
     # Should always specify both left_on and right_on and not 'on' at the same time.
     with pytest.raises(ValueError):
         call__determine_merge_on(left, right, left_on='c')
@@ -96,18 +96,18 @@ def test__determine_merge_on_left_on_right_on_df_df_non_happy():
         call__determine_merge_on(left, right, How.cross, left_on='c', right_on='c')
 
 
-def test__determine_merge_index_on_df_df_happy():
-    left = get_fake_df(['a'], ['b', 'c'])
-    right = get_fake_df(['a'], ['c', 'd'])
+def test__determine_merge_index_on_df_df_happy(dialect):
+    left = get_fake_df(dialect, ['a'], ['b', 'c'])
+    right = get_fake_df(dialect, ['a'], ['c', 'd'])
     assert call__determine_merge_on(left, right, left_on='c', right_index=True) == MergeOn(['c'], ['a'], [])
     assert call__determine_merge_on(left, right, left_index=True, right_on='c') == MergeOn(['a'], ['c'], [])
     assert call__determine_merge_on(left, right, left_index=True, right_index=True) == \
            MergeOn(['a'], ['a'], [])
 
 
-def test__determine_merge_df_serie_happy():
-    left = get_fake_df(['a'], ['b', 'c'])
-    right = get_fake_df(['a'], ['c', 'd'])['c']
+def test__determine_merge_df_serie_happy(dialect):
+    left = get_fake_df(dialect, ['a'], ['b', 'c'])
+    right = get_fake_df(dialect, ['a'], ['c', 'd'])['c']
     assert call__determine_merge_on(left, right) == MergeOn(['c'], ['c'], [])
     assert call__determine_merge_on(left, right, on='c') == MergeOn(['c'], ['c'], [])
     assert call__determine_merge_on(left, right, left_on='c', right_on='c') == MergeOn(['c'], ['c'], [])
@@ -119,8 +119,8 @@ def test__determine_merge_df_serie_happy():
 
 
 def test__determine_merge_on_w_conditional(dialect) -> None:
-    left = get_fake_df(['a'], ['b', 'c'], dialect=dialect)
-    right = get_fake_df(['a'], ['c', 'd'], dialect=dialect).materialize()['c']
+    left = get_fake_df(dialect, ['a'], ['b', 'c'])
+    right = get_fake_df(dialect, ['a'], ['c', 'd']).materialize()['c']
     series_bool = left['c'] == right
 
     assert call__determine_merge_on(left, right, on=[series_bool]) == MergeOn([], [], [series_bool])
@@ -130,9 +130,8 @@ def test__determine_merge_on_w_conditional(dialect) -> None:
 
 
 def test__determine_result_columns(dialect):
-    dialect = PGDialect()  # TODO: BigQuery
-    left = get_fake_df(['a'], ['b', 'c'], 'int64')
-    right = get_fake_df(['a'], ['c', 'd'], 'float64')
+    left = get_fake_df(dialect, ['a'], ['b', 'c'], 'int64')
+    right = get_fake_df(dialect, ['a'], ['c', 'd'], 'float64')
 
     result = _determine_result_columns(dialect, left, right, MergeOn(['a'], ['a'], []), ('_x', '_y'))
     assert result == (
@@ -202,24 +201,24 @@ def test__determine_result_columns(dialect):
 def test__determine_result_columns_non_happy_path(dialect):
     # With pandas the following works, there will just be two b_x and two b_y columns, but we cannot
     # generate sql that has the same column name multiple times, so we raise an error
-    left = get_fake_df(['a'], ['b', 'b_x'], 'int64')
-    right = get_fake_df(['a'], ['b', 'b_y'], 'float64')
+    left = get_fake_df(dialect, ['a'], ['b', 'b_x'], 'int64')
+    right = get_fake_df(dialect, ['a'], ['b', 'b_y'], 'float64')
     with pytest.raises(ValueError):
         _determine_result_columns(dialect, left, right, MergeOn(['a'], ['a'], []), ('_x', '_y'))
 
 
-def test_merge_non_happy_path_how():
-    left = get_fake_df(['a'], ['b', 'b_x'], 'int64')
-    right = get_fake_df(['a'], ['b', 'b_y'], 'float64')
+def test_merge_non_happy_path_how(dialect):
+    left = get_fake_df(dialect, ['a'], ['b', 'b_x'], 'int64')
+    right = get_fake_df(dialect, ['a'], ['b', 'b_y'], 'float64')
     with pytest.raises(ValueError, match='how'):
         merge(left, right, 'wrong how',
               on=None, left_on=None, right_on=None, left_index=True, right_index=True,
               suffixes=('_x', '_y'))
 
 
-def test_verify_on_conflicts() -> None:
-    left = get_fake_df(['a'], ['b'], 'int64')
-    right = get_fake_df(['a'], ['b'], 'float64')
+def test_verify_on_conflicts(dialect) -> None:
+    left = get_fake_df(dialect, ['a'], ['b'], 'int64')
+    right = get_fake_df(dialect, ['a'], ['b'], 'float64')
     with pytest.raises(ValueError, match=r'if how == "cross"'):
         _verify_on_conflicts(
             left,
@@ -284,8 +283,8 @@ def test_verify_on_conflicts() -> None:
 
 
 def test_verify_on_conflicts_conditional(dialect) -> None:
-    left = get_fake_df(['a'], ['b'], 'float64', dialect=dialect)
-    right = get_fake_df(['a'], ['b'], 'float64', dialect=dialect)
+    left = get_fake_df(dialect, ['a'], ['b'], 'float64')
+    right = get_fake_df(dialect, ['a'], ['b'], 'float64')
     bool_series = left['b'] == left['b']
 
     with pytest.raises(ValueError, match=r'valid only when left.base_node != right.base_node.'):
@@ -318,7 +317,7 @@ def test_verify_on_conflicts_conditional(dialect) -> None:
             right_index=False,
         )
 
-    other_df = get_fake_df(['a'], ['b'], 'float64', dialect=dialect)
+    other_df = get_fake_df(dialect, ['a'], ['b'], 'float64')
     other_df = other_df.materialize(node_name='other')
     bool_series = left['b'] > right['b'] + other_df['b']
 
@@ -336,9 +335,9 @@ def test_verify_on_conflicts_conditional(dialect) -> None:
 
 
 def test__resolve_merge_expression_reference(dialect) -> None:
-    left = get_fake_df(['a'], ['b'], 'float64', dialect=dialect)
+    left = get_fake_df(dialect, ['a'], ['b'], 'float64')
     left = left.materialize()
-    right = get_fake_df(['a'], ['b'], 'float64', dialect=dialect)
+    right = get_fake_df(dialect, ['a'], ['b'], 'float64')
 
     bool_series = left['b'].astype(int) == right['b'].astype(int)
     result = _resolve_merge_expression_references(dialect, left, right, MergeOn([], [], [bool_series]))

--- a/bach/tests/unit/bach/test_series.py
+++ b/bach/tests/unit/bach/test_series.py
@@ -1,15 +1,20 @@
 """
 Copyright 2021 Objectiv B.V.
 """
+from typing import List
+
 from bach import get_series_type_from_dtype
 from bach.expression import Expression
 from bach.partitioning import GroupBy
 from tests.unit.bach.util import get_fake_df, FakeEngine
 
 
-def test_equals():
-    left = get_fake_df(['a'], ['b', 'c'])
-    right = get_fake_df(['a'], ['b', 'c'])
+def test_equals(dialect):
+    def get_df(index_names: List[str], data_names: List[str]):
+        return get_fake_df(dialect=dialect, index_names=index_names, data_names=data_names)
+
+    left = get_df(['a'], ['b', 'c'])
+    right = get_df(['a'], ['b', 'c'])
 
     result = left['b'].equals(left['b'])
     # assert result is a boolean (for e.g.  '==') this is not the case
@@ -19,16 +24,16 @@ def test_equals():
     assert not left['b'].equals(left['c'])
     assert not left['b'].equals(right['c'])
 
-    left = get_fake_df(['a', 'x'], ['b', 'c'])
-    right = get_fake_df(['a'], ['b', 'c'])
+    left = get_df(['a', 'x'], ['b', 'c'])
+    right = get_df(['a'], ['b', 'c'])
     assert left['b'].equals(left['b'])
     assert not left['b'].equals(right['b'])
     assert not left['b'].equals(left['c'])
     assert not left['b'].equals(right['c'])
 
     # different order in the index
-    left = get_fake_df(['a', 'b'], ['c'])
-    right = get_fake_df(['b', 'a'], ['c'])
+    left = get_df(['a', 'b'], ['c'])
+    right = get_df(['b', 'a'], ['c'])
     assert not left['c'].equals(right['c'])
 
     engine = left.engine

--- a/bach/tests/unit/bach/test_sql_model.py
+++ b/bach/tests/unit/bach/test_sql_model.py
@@ -1,11 +1,14 @@
 """
 Copyright 2022 Objectiv B.V.
 """
+import pytest
+
 from bach.expression import Expression
 from bach.sql_model import BachSqlModel
 from sql_models.model import CustomSqlModelBuilder, Materialization
 
 
+@pytest.mark.db_independent
 def test_bach_sql_model_copy():
     # test that if we call a function that should return a copy on a BachSqlModel instance, that we get
     # a BachSqlModel instance again.

--- a/bach/tests/unit/bach/test_utils.py
+++ b/bach/tests/unit/bach/test_utils.py
@@ -1,8 +1,11 @@
 from typing import NamedTuple
 
+import pytest
+
 from bach.utils import get_merged_series_dtype, is_valid_column_name
 
 
+@pytest.mark.db_independent
 def test_get_merged_series_dtype() -> None:
     assert get_merged_series_dtype({'string', 'int64'}) == 'string'
     assert get_merged_series_dtype({'int64'}) == 'int64'

--- a/bach/tests/unit/bach/util.py
+++ b/bach/tests/unit/bach/util.py
@@ -25,10 +25,10 @@ class FakeEngine:
 
 
 def get_fake_df(
+    dialect: Dialect,
     index_names: List[str],
     data_names: List[str],
-    dtype: Union[str, Dict[str, str]] = 'int64',
-    dialect: Dialect = PGDialect()
+    dtype: Union[str, Dict[str, str]] = 'int64'
 ) -> DataFrame:
     engine = FakeEngine(dialect=dialect)
     columns = index_names + data_names

--- a/bach/tests/unit/sql_models/test_graph_operations.py
+++ b/bach/tests/unit/sql_models/test_graph_operations.py
@@ -10,6 +10,8 @@ from sql_models.graph_operations import get_graph_nodes_info, get_node, get_node
 from sql_models.model import RefPath, SqlModel
 from tests.unit.sql_models.util import ValueModel, RefModel, JoinModel, RefValueModel
 
+pytestmark = [pytest.mark.db_independent]  # mark all tests here as database independent.
+
 
 def get_simple_test_graph():
     """ Give a simple graph that consists of 4 model instances of 3 model types. """

--- a/bach/tests/unit/sql_models/test_graph_operations_replace_node.py
+++ b/bach/tests/unit/sql_models/test_graph_operations_replace_node.py
@@ -13,6 +13,9 @@ from sql_models.model import SqlModel, RefPath
 from tests.unit.sql_models.util import ValueModel, RefModel, JoinModel, RefValueModel
 
 
+pytestmark = [pytest.mark.db_independent]  # mark all tests here as database independent.
+
+
 def call_replace_node_in_graph(
         start_node: SqlModel,
         reference_path: RefPath,

--- a/bach/tests/unit/sql_models/test_model.py
+++ b/bach/tests/unit/sql_models/test_model.py
@@ -13,6 +13,9 @@ from sql_models.sql_generator import to_sql
 from tests.unit.sql_models.util import RefModel, ValueModel, JoinModel
 
 
+pytestmark = [pytest.mark.db_independent]  # mark all tests here as database independent.
+
+
 def test_builder_cycles_raise_exception():
     rm1 = RefModel()
     rm2 = RefModel(ref=rm1)

--- a/bach/tests/unit/sql_models/test_model_escape_format.py
+++ b/bach/tests/unit/sql_models/test_model_escape_format.py
@@ -1,8 +1,11 @@
 """
 Copyright 2022 Objectiv B.V.
 """
+import pytest
+
 from sql_models.model import escape_format_string
 
+pytestmark = [pytest.mark.db_independent]  # mark all tests here as database independent.
 
 def assert_escape_compare_value(value):
     """ helper for test__escape_value. Assert that the escaped value, after formatting equals the original"""

--- a/bach/tests/unit/sql_models/test_sql_query_parser.py
+++ b/bach/tests/unit/sql_models/test_sql_query_parser.py
@@ -3,8 +3,15 @@ Copyright 2021 Objectiv B.V.
 """
 from typing import List
 
+import pytest
+
 from sql_models.sql_query_parser import raw_sql_to_selects, CteTuple
 from tests.unit.sql_models.util import assert_roughly_equal_sql
+
+
+# mark all tests here as database independent. Perhaps in the future we'll have DB specific parsing, but
+# currently having generic parsing is enough
+pytestmark = [pytest.mark.db_independent]
 
 
 def test_parse_select():

--- a/bach/tests/unit/sql_models/test_util.py
+++ b/bach/tests/unit/sql_models/test_util.py
@@ -1,9 +1,13 @@
 """
 Copyright 2021 Objectiv B.V.
 """
-from sql_models.util import extract_format_fields, quote_identifier, quote_string, is_postgres,\
-    is_bigquery, DatabaseNotSupportedException
+import pytest
 
+from sql_models.util import extract_format_fields, quote_identifier, quote_string, is_postgres,\
+    is_bigquery
+
+
+pytestmark = [pytest.mark.db_independent]  # mark all tests here as database independent.
 
 def test_extract_format_fields():
     assert extract_format_fields('{test}') == {'test'}


### PR DESCRIPTION
With this PR all unittest (not the functional tests!) are either classified as multi-database or database-independent.

## Changes
There are two main changes in this PR.
1. This first change is a bit of a meta-change. This introduces the `db_independent` mark, that we can use to mark unittests as database independent (`@pytest.mark.db_independent`). Basically this mark means: we checked this test, it doesn't need to support multiple databases. Commits: ce6a85e0fa6813ab1946562e48fd87a30788e1fa, a49303603107fa49d1764c58e840c72c96a9a244, and d7309bba9993cfe63467c1b214869970e0fb2636
3. Changed all unittests, either added the marking, or added `dialect` as a parameter and made them work for both databases. Commits: c43bd50a26023167712e1322a82ee301b96fa778 and 392a6fba663a22572321444159f253a7d4db5567


## All *unit* tests converted
With the combination of the mark and the `--all` option we can now verify that all tests have either been converted, or checked to be database independent. 
```
pytest tests/unit/ -m db_independent
...
41 passed, 72 deselected
```
that is, there are `41` db-independent tests, and `72` multi-database tests.
So if we run the tests for both BigQuery and Postgres we expect in total there to be `41 + 2 * 72 = 185` tests
```
pytest tests/unit/ --all
...
185 passed
```
