### PR TITLE
Support numpy `bool_` type

### DIFF
--- a/bach/bach/series/series_boolean.py
+++ b/bach/bach/series/series_boolean.py
@@ -12,6 +12,8 @@ from bach.series.series import WrappedPartition
 from sql_models.constants import DBDialect
 from sql_models.util import is_postgres
 
+import numpy
+
 
 class SeriesBoolean(Series, ABC):
     """
@@ -38,7 +40,7 @@ class SeriesBoolean(Series, ABC):
         DBDialect.POSTGRES: 'boolean',
         DBDialect.BIGQUERY: 'boolean',
     }
-    supported_value_types = (bool, )
+    supported_value_types = (bool, numpy.bool_)
 
     # Notes for supported_value_to_literal() and supported_literal_to_expression():
     # 'True' and 'False' are valid boolean literals in Postgres

--- a/bach/bach/types.py
+++ b/bach/bach/types.py
@@ -125,6 +125,7 @@ class TypeRegistry:
         self._register_value_klass(numpy.int64, SeriesInt64)
         self._register_value_klass(float, SeriesFloat64)
         self._register_value_klass(numpy.float64, SeriesFloat64)
+        self._register_value_klass(numpy.bool_, SeriesBoolean)
         self._register_value_klass(bool, SeriesBoolean)
         self._register_value_klass(type(None), SeriesString)  # NoneType ends up as a string for now
         self._register_value_klass(str, SeriesString)

--- a/bach/tests/functional/bach/test_series.py
+++ b/bach/tests/functional/bach/test_series.py
@@ -547,7 +547,6 @@ def test_series_unstack():
     bt = get_bt_with_test_data(full_data_set=False)
     bt['village'] = bt.city + ' village'
     unstacked_bt = bt.groupby(['skating_order', 'village']).inhabitants.sum().unstack()
-    # unstacked_bt = bt.set_index(['skating_order', 'village']).inhabitants.unstack()
 
     expected_columns = ['Drylts village', 'Ljouwert village', 'Snits village']
     assert sorted(unstacked_bt.data_columns) == expected_columns
@@ -562,6 +561,29 @@ def test_series_unstack():
             [3, 3055., None, None]
         ],
         order_by='skating_order'
+    )
+
+    # test unstack on boolean column
+    bt = get_bt_with_test_data(full_data_set=True)
+    bt['big_city'] = bt.inhabitants > 1000
+    unstacked_bt = bt.groupby(['municipality', 'big_city']).founding.min().unstack(fill_value=0)
+
+    expected_columns = ['False', 'True']
+    assert sorted(unstacked_bt.data_columns) == expected_columns
+    unstacked_bt_sorted = unstacked_bt.copy_override(series={x: unstacked_bt[x] for x in expected_columns})
+
+    assert_equals_data(
+        unstacked_bt_sorted,
+        expected_columns=['municipality'] + expected_columns,
+        expected_data=[
+            ['De Friese Meren', 1426, 0],
+            ['Harlingen', 0, 1234],
+            ['Leeuwarden', 0, 1285],
+            ['Noardeast-Fryslân', 0, 1298],
+            ['Súdwest-Fryslân', 1061, 1268],
+            ['Waadhoeke', 0, 1374]
+        ],
+        order_by='municipality'
     )
 
 


### PR DESCRIPTION
support for numby.bool_ type. Reason is that our `to_numpy()` returns this type. This in turn is used in unstack.