### PR TITLE
Kathiabarahona/series string fix tests

### DIFF
--- a/bach/bach/expression.py
+++ b/bach/bach/expression.py
@@ -112,7 +112,7 @@ class StringValueToken(ExpressionToken):
     value: str
 
     def to_sql(self, dialect: Dialect) -> str:
-        return escape_raw_sql(quote_string(self.value))
+        return escape_raw_sql(quote_string(dialect, self.value))
 
 
 @dataclass(frozen=True)

--- a/bach/bach/series/series_json.py
+++ b/bach/bach/series/series_json.py
@@ -269,7 +269,7 @@ class SeriesJsonb(Series):
         def _find_in_json_list(self, key: Union[str, Dict[str, str]]):
             if isinstance(key, (dict, str)):
                 key = json.dumps(key)
-                quoted_key = quote_string(key)
+                quoted_key = quote_string(self._series_object.engine, key)
                 expression_str = f"""(select min(case when ({quoted_key}::jsonb) <@ value
                 then ordinality end) -1 from jsonb_array_elements({{}}) with ordinality)"""
                 return expression_str

--- a/bach/tests/functional/bach/test_series_string.py
+++ b/bach/tests/functional/bach/test_series_string.py
@@ -8,14 +8,14 @@ from tests.functional.bach.test_data_and_utils import get_bt_with_test_data, ass
     get_df_with_test_data
 
 
-def test_from_const(pg_engine):
+def test_from_const(engine):
     # TODO: BigQuery
     a = 'a string'
     b = 'a string\'"\'\' "" \\ with quotes'
     c = None
     d = '\'\'!@&*(HJD☢%'
 
-    bt = get_df_with_test_data(pg_engine)[['city']]
+    bt = get_df_with_test_data(engine)[['city']]
     bt['a'] = a
     bt['b'] = b
     bt['c'] = SeriesString.from_const(base=bt, value=c, name='temp')

--- a/bach/tests/unit/bach/test_expression.py
+++ b/bach/tests/unit/bach/test_expression.py
@@ -70,11 +70,21 @@ def test_column_reference(dialect):
 def test_string(dialect):
     expr = Expression.string_value('a string')
     assert expr == Expression([StringValueToken('a string')])
-    assert expr.to_sql(dialect) == "'a string'"
-    assert expr.to_sql(dialect, 'tab') == "'a string'"
+
+    if is_bigquery(dialect):
+        assert expr.to_sql(dialect) == 'r"""a string"""'
+        assert expr.to_sql(dialect, 'tab') == 'r"""a string"""'
+    else:
+        assert expr.to_sql(dialect) == "'a string'"
+        assert expr.to_sql(dialect, 'tab') == "'a string'"
+
     expr = Expression.string_value('a string \' with quotes\'\' in it')
     assert expr == Expression([StringValueToken('a string \' with quotes\'\' in it')])
-    assert expr.to_sql(dialect, ) == "'a string '' with quotes'''' in it'"
+
+    if is_bigquery(dialect):
+        assert expr.to_sql(dialect) == 'r"""a string \' with quotes\'\' in it"""'
+    else:
+        assert expr.to_sql(dialect) == "'a string '' with quotes'''' in it'"
 
 
 def test_combined(dialect):

--- a/bach/tests/unit/sql_models/test_util.py
+++ b/bach/tests/unit/sql_models/test_util.py
@@ -42,7 +42,18 @@ def test_quote_identifier(dialect):
         raise Exception()
 
 
-def test_quote_string():
-    assert quote_string("test") == "'test'"
-    assert quote_string("te'st") == "'te''st'"
-    assert quote_string("'te''st'") == "'''te''''st'''"
+def test_quote_string(dialect):
+    if is_postgres(dialect):
+        # https://www.postgresql.org/docs/14/sql-syntax-lexical.html#SQL-SYNTAX-CONSTANTS
+        assert quote_string(dialect, "test") == "'test'"
+        assert quote_string(dialect, "te'st") == "'te''st'"
+        assert quote_string(dialect, "'te''st'") == "'''te''''st'''"
+
+    elif is_bigquery(dialect):
+        # https://cloud.google.com/bigquery/docs/reference/standard-sql/lexical#string_and_bytes_literals
+        assert quote_string(dialect, "test") == 'r"""test"""'
+        assert quote_string(dialect, "te'st") == 'r"""te\'st"""'
+        assert quote_string(dialect, "'te''st'") == 'r"""\'te\'\'st\'"""'
+    else:
+        # if we add more dialects, we should not forget to extend this test
+        raise Exception()


### PR DESCRIPTION
* Speeded up `test_string_slice`. Instead of executing a query per slice, we just execute one containing all slices we need to test.
* Changed the way we quote string constants for bigquery, uses raw strings to preserve escape characters.