### PR TITLE
consider boolean indexing even if df has no index

### DIFF
--- a/bach/bach/indexing.py
+++ b/bach/bach/indexing.py
@@ -68,19 +68,18 @@ class BaseLocIndex(object):
         """
         returns a boolean series representing the subset to get
         """
-        if not self.obj:
+        from bach.series import SeriesBoolean
+        if not self.obj.index and not isinstance(labels, SeriesBoolean):
             raise ValueError('Cannot access rows by label if DataFrame/Series has no index.')
+
+        if isinstance(labels, SeriesBoolean):
+            return labels
 
         level_0_index = self.obj.index_columns[0]
 
-        if isinstance(labels, (str, int)):
-            return self.obj.index[level_0_index] == labels
-
-        if isinstance(labels, list):
-            loc_conditions = [self.obj.index[level_0_index] == label for label in labels]
-            return reduce(lambda cond1, cond2: cond1 | cond2, loc_conditions)
-
-        return labels
+        list_of_labels = [labels] if isinstance(labels, (str, int)) else labels
+        loc_conditions = [self.obj.index[level_0_index] == label for label in list_of_labels]
+        return reduce(lambda cond1, cond2: cond1 | cond2, loc_conditions)
 
     def _get_sliced_subset(
         self,

--- a/bach/tests/functional/bach/test_df_indexing.py
+++ b/bach/tests/functional/bach/test_df_indexing.py
@@ -4,7 +4,7 @@ import pandas as pd
 import pytest
 
 from bach import Series, DataFrame
-from tests.functional.bach.test_data_and_utils import get_from_df, assert_equals_data
+from tests.functional.bach.test_data_and_utils import get_from_df, assert_equals_data, get_df_with_test_data
 
 
 @pytest.fixture()
@@ -212,5 +212,25 @@ def test_set_item_by_slicing(indexing_dfs: Tuple[pd.DataFrame, DataFrame]) -> No
             ['c', None, 1, None],
             ['d', None, 1, None],
             ['e', 4, 9, 'j'],
+        ],
+    )
+
+
+def test_indexing_wo_index(engine) -> None:
+    bt = get_df_with_test_data(engine)[['city']]
+    bt['city_normal'] = 'placeholder'
+    bt = bt.reset_index()
+
+    with pytest.raises(ValueError, match=r'Cannot access rows by label'):
+        bt.loc[0, 'city_normal']
+
+    bt.loc[bt.city == 'Snits', 'city_normal'] = 'Snake'
+    assert_equals_data(
+        bt,
+        expected_columns=['_index_skating_order', 'city', 'city_normal'],
+        expected_data=[
+            [1, 'Ljouwert', 'placeholder'],
+            [2, 'Snits', 'Snake'],
+            [3, 'Drylts', 'placeholder'],
         ],
     )


### PR DESCRIPTION
Indexing using a boolean series shouldn't consider dataframe's indexes, since it already works as a mask. Now we validate only when trying to index by label or list of labels