### PR TITLE
support nulls in DataFrame.from_pandas

### DIFF
--- a/bach/bach/from_pandas.py
+++ b/bach/bach/from_pandas.py
@@ -221,14 +221,14 @@ def _from_pd_shared(
     supported_pandas_dtypes = ['int64', 'float64', 'string', 'datetime64[ns]', 'bool', 'int32']
     all_dtypes = {}
     for column in df_copy.columns:
-        if df_copy[column].dropna().empty:
-            raise ValueError(f'{column} column has no non-nullable values, cannot infer type.')
-
         dtype = df_copy[column].dtype.name
 
         if dtype in supported_pandas_dtypes:
             all_dtypes[str(column)] = dtype
             continue
+
+        if df_copy[column].dropna().empty:
+            raise ValueError(f'{column} column has no non-nullable values, cannot infer type.')
 
         if convert_objects:
             df_copy[column] = df_copy[column].convert_dtypes(

--- a/bach/bach/from_pandas.py
+++ b/bach/bach/from_pandas.py
@@ -3,6 +3,7 @@ Copyright 2021 Objectiv B.V.
 """
 from typing import Tuple, Dict
 
+import numpy
 import pandas
 from sqlalchemy.engine import Engine, Dialect
 
@@ -220,6 +221,9 @@ def _from_pd_shared(
     supported_pandas_dtypes = ['int64', 'float64', 'string', 'datetime64[ns]', 'bool', 'int32']
     all_dtypes = {}
     for column in df_copy.columns:
+        if df_copy[column].dropna().empty:
+            raise ValueError(f'{column} column has no non-nullable values, cannot infer type.')
+
         dtype = df_copy[column].dtype.name
 
         if dtype in supported_pandas_dtypes:
@@ -236,14 +240,17 @@ def _from_pd_shared(
             raise TypeError(f'unsupported dtype for {column}: {dtype}')
 
         if cte and convert_objects:
-            types = df_copy[column].apply(type).unique()
+            non_nullables = df_copy[column].dropna()
+            types = non_nullables.apply(type).unique()
             if len(types) != 1:
                 raise TypeError(f'multiple types found in column {column}: {types}')
-            dtype = value_to_dtype(df_copy[column][0])
+            dtype = value_to_dtype(non_nullables.iloc[0])
 
         all_dtypes[str(column)] = dtype
 
     _assert_column_names_valid(dialect=dialect, df=df_copy)
 
     index_dtypes = {index_name: all_dtypes[index_name] for index_name in index}
+
+    df_copy = df_copy.replace({numpy.nan: None})
     return df_copy, index_dtypes, all_dtypes

--- a/bach/tests/functional/bach/test_df_from_pandas.py
+++ b/bach/tests/functional/bach/test_df_from_pandas.py
@@ -334,3 +334,21 @@ def test_from_pandas_columns_w_nulls(engine) -> None:
             [2, 'c', 2, None],
         ],
     )
+
+    pdf['d'] = pdf['d'].astype(str)
+    result = DataFrame.from_pandas(
+        engine=engine,
+        df=pdf,
+        convert_objects=True,
+        materialization='cte'
+    )
+    assert_equals_data(
+        result,
+        expected_columns=['_index_0', 'a', 'b', 'c', 'd'],
+        expected_data=[
+            [0, 'a', None, None, 'None'],
+            [1, None, 1, pd.Timestamp("1940-04-25"), 'None'],
+            [2, 'c', 2, None, 'None'],
+        ],
+    )
+


### PR DESCRIPTION
Most of our tests for ``dropna`` and ``fillna`` contain columns with nulls, currently `DataFrame.from_pandas` raises errors when trying to convert such columns. 