### PR TITLE
Bach bq load data from cte

### DIFF
--- a/bach/bach/from_pandas.py
+++ b/bach/bach/from_pandas.py
@@ -120,7 +120,7 @@ def from_pandas_ephemeral(
     all_values_str = join_expressions(per_row_expr, join_str=',\n').to_sql(engine.dialect)
 
     if is_postgres(engine):
-        # We are building for sql of the form:
+        # We are building sql of the form:
         #     select * from (values
         #         ('row 1', cast(1234 as bigint), cast(-13.37 as double precision)),
         #         ('row 2', cast(1337 as bigint), cast(31.337 as double precision))
@@ -132,7 +132,7 @@ def from_pandas_ephemeral(
         column_names_str = column_names_expr.to_sql(engine.dialect)
         sql = f'select * from (values \n{all_values_str}\n) as t({column_names_str})\n'
     elif is_bigquery(engine):
-        # We are building for sql of the form:
+        # We are building sql of the form:
         #     select * from UNNEST([
         #         STRUCT<`a` STRING, `b` INT64, `c` FLOAT64>
         #         ('row 1', 1234, cast(-13.37 as FLOAT64))

--- a/bach/bach/utils.py
+++ b/bach/bach/utils.py
@@ -49,6 +49,10 @@ def escape_parameter_characters(conn: Connection, raw_sql: str) -> str:
 
 
 def is_valid_column_name(dialect: Dialect, name: str) -> bool:
+    """
+    Check that the given name is a valid column name in the SQL dialect.
+    :return: True if the name is a valid column name, False otherwise.
+    """
     if is_postgres(dialect):
         # Identifiers longer than 63 characters are not necessarily wrong, but they will be truncated which
         # could lead to identifier collisions, so we just disallow it.

--- a/bach/bach/utils.py
+++ b/bach/bach/utils.py
@@ -51,7 +51,6 @@ def escape_parameter_characters(conn: Connection, raw_sql: str) -> str:
 def is_valid_column_name(dialect: Dialect, name: str) -> bool:
     """
     Check that the given name is a valid column name in the SQL dialect.
-    :return: True if the name is a valid column name, False otherwise.
     """
     if is_postgres(dialect):
         # Identifiers longer than 63 characters are not necessarily wrong, but they will be truncated which

--- a/bach/tests/functional/bach/test_data_and_utils.py
+++ b/bach/tests/functional/bach/test_data_and_utils.py
@@ -6,7 +6,6 @@ Utilities and a very simple dataset for testing Bach DataFrames.
 This file does not contain any test, but having the file's name start with `test_` makes pytest treat it
 as a test file. This makes pytest rewrite the asserts to give clearer errors.
 """
-import os
 from typing import List, Union, Type, Dict, Any
 
 import pandas
@@ -27,6 +26,7 @@ from tests.conftest import DB_PG_TEST_URL
 
 # cities is the main table and should be used when sufficient. The other tables can be used in addition
 # for more complex scenarios (e.g. merging)
+from tests.unit.bach.util import get_pandas_df
 
 TEST_DATA_CITIES_FULL = [
     [1, 'Ljouwert', 'Leeuwarden', 93485, 1285],
@@ -123,19 +123,12 @@ def get_bt(
     return _TABLE_DATAFRAME_CACHE[lookup_key].copy_override(savepoints=Savepoints())
 
 
-def get_pandas_df(dataset: List[List[Any]], columns: List[str]) -> pandas.DataFrame:
-    """ Convert the given dataset to a Pandas DataFrame """
-    df = pandas.DataFrame.from_records(dataset, columns=columns)
-    df.set_index(df.columns[0], drop=False, inplace=True)
-    if 'moment' in df.columns:
-        df['moment'] = df['moment'].astype('datetime64')
-    if 'date' in df.columns:
-        df['date'] = df['date'].astype('datetime64')
-    return df
-
-
 def get_from_df(table: str, df: pandas.DataFrame, convert_objects=True) -> DataFrame:
-    """ Create a database table with the data from the data-frame. """
+    """
+    Create a database table with the data from the data-frame.
+
+    Will be deprecated! When possible use `DataFrame.from_pandas()` with `materialization='cte'`
+    """
     engine = sqlalchemy.create_engine(DB_PG_TEST_URL)
     buh_tuh = DataFrame.from_pandas(
         engine=engine,
@@ -180,6 +173,9 @@ def get_df_with_test_data(engine: Engine, full_data_set: bool = False) -> DataFr
 
 
 def get_bt_with_test_data(full_data_set: bool = False) -> DataFrame:
+    """
+    DEPRECATED: Use get_df_with_test_data()
+    """
     if full_data_set:
         return get_bt('test_table_full', TEST_DATA_CITIES_FULL, CITIES_COLUMNS, True)
     return get_bt('test_table_partial', TEST_DATA_CITIES, CITIES_COLUMNS, True)

--- a/bach/tests/functional/bach/test_df_drop_duplicates.py
+++ b/bach/tests/functional/bach/test_df_drop_duplicates.py
@@ -1,10 +1,11 @@
 import pandas as pd
 import pytest
 
-from tests.functional.bach.test_data_and_utils import assert_equals_data, get_from_df
+from bach import DataFrame
+from tests.functional.bach.test_data_and_utils import assert_equals_data
 
 
-def test_df_basic_drop_duplicates() -> None:
+def test_df_basic_drop_duplicates(engine) -> None:
     pdf = pd.DataFrame(
         data={
             'a': [1, 1, 2, 3, 4, 4, 5],
@@ -12,7 +13,7 @@ def test_df_basic_drop_duplicates() -> None:
         }
     )
 
-    df = get_from_df('drop_dup_table', pdf)
+    df = DataFrame.from_pandas(engine=engine, df=pdf, convert_objects=True)
     result = df.drop_duplicates().sort_index()
 
     expected_pdf = pd.DataFrame(
@@ -47,7 +48,7 @@ def test_df_basic_drop_duplicates() -> None:
     )
 
 
-def test_df_basic_w_subset_drop_duplicates() -> None:
+def test_df_basic_w_subset_drop_duplicates(engine) -> None:
     pdf = pd.DataFrame(
         data={
             'a': [1, 1, 2, 3, 4, 4, 5],
@@ -56,7 +57,7 @@ def test_df_basic_w_subset_drop_duplicates() -> None:
         }
     )
     subset = ['a', 'b']
-    df = get_from_df('drop_dup_table', pdf)
+    df = DataFrame.from_pandas(engine=engine, df=pdf, convert_objects=True)
     result = df.drop_duplicates(subset=subset).sort_index()
 
     expected_pdf = pd.DataFrame(
@@ -91,14 +92,14 @@ def test_df_basic_w_subset_drop_duplicates() -> None:
     )
 
 
-def test_df_keep_last_drop_duplicates() -> None:
+def test_df_keep_last_drop_duplicates(engine) -> None:
     pdf = pd.DataFrame(
         data={
             'a': [1, 1, 1, 3, 4, 1, 1],
             'b': ['a', 'b', 'b', 'c', 'd', 'a', 'a'],
         }
     )
-    df = get_from_df('drop_dup_table', pdf)
+    df = DataFrame.from_pandas(engine=engine, df=pdf, convert_objects=True)
     result = df.drop_duplicates(keep='last').sort_index()
 
     expected_df = pd.DataFrame(
@@ -136,14 +137,14 @@ def test_df_keep_last_drop_duplicates() -> None:
     )
 
 
-def test_df_drop_all_duplicates() -> None:
+def test_df_drop_all_duplicates(engine) -> None:
     pdf = pd.DataFrame(
         data={
             'a': [1, 1, 1, 3, 4, 1, 1],
             'b': ['a', 'b', 'b', 'c', 'd', 'a', 'a'],
         }
     )
-    df = get_from_df('drop_dup_table', pdf)
+    df = DataFrame.from_pandas(engine=engine, df=pdf, convert_objects=True)
 
     result = df.drop_duplicates(keep=False).sort_index()
 
@@ -173,7 +174,7 @@ def test_df_drop_all_duplicates() -> None:
     )
 
 
-def test_drop_duplicates_w_sorting() -> None:
+def test_drop_duplicates_w_sorting(engine) -> None:
     pdf = pd.DataFrame(
         data={
             'a': [1, 1, 1, 3, 4, 1, 1],
@@ -183,7 +184,7 @@ def test_drop_duplicates_w_sorting() -> None:
         },
     )
 
-    df = get_from_df('drop_dup_table', pdf)
+    df = DataFrame.from_pandas(engine=engine, df=pdf, convert_objects=True)
     result = df.drop_duplicates(subset=['a', 'b'], sort_by=['c'], ascending=False)
 
     assert_equals_data(
@@ -209,14 +210,15 @@ def test_drop_duplicates_w_sorting() -> None:
         ],
     )
 
-def test_errors_drop_duplicates() -> None:
+
+def test_errors_drop_duplicates(engine) -> None:
     pdf = pd.DataFrame(
         data={
             'a': [1, 1, 1, 3, 4, 1, 1],
             'b': ['a', 'b', 'b', 'c', 'd', 'a', 'a'],
         }
     )
-    df = get_from_df('drop_dup_table', pdf)
+    df = DataFrame.from_pandas(engine=engine, df=pdf, convert_objects=True)
     with pytest.raises(ValueError, match=r'keep must be either'):
         df.drop_duplicates(keep='random')
 

--- a/bach/tests/functional/bach/test_df_from_pandas.py
+++ b/bach/tests/functional/bach/test_df_from_pandas.py
@@ -84,13 +84,12 @@ def test_from_pandas_ephemeral_basic(engine):
         materialization='cte',
         name='ephemeral data'
     )
-    print(bt.to_pandas())
     assert_equals_data(bt, expected_columns=EXPECTED_COLUMNS, expected_data=EXPECTED_DATA)
 
 
 def test_from_pandas_ephemeral_injection(engine):
-    # We only support 'weird' Series name on Postgres. We must make sure tho that these 'weird' names are
-    # handled correctly tho!
+    # We only support 'weird' Series names on Postgres. We must make sure tho that these 'weird' names are
+    # handled correctly, which we test here.
     # On bigquery we cannot support 'weird' series names, because we map Series names directly to column
     # names and BigQuery only allows [a-zA-Z0-9_] in quoted column names. This behaviour for BigQuery is
     # tested in tests/unit/bach/test_df_from_pandas.py

--- a/bach/tests/functional/bach/test_series.py
+++ b/bach/tests/functional/bach/test_series.py
@@ -162,13 +162,13 @@ def test_series_sort_index_multi_level():
 def test_fillna():
     # TODO test fillna with series instead of constants.
     values = [1, np.nan, 3, np.nan, 7]
-    pdf = pd.DataFrame(data=values)
+    pdf = pd.DataFrame(data={'0': values})
     bt = get_from_df('test_fillna', pdf)
 
     def tf(x):
         bt_fill = bt['0'].fillna(x)
         assert bt_fill.expression.is_constant == bt['0'].expression.is_constant
-        np.testing.assert_equal(pdf[0].fillna(x).to_numpy(), bt_fill.to_numpy())
+        np.testing.assert_equal(pdf['0'].fillna(x).to_numpy(), bt_fill.to_numpy())
 
     assert(bt['0'].dtype == 'float64')
     tf(1.25)

--- a/bach/tests/functional/bach/test_series_numeric.py
+++ b/bach/tests/functional/bach/test_series_numeric.py
@@ -48,7 +48,7 @@ def helper_test_simple_arithmetic(engine: Engine, a: Union[int, float], b: Union
 
 def test_round():
     values = [1.9, 3.0, 4.123, 6.425124, 2.00000000001, 2.1, np.nan, 7.]
-    pdf = pd.DataFrame(data=values)
+    pdf = pd.DataFrame(data={'0': values})
     bt = get_from_df('test_round', pdf)
     bt['const'] = 14.12345
     assert bt.const.expression.is_constant
@@ -56,34 +56,34 @@ def test_round():
     for i in 0, 3, 5, 9:
         assert bt.const.round(i).expression.is_constant
         assert not bt['0'].round(i).expression.is_constant
-        np.testing.assert_equal(pdf[0].round(i).to_numpy(), bt['0'].round(i).to_numpy())
-        np.testing.assert_equal(pdf[0].round(decimals=i).to_numpy(), bt['0'].round(decimals=i).to_numpy())
+        np.testing.assert_equal(pdf['0'].round(i).to_numpy(), bt['0'].round(i).to_numpy())
+        np.testing.assert_equal(pdf['0'].round(decimals=i).to_numpy(), bt['0'].round(decimals=i).to_numpy())
 
 
 def test_round_integer():
     values = [1, 3, 4, 6, 2, 2, 6, 7]
-    pdf = pd.DataFrame(data=values)
+    pdf = pd.DataFrame(data={'0': values})
     bt = get_from_df('test_round', pdf)
 
     for i in 0, 3, 5, 9:
         result = bt['0'].round(i).sort_values().to_pandas()
-        expected = pdf[0].round(i).sort_values()
+        expected = pdf['0'].round(i).sort_values()
         pd.testing.assert_series_equal(expected, result, check_names=False, check_index=False)
 
         result2 = bt['0'].round(decimals=i).sort_values().to_pandas()
-        expected2 = pdf[0].round(decimals=i).sort_values()
+        expected2 = pdf['0'].round(decimals=i).sort_values()
         pd.testing.assert_series_equal(expected2, result2, check_names=False, check_index=False)
 
 
 def test_aggregations_simple_tests():
     values = [1, 3, 4, 6, 2, 2, np.nan, 7, 8]
-    pdf = pd.DataFrame(data=values)
+    pdf = pd.DataFrame(data={'0': values})
     bt = get_from_df('test_aggregations_simple_tests', pdf)
 
     numeric_agg = ['sum', 'mean']
     stats_agg = ['sem', 'std', 'var']
     for agg in numeric_agg + stats_agg:
-        pd_agg = pdf[0].agg(agg)
+        pd_agg = pdf['0'].agg(agg)
         bt_agg = bt['0'].agg(agg)
         assert bt_agg.expression.has_aggregate_function
         assert not bt_agg.expression.is_constant
@@ -92,11 +92,11 @@ def test_aggregations_simple_tests():
 
 
 def test_aggregations_sum_mincount():
-    pdf = pd.DataFrame(data=[1, np.nan, 7, 8])
+    pdf = pd.DataFrame(data={'0': [1, np.nan, 7, 8]})
     bt = get_from_df('test_aggregations_sum_mincount', pdf)
 
     for i in [5, 4, 3]:
-        pd_agg = pdf.sum(min_count=i)[0]
+        pd_agg = pdf.sum(min_count=i)['0']
         bt_agg = bt.sum(min_count=i)['0_sum']
 
         # since sum is wrapped in a CASE WHEN, we need to make sure that these are still valid:

--- a/bach/tests/unit/bach/test_df_from_pandas.py
+++ b/bach/tests/unit/bach/test_df_from_pandas.py
@@ -1,0 +1,55 @@
+"""
+Copyright 2022 Objectiv B.V.
+"""
+import pytest
+
+from bach.from_pandas import _assert_column_names_valid
+from tests.unit.bach.test_utils import ColNameValid
+from tests.unit.bach.util import get_pandas_df
+
+
+def test__assert_column_names_valid_generic(dialect):
+    # check for duplicates and for non-named columns
+    data = [[1, 2, 3], [3, 4, 5]]
+    column_names = ['a', 'b', 'c']
+    pdf = get_pandas_df(dataset=data, columns=column_names)
+    # OK, columns are 'a', 'b', and 'c'
+    _assert_column_names_valid(dialect=dialect, df=pdf)
+
+    # Not OK: column name 'a' appears twice
+    pdf.columns = ['a', 'b', 'a']
+    with pytest.raises(ValueError, match='Duplicate column names'):
+        _assert_column_names_valid(dialect=dialect, df=pdf)
+
+    # Not OK: column names are not all strings
+    pdf.columns = ['a', 'b', 0]
+    with pytest.raises(ValueError, match='Not all columns names are strings'):
+        _assert_column_names_valid(dialect=dialect, df=pdf)
+
+
+    # Not OK: second column has no name
+    pdf.columns = ['a', None, 'c']
+    with pytest.raises(ValueError, match='Not all columns names are strings'):
+        _assert_column_names_valid(dialect=dialect, df=pdf)
+
+
+def test__assert_column_names_valid_db_specific(dialect):
+    # test whether column names are allowed for specific dialects
+    # We'll just test a few combinations here
+    tests = [
+        #            column name              PG     BQ
+        ColNameValid('test',                  True, True),
+        ColNameValid('test' * 15 + 'test',    False, True),   # 64 characters
+        ColNameValid('abcdefghij' * 30 + 'a', False, False),  # 301 characters
+        ColNameValid('#@*&O*JALDSJK',         True, False),
+    ]
+    for test in tests:
+        data = [[1, 2, 3], [3, 4, 5]]
+        column_names = ['a', 'b', test.name]
+        pdf = get_pandas_df(dataset=data, columns=column_names)
+        expected = getattr(test, dialect.name)
+        if expected:
+            _assert_column_names_valid(dialect=dialect, df=pdf)
+        else:
+            with pytest.raises(ValueError, match='Invalid column names: .* for SQL dialect'):
+                _assert_column_names_valid(dialect=dialect, df=pdf)

--- a/bach/tests/unit/bach/util.py
+++ b/bach/tests/unit/bach/util.py
@@ -2,7 +2,9 @@
 Copyright 2021 Objectiv B.V.
 """
 from dataclasses import dataclass, field
-from typing import List, Dict, Union, cast, Optional, NamedTuple
+from typing import List, Dict, Union, cast, Optional, NamedTuple, Any
+
+import pandas
 from sqlalchemy.dialects.postgresql.base import PGDialect
 from sqlalchemy.engine import Dialect, Engine
 
@@ -88,3 +90,18 @@ def get_fake_df_test_data(dialect: Dialect) -> DataFrame:
         },
         dialect=dialect
     )
+
+
+def get_pandas_df(dataset: List[List[Any]], columns: List[str]) -> pandas.DataFrame:
+    """
+    Convert the given dataset to a Pandas DataFrame
+    :param dataset: list, with each item representing a row, and each row consisting of a list of columns.
+    :param columns: names of the columns
+    """
+    df = pandas.DataFrame.from_records(dataset, columns=columns)
+    df.set_index(df.columns[0], drop=False, inplace=True)
+    if 'moment' in df.columns:
+        df['moment'] = df['moment'].astype('datetime64')
+    if 'date' in df.columns:
+        df['date'] = df['date'].astype('datetime64')
+    return df


### PR DESCRIPTION
**Main Change:**  `DataFrame.from_pandas()` support for BigQuery when `materialization='cte'`.  Note that `materialization='table'` is NOT yet supported

**Other Changes:**
* `DataFrame.from_pandas()` now complains if the DataFrame's columns are not all unique and strings.
  * changed some tests that used a column named `0`, renamed that column to`'0'`
* Modified some tests for `from_pandas()` and added some
  *  A lot of tests in `test_df_from_pandas.py` have not been made multi-database yet, because they either test `materialization='table'` or they use types that we do not support yet.
* Converted some tests that previously used `get_from_df()` to now use `DataFrame.from_pandas()` directly. This change makes those tests work with BigQuery too. Unfortunately it wasn't trivial to convert all tests, so left others alone for now.