### PR TITLE
Improve navigation after waiting for event to be tracked

### DIFF
--- a/tracker/trackers/react/src/common/factories/makeAnchorClickHandler.tsx
+++ b/tracker/trackers/react/src/common/factories/makeAnchorClickHandler.tsx
@@ -59,7 +59,24 @@ export const makeAnchorClickHandler =
       // Execute onClick prop, if any.
       props.onClick && props.onClick(event);
 
-      // Resume navigation.
-      window.location.href = props.anchorHref;
+      // Resume navigation by duplicating the anchor to preserve behavior tied to attributes like
+      // `target` and `rel`. During tests in a jsdom environment `currentTarget` doesn't get
+      // set so in that case we have to fall back on `target`.
+      const originalAnchor = event.currentTarget || event.target;
+      const newAnchor = document.createElement('a');
+      for (const attribute of originalAnchor.getAttributeNames()) {
+        // We know for sure the attribute exists at this point, so we have to convince TypeScript
+        newAnchor.setAttribute(attribute, originalAnchor.getAttribute(attribute) as string);
+      }
+
+      // Check if the ctrl or meta key was pressed. In this case the user probably wanted to open
+      // the link in a new tab, but we can't know for sure since it depends on platform and user
+      // preferences. We lost proper behavior when we `preventDefault()`ed so the best we can do is
+      // make a guess and hope this is right in most cases.
+      if (event.metaKey || event.ctrlKey) {
+        newAnchor.setAttribute('target', '_blank');
+      }
+
+      newAnchor.click();
     }
   };


### PR DESCRIPTION
When `waitUntilTracked=true` on an anchor the default browser behavior is cancelled to be able to wait for tracking. Unfortunately the default behavior cannot be resumed. This is an issue for two reasons as far as I've noticed:

1. User selected preferences regarding navigation like behavior on ctrl/cmd+click break.
2. Attributes like `target` and `rel` get ignored. Breaking `rel="noopener noreferrer"` probably [isn't a big deal anymore](https://mathiasbynens.github.io/rel-noopener/) for security, but it's not good either.

This PR proposes a hacky but slightly improved way of resuming navigation after it was cancelled. By creating a new anchor with the same attributes we keep the behavior related to those attributes. Regarding cmd+click, the goal here is to do something that will be right more often than it is wrong, since correct behavior is not possible.

Please let me know if you think this is an improvement. A better solution than this PR would probably be to remove the `waitUntilTracked` option entirely.