### PR TITLE
Trackers: context names enums generation

### DIFF
--- a/tracker/CONTRIBUTING.md
+++ b/tracker/CONTRIBUTING.md
@@ -158,7 +158,7 @@ Install dependencies for all packages and links local packages to each other.
 Runs prettier for all packages in write mode.
 
 ### `yarn prettify:generated`
-Runs prettier for `core/schema/src/*`, `core/tracker/src/ContextFactories.ts` and `core/tracker/src/EventFactories.ts` in write mode.
+Runs prettier for `core/schema/src/*`, `core/tracker/src/ContextFactories.ts`, `core/tracker/src/ContextNames.ts` and `core/tracker/src/EventFactories.ts` in write mode.
 
 ### `yarn tsc`
 Runs the TypeScript compiler for all typed packages.

--- a/tracker/core/react/tests/ApplicationLoadedEvent.test.tsx
+++ b/tracker/core/react/tests/ApplicationLoadedEvent.test.tsx
@@ -2,7 +2,7 @@
  * Copyright 2021-2022 Objectiv B.V.
  */
 
-import { makeApplicationLoadedEvent, makeContentContext, Tracker } from '@objectiv/tracker-core';
+import { LocationContextName, makeApplicationLoadedEvent, makeContentContext, Tracker } from '@objectiv/tracker-core';
 import { render } from '@testing-library/react';
 import React from 'react';
 import {
@@ -107,7 +107,7 @@ describe('trackApplicationLoaded', () => {
       1,
       expect.objectContaining(
         makeApplicationLoadedEvent({
-          location_stack: [expect.objectContaining({ _type: 'ContentContext', id: 'override' })],
+          location_stack: [expect.objectContaining({ _type: LocationContextName.ContentContext, id: 'override' })],
         })
       ),
       undefined

--- a/tracker/core/react/tests/ExpandableContextWrapper.test.tsx
+++ b/tracker/core/react/tests/ExpandableContextWrapper.test.tsx
@@ -2,7 +2,7 @@
  * Copyright 2021-2022 Objectiv B.V.
  */
 
-import { Tracker } from '@objectiv/tracker-core';
+import { LocationContextName, Tracker } from '@objectiv/tracker-core';
 import { fireEvent, getByText, render } from '@testing-library/react';
 import React from 'react';
 import {
@@ -52,7 +52,7 @@ describe('ExpandableContextWrapper', () => {
         _type: 'PressEvent',
         location_stack: [
           expect.objectContaining({
-            _type: 'ExpandableContext',
+            _type: LocationContextName.ExpandableContext,
             ...expandableContentContextProps,
           }),
         ],
@@ -85,7 +85,7 @@ describe('ExpandableContextWrapper', () => {
         _type: 'PressEvent',
         location_stack: [
           expect.objectContaining({
-            _type: 'ExpandableContext',
+            _type: LocationContextName.ExpandableContext,
             ...expandableContentContextProps,
           }),
         ],

--- a/tracker/core/react/tests/FailureEvent.test.tsx
+++ b/tracker/core/react/tests/FailureEvent.test.tsx
@@ -2,7 +2,7 @@
  * Copyright 2021-2022 Objectiv B.V.
  */
 
-import { makeContentContext, makeFailureEvent, Tracker } from '@objectiv/tracker-core';
+import { LocationContextName, makeContentContext, makeFailureEvent, Tracker } from '@objectiv/tracker-core';
 import { render } from '@testing-library/react';
 import React from 'react';
 import { trackFailureEvent, TrackingContextProvider, useFailureEventTracker } from '../src';
@@ -85,7 +85,7 @@ describe('FailureEvent', () => {
       expect.objectContaining(
         makeFailureEvent({
           message: 'ko',
-          location_stack: [expect.objectContaining({ _type: 'ContentContext', id: 'override' })],
+          location_stack: [expect.objectContaining({ _type: LocationContextName.ContentContext, id: 'override' })],
         })
       ),
       undefined

--- a/tracker/core/react/tests/HiddenEvent.test.tsx
+++ b/tracker/core/react/tests/HiddenEvent.test.tsx
@@ -2,7 +2,7 @@
  * Copyright 2021-2022 Objectiv B.V.
  */
 
-import { makeContentContext, makeHiddenEvent, Tracker } from '@objectiv/tracker-core';
+import { LocationContextName, makeContentContext, makeHiddenEvent, Tracker } from '@objectiv/tracker-core';
 import { render } from '@testing-library/react';
 import React from 'react';
 import { TrackingContextProvider, trackHiddenEvent, useHiddenEventTracker } from '../src';
@@ -71,7 +71,7 @@ describe('HiddenEvent', () => {
       1,
       expect.objectContaining(
         makeHiddenEvent({
-          location_stack: [expect.objectContaining({ _type: 'ContentContext', id: 'override' })],
+          location_stack: [expect.objectContaining({ _type: LocationContextName.ContentContext, id: 'override' })],
         })
       ),
       undefined

--- a/tracker/core/react/tests/InputChangeEvent.test.tsx
+++ b/tracker/core/react/tests/InputChangeEvent.test.tsx
@@ -2,7 +2,7 @@
  * Copyright 2021-2022 Objectiv B.V.
  */
 
-import { makeContentContext, makeInputChangeEvent, Tracker } from '@objectiv/tracker-core';
+import { LocationContextName, makeContentContext, makeInputChangeEvent, Tracker } from '@objectiv/tracker-core';
 import { render } from '@testing-library/react';
 import React from 'react';
 import { TrackingContextProvider, trackInputChangeEvent, useInputChangeEventTracker } from '../src';
@@ -79,7 +79,7 @@ describe('InputChangeEvent', () => {
       1,
       expect.objectContaining(
         makeInputChangeEvent({
-          location_stack: [expect.objectContaining({ _type: 'ContentContext', id: 'override' })],
+          location_stack: [expect.objectContaining({ _type: LocationContextName.ContentContext, id: 'override' })],
         })
       ),
       undefined

--- a/tracker/core/react/tests/InputContextWrapper.test.tsx
+++ b/tracker/core/react/tests/InputContextWrapper.test.tsx
@@ -2,7 +2,7 @@
  * Copyright 2021-2022 Objectiv B.V.
  */
 
-import { Tracker } from '@objectiv/tracker-core';
+import { LocationContextName, Tracker } from '@objectiv/tracker-core';
 import { fireEvent, getByTestId, render } from '@testing-library/react';
 import React from 'react';
 import {
@@ -52,7 +52,7 @@ describe('InputContextWrapper', () => {
         _type: 'InputChangeEvent',
         location_stack: [
           expect.objectContaining({
-            _type: 'InputContext',
+            _type: LocationContextName.InputContext,
             ...inputContextProps,
           }),
         ],
@@ -85,7 +85,7 @@ describe('InputContextWrapper', () => {
         _type: 'InputChangeEvent',
         location_stack: [
           expect.objectContaining({
-            _type: 'InputContext',
+            _type: LocationContextName.InputContext,
             ...inputContextProps,
           }),
         ],

--- a/tracker/core/react/tests/InteractiveEvent.test.tsx
+++ b/tracker/core/react/tests/InteractiveEvent.test.tsx
@@ -2,7 +2,7 @@
  * Copyright 2021-2022 Objectiv B.V.
  */
 
-import { makeContentContext, makeInteractiveEvent, Tracker } from '@objectiv/tracker-core';
+import { LocationContextName, makeContentContext, makeInteractiveEvent, Tracker } from '@objectiv/tracker-core';
 import { render } from '@testing-library/react';
 import React from 'react';
 import { TrackingContextProvider, trackInteractiveEvent, useInteractiveEventTracker } from '../src';
@@ -79,7 +79,7 @@ describe('InteractiveEvent', () => {
       1,
       expect.objectContaining(
         makeInteractiveEvent({
-          location_stack: [expect.objectContaining({ _type: 'ContentContext', id: 'override' })],
+          location_stack: [expect.objectContaining({ _type: LocationContextName.ContentContext, id: 'override' })],
         })
       ),
       undefined

--- a/tracker/core/react/tests/LinkContextWrapper.test.tsx
+++ b/tracker/core/react/tests/LinkContextWrapper.test.tsx
@@ -2,7 +2,7 @@
  * Copyright 2021-2022 Objectiv B.V.
  */
 
-import { Tracker } from '@objectiv/tracker-core';
+import { LocationContextName, Tracker } from '@objectiv/tracker-core';
 import { fireEvent, getByText, render } from '@testing-library/react';
 import React from 'react';
 import { LinkContextWrapper, LocationTree, ObjectivProvider, trackPressEvent, usePressEventTracker } from '../src';
@@ -46,7 +46,7 @@ describe('LinkContextWrapper', () => {
         _type: 'PressEvent',
         location_stack: [
           expect.objectContaining({
-            _type: 'LinkContext',
+            _type: LocationContextName.LinkContext,
             ...linkContextProps,
           }),
         ],
@@ -79,7 +79,7 @@ describe('LinkContextWrapper', () => {
         _type: 'PressEvent',
         location_stack: [
           expect.objectContaining({
-            _type: 'LinkContext',
+            _type: LocationContextName.LinkContext,
             ...linkContextProps,
           }),
         ],

--- a/tracker/core/react/tests/LocationContextWrapper.test.tsx
+++ b/tracker/core/react/tests/LocationContextWrapper.test.tsx
@@ -2,7 +2,7 @@
  * Copyright 2021-2022 Objectiv B.V.
  */
 
-import { makeContentContext, Tracker } from '@objectiv/tracker-core';
+import { LocationContextName, makeContentContext, Tracker } from '@objectiv/tracker-core';
 import { fireEvent, getByText, render } from '@testing-library/react';
 import React from 'react';
 import { LocationContextWrapper, LocationTree, ObjectivProvider, trackPressEvent, usePressEventTracker } from '../src';
@@ -46,7 +46,7 @@ describe('LocationContextWrapper', () => {
         _type: 'PressEvent',
         location_stack: [
           expect.objectContaining({
-            _type: 'ContentContext',
+            _type: LocationContextName.ContentContext,
             id: 'test-section',
           }),
         ],
@@ -79,7 +79,7 @@ describe('LocationContextWrapper', () => {
         _type: 'PressEvent',
         location_stack: [
           expect.objectContaining({
-            _type: 'ContentContext',
+            _type: LocationContextName.ContentContext,
             id: 'test-section',
           }),
         ],

--- a/tracker/core/react/tests/LocationTree.test.ts
+++ b/tracker/core/react/tests/LocationTree.test.ts
@@ -3,6 +3,7 @@
  */
 
 import {
+  LocationContextName,
   makeContentContext,
   makeLinkContext,
   makeNavigationContext,
@@ -51,22 +52,22 @@ describe('LocationTree', () => {
       }),
       expect.objectContaining({
         __instance_id: root.__instance_id,
-        _type: 'RootLocationContext',
+        _type: LocationContextName.RootLocationContext,
         id: 'root',
         parentLocationId: rootNode.__instance_id,
       }),
       expect.objectContaining({
-        _type: 'NavigationContext',
+        _type: LocationContextName.NavigationContext,
         id: 'nav',
         parentLocationId: root.__instance_id,
       }),
       expect.objectContaining({
-        _type: 'PressableContext',
+        _type: LocationContextName.PressableContext,
         id: 'button',
         parentLocationId: nav.__instance_id,
       }),
       expect.objectContaining({
-        _type: 'NavigationContext',
+        _type: LocationContextName.NavigationContext,
         id: 'footer',
         parentLocationId: root.__instance_id,
       }),
@@ -98,17 +99,17 @@ describe('LocationTree', () => {
       }),
       expect.objectContaining({
         __instance_id: root.__instance_id,
-        _type: 'RootLocationContext',
+        _type: LocationContextName.RootLocationContext,
         id: 'root',
         parentLocationId: rootNode.__instance_id,
       }),
       expect.objectContaining({
-        _type: 'NavigationContext',
+        _type: LocationContextName.NavigationContext,
         id: 'nav',
         parentLocationId: root.__instance_id,
       }),
       expect.objectContaining({
-        _type: 'NavigationContext',
+        _type: LocationContextName.NavigationContext,
         id: 'footer',
         parentLocationId: root.__instance_id,
       }),
@@ -140,12 +141,12 @@ describe('LocationTree', () => {
       }),
       expect.objectContaining({
         __instance_id: root.__instance_id,
-        _type: 'RootLocationContext',
+        _type: LocationContextName.RootLocationContext,
         id: 'root',
         parentLocationId: rootNode.__instance_id,
       }),
       expect.objectContaining({
-        _type: 'NavigationContext',
+        _type: LocationContextName.NavigationContext,
         id: 'footer',
         parentLocationId: root.__instance_id,
       }),
@@ -186,17 +187,17 @@ describe('LocationTree', () => {
       }),
       expect.objectContaining({
         __instance_id: root.__instance_id,
-        _type: 'RootLocationContext',
+        _type: LocationContextName.RootLocationContext,
         id: 'root',
         parentLocationId: rootNode.__instance_id,
       }),
       expect.objectContaining({
-        _type: 'NavigationContext',
+        _type: LocationContextName.NavigationContext,
         id: 'nav',
         parentLocationId: root.__instance_id,
       }),
       expect.objectContaining({
-        _type: 'PressableContext',
+        _type: LocationContextName.PressableContext,
         id: 'button',
         parentLocationId: nav.__instance_id,
       }),
@@ -281,14 +282,14 @@ describe('LocationTree', () => {
     LocationTree.log();
 
     expect(console.log).toHaveBeenCalledTimes(9);
-    expect(console.log).toHaveBeenNthCalledWith(1, 'ContentContext:root');
-    expect(console.log).toHaveBeenNthCalledWith(2, '  ContentContext:1');
-    expect(console.log).toHaveBeenNthCalledWith(3, '  ContentContext:2');
-    expect(console.log).toHaveBeenNthCalledWith(4, '    ContentContext:2a');
-    expect(console.log).toHaveBeenNthCalledWith(5, '    ContentContext:2b');
-    expect(console.log).toHaveBeenNthCalledWith(6, '  ContentContext:3');
-    expect(console.log).toHaveBeenNthCalledWith(7, '    ContentContext:3a');
-    expect(console.log).toHaveBeenNthCalledWith(8, '  ContentContext:footer');
-    expect(console.log).toHaveBeenNthCalledWith(9, '    ContentContext:4');
+    expect(console.log).toHaveBeenNthCalledWith(1, `${LocationContextName.ContentContext}:root`);
+    expect(console.log).toHaveBeenNthCalledWith(2, `  ${LocationContextName.ContentContext}:1`);
+    expect(console.log).toHaveBeenNthCalledWith(3, `  ${LocationContextName.ContentContext}:2`);
+    expect(console.log).toHaveBeenNthCalledWith(4, `    ${LocationContextName.ContentContext}:2a`);
+    expect(console.log).toHaveBeenNthCalledWith(5, `    ${LocationContextName.ContentContext}:2b`);
+    expect(console.log).toHaveBeenNthCalledWith(6, `  ${LocationContextName.ContentContext}:3`);
+    expect(console.log).toHaveBeenNthCalledWith(7, `    ${LocationContextName.ContentContext}:3a`);
+    expect(console.log).toHaveBeenNthCalledWith(8, `  ${LocationContextName.ContentContext}:footer`);
+    expect(console.log).toHaveBeenNthCalledWith(9, `    ${LocationContextName.ContentContext}:4`);
   });
 });

--- a/tracker/core/react/tests/MediaEvent.test.tsx
+++ b/tracker/core/react/tests/MediaEvent.test.tsx
@@ -2,7 +2,7 @@
  * Copyright 2021-2022 Objectiv B.V.
  */
 
-import { makeContentContext, makeMediaEvent, Tracker } from '@objectiv/tracker-core';
+import { LocationContextName, makeContentContext, makeMediaEvent, Tracker } from '@objectiv/tracker-core';
 import { render } from '@testing-library/react';
 import React from 'react';
 import { TrackingContextProvider, trackMediaEvent, useMediaEventTracker } from '../src';
@@ -79,7 +79,7 @@ describe('trackMedia', () => {
       1,
       expect.objectContaining(
         makeMediaEvent({
-          location_stack: [expect.objectContaining({ _type: 'ContentContext', id: 'override' })],
+          location_stack: [expect.objectContaining({ _type: LocationContextName.ContentContext, id: 'override' })],
         })
       ),
       undefined

--- a/tracker/core/react/tests/MediaLoadEvent.test.tsx
+++ b/tracker/core/react/tests/MediaLoadEvent.test.tsx
@@ -2,7 +2,7 @@
  * Copyright 2021-2022 Objectiv B.V.
  */
 
-import { makeContentContext, makeMediaLoadEvent, Tracker } from '@objectiv/tracker-core';
+import { LocationContextName, makeContentContext, makeMediaLoadEvent, Tracker } from '@objectiv/tracker-core';
 import { render } from '@testing-library/react';
 import React from 'react';
 import { TrackingContextProvider, trackMediaLoadEvent, useMediaLoadEventTracker } from '../src';
@@ -79,7 +79,7 @@ describe('trackMediaLoad', () => {
       1,
       expect.objectContaining(
         makeMediaLoadEvent({
-          location_stack: [expect.objectContaining({ _type: 'ContentContext', id: 'override' })],
+          location_stack: [expect.objectContaining({ _type: LocationContextName.ContentContext, id: 'override' })],
         })
       ),
       undefined

--- a/tracker/core/react/tests/MediaPauseEvent.test.tsx
+++ b/tracker/core/react/tests/MediaPauseEvent.test.tsx
@@ -2,7 +2,7 @@
  * Copyright 2021-2022 Objectiv B.V.
  */
 
-import { makeContentContext, makeMediaPauseEvent, Tracker } from '@objectiv/tracker-core';
+import { LocationContextName, makeContentContext, makeMediaPauseEvent, Tracker } from '@objectiv/tracker-core';
 import { render } from '@testing-library/react';
 import React from 'react';
 import { TrackingContextProvider, trackMediaPauseEvent, useMediaPauseEventTracker } from '../src';
@@ -79,7 +79,7 @@ describe('trackMediaPause', () => {
       1,
       expect.objectContaining(
         makeMediaPauseEvent({
-          location_stack: [expect.objectContaining({ _type: 'ContentContext', id: 'override' })],
+          location_stack: [expect.objectContaining({ _type: LocationContextName.ContentContext, id: 'override' })],
         })
       ),
       undefined

--- a/tracker/core/react/tests/MediaPlayerContextWrapper.test.tsx
+++ b/tracker/core/react/tests/MediaPlayerContextWrapper.test.tsx
@@ -2,7 +2,7 @@
  * Copyright 2021-2022 Objectiv B.V.
  */
 
-import { Tracker } from '@objectiv/tracker-core';
+import { LocationContextName, Tracker } from '@objectiv/tracker-core';
 import { fireEvent, getByText, render } from '@testing-library/react';
 import React from 'react';
 import {
@@ -52,7 +52,7 @@ describe('MediaPlayerContextWrapper', () => {
         _type: 'PressEvent',
         location_stack: [
           expect.objectContaining({
-            _type: 'MediaPlayerContext',
+            _type: LocationContextName.MediaPlayerContext,
             ...mediaPlayerContextProps,
           }),
         ],
@@ -85,7 +85,7 @@ describe('MediaPlayerContextWrapper', () => {
         _type: 'PressEvent',
         location_stack: [
           expect.objectContaining({
-            _type: 'MediaPlayerContext',
+            _type: LocationContextName.MediaPlayerContext,
             ...mediaPlayerContextProps,
           }),
         ],

--- a/tracker/core/react/tests/MediaStartEvent.test.tsx
+++ b/tracker/core/react/tests/MediaStartEvent.test.tsx
@@ -2,7 +2,7 @@
  * Copyright 2021-2022 Objectiv B.V.
  */
 
-import { makeContentContext, makeMediaStartEvent, Tracker } from '@objectiv/tracker-core';
+import { LocationContextName, makeContentContext, makeMediaStartEvent, Tracker } from '@objectiv/tracker-core';
 import { render } from '@testing-library/react';
 import React from 'react';
 import { TrackingContextProvider, trackMediaStartEvent, useMediaStartEventTracker } from '../src';
@@ -79,7 +79,7 @@ describe('trackMediaStart', () => {
       1,
       expect.objectContaining(
         makeMediaStartEvent({
-          location_stack: [expect.objectContaining({ _type: 'ContentContext', id: 'override' })],
+          location_stack: [expect.objectContaining({ _type: LocationContextName.ContentContext, id: 'override' })],
         })
       ),
       undefined

--- a/tracker/core/react/tests/MediaStopEvent.test.tsx
+++ b/tracker/core/react/tests/MediaStopEvent.test.tsx
@@ -2,7 +2,7 @@
  * Copyright 2021-2022 Objectiv B.V.
  */
 
-import { makeContentContext, makeMediaStopEvent, Tracker } from '@objectiv/tracker-core';
+import { LocationContextName, makeContentContext, makeMediaStopEvent, Tracker } from '@objectiv/tracker-core';
 import { render } from '@testing-library/react';
 import React from 'react';
 import { TrackingContextProvider, trackMediaStopEvent, useMediaStopEventTracker } from '../src';
@@ -79,7 +79,7 @@ describe('trackMediaStop', () => {
       1,
       expect.objectContaining(
         makeMediaStopEvent({
-          location_stack: [expect.objectContaining({ _type: 'ContentContext', id: 'override' })],
+          location_stack: [expect.objectContaining({ _type: LocationContextName.ContentContext, id: 'override' })],
         })
       ),
       undefined

--- a/tracker/core/react/tests/NavigationContextWrapper.test.tsx
+++ b/tracker/core/react/tests/NavigationContextWrapper.test.tsx
@@ -2,7 +2,7 @@
  * Copyright 2021-2022 Objectiv B.V.
  */
 
-import { Tracker } from '@objectiv/tracker-core';
+import { LocationContextName, Tracker } from '@objectiv/tracker-core';
 import { fireEvent, getByText, render } from '@testing-library/react';
 import React from 'react';
 import {
@@ -52,7 +52,7 @@ describe('NavigationContextWrapper', () => {
         _type: 'PressEvent',
         location_stack: [
           expect.objectContaining({
-            _type: 'NavigationContext',
+            _type: LocationContextName.NavigationContext,
             ...navigationContextProps,
           }),
         ],
@@ -85,7 +85,7 @@ describe('NavigationContextWrapper', () => {
         _type: 'PressEvent',
         location_stack: [
           expect.objectContaining({
-            _type: 'NavigationContext',
+            _type: LocationContextName.NavigationContext,
             ...navigationContextProps,
           }),
         ],

--- a/tracker/core/react/tests/NonInteractiveEvent.test.tsx
+++ b/tracker/core/react/tests/NonInteractiveEvent.test.tsx
@@ -2,7 +2,7 @@
  * Copyright 2021-2022 Objectiv B.V.
  */
 
-import { makeContentContext, makeNonInteractiveEvent, Tracker } from '@objectiv/tracker-core';
+import { LocationContextName, makeContentContext, makeNonInteractiveEvent, Tracker } from '@objectiv/tracker-core';
 import { render } from '@testing-library/react';
 import React from 'react';
 import { TrackingContextProvider, trackNonInteractiveEvent, useNonInteractiveEventTracker } from '../src';
@@ -83,7 +83,7 @@ describe('NonInteractiveEvent', () => {
       1,
       expect.objectContaining(
         makeNonInteractiveEvent({
-          location_stack: [expect.objectContaining({ _type: 'ContentContext', id: 'override' })],
+          location_stack: [expect.objectContaining({ _type: LocationContextName.ContentContext, id: 'override' })],
         })
       ),
       undefined

--- a/tracker/core/react/tests/ObjectivProvider.test.tsx
+++ b/tracker/core/react/tests/ObjectivProvider.test.tsx
@@ -4,7 +4,9 @@
 
 import { matchUUID, MockConsoleImplementation } from '@objectiv/testing-tools';
 import {
+  GlobalContextName,
   GlobalContextValidationRule,
+  LocationContextName,
   LocationContextValidationRule,
   makeApplicationLoadedEvent,
   Tracker,
@@ -45,12 +47,12 @@ describe('ObjectivProvider', () => {
             validationRules: [
               new GlobalContextValidationRule({
                 logPrefix: 'OpenTaxonomyValidationPlugin',
-                contextName: 'ApplicationContext',
+                contextName: GlobalContextName.ApplicationContext,
                 once: true,
               }),
               new LocationContextValidationRule({
                 logPrefix: 'OpenTaxonomyValidationPlugin',
-                contextName: 'RootLocationContext',
+                contextName: LocationContextName.RootLocationContext,
                 once: true,
                 position: 0,
               }),
@@ -60,7 +62,7 @@ describe('ObjectivProvider', () => {
             applicationContext: {
               __instance_id: matchUUID,
               __global_context: true,
-              _type: 'ApplicationContext',
+              _type: GlobalContextName.ApplicationContext,
               id: 'app-id',
             },
             pluginName: 'ApplicationContextPlugin',

--- a/tracker/core/react/tests/OverlayContextWrapper.test.tsx
+++ b/tracker/core/react/tests/OverlayContextWrapper.test.tsx
@@ -2,7 +2,7 @@
  * Copyright 2021-2022 Objectiv B.V.
  */
 
-import { Tracker } from '@objectiv/tracker-core';
+import { LocationContextName, Tracker } from '@objectiv/tracker-core';
 import { fireEvent, getByText, render } from '@testing-library/react';
 import React from 'react';
 import { OverlayContextWrapper, ObjectivProvider, trackPressEvent, usePressEventTracker, LocationTree } from '../src';
@@ -46,7 +46,7 @@ describe('OverlayContextWrapper', () => {
         _type: 'PressEvent',
         location_stack: [
           expect.objectContaining({
-            _type: 'OverlayContext',
+            _type: LocationContextName.OverlayContext,
             ...overlayContextProps,
           }),
         ],
@@ -79,7 +79,7 @@ describe('OverlayContextWrapper', () => {
         _type: 'PressEvent',
         location_stack: [
           expect.objectContaining({
-            _type: 'OverlayContext',
+            _type: LocationContextName.OverlayContext,
             ...overlayContextProps,
           }),
         ],

--- a/tracker/core/react/tests/PressEvent.test.tsx
+++ b/tracker/core/react/tests/PressEvent.test.tsx
@@ -2,7 +2,7 @@
  * Copyright 2021-2022 Objectiv B.V.
  */
 
-import { makeContentContext, makePressEvent, Tracker } from '@objectiv/tracker-core';
+import { LocationContextName, makeContentContext, makePressEvent, Tracker } from '@objectiv/tracker-core';
 import { render } from '@testing-library/react';
 import React from 'react';
 import { trackPressEvent, TrackingContextProvider, usePressEventTracker } from '../src';
@@ -79,7 +79,7 @@ describe('PressEvent', () => {
       1,
       expect.objectContaining(
         makePressEvent({
-          location_stack: [expect.objectContaining({ _type: 'ContentContext', id: 'override' })],
+          location_stack: [expect.objectContaining({ _type: LocationContextName.ContentContext, id: 'override' })],
         })
       ),
       undefined

--- a/tracker/core/react/tests/PressableContextWrapper.test.tsx
+++ b/tracker/core/react/tests/PressableContextWrapper.test.tsx
@@ -2,7 +2,7 @@
  * Copyright 2021-2022 Objectiv B.V.
  */
 
-import { Tracker } from '@objectiv/tracker-core';
+import { LocationContextName, Tracker } from '@objectiv/tracker-core';
 import { fireEvent, getByText, render } from '@testing-library/react';
 import React from 'react';
 import { PressableContextWrapper, LocationTree, ObjectivProvider, trackPressEvent, usePressEventTracker } from '../src';
@@ -46,7 +46,7 @@ describe('PressableContextWrapper', () => {
         _type: 'PressEvent',
         location_stack: [
           expect.objectContaining({
-            _type: 'PressableContext',
+            _type: LocationContextName.PressableContext,
             ...buttonContextProps,
           }),
         ],
@@ -79,7 +79,7 @@ describe('PressableContextWrapper', () => {
         _type: 'PressEvent',
         location_stack: [
           expect.objectContaining({
-            _type: 'PressableContext',
+            _type: LocationContextName.PressableContext,
             ...buttonContextProps,
           }),
         ],

--- a/tracker/core/react/tests/RootLocationContextWrapper.test.tsx
+++ b/tracker/core/react/tests/RootLocationContextWrapper.test.tsx
@@ -2,7 +2,7 @@
  * Copyright 2021-2022 Objectiv B.V.
  */
 
-import { Tracker } from '@objectiv/tracker-core';
+import { LocationContextName, Tracker } from '@objectiv/tracker-core';
 import { fireEvent, getByText, render } from '@testing-library/react';
 import React from 'react';
 import {
@@ -52,7 +52,7 @@ describe('RootLocationContextWrapper', () => {
         _type: 'PressEvent',
         location_stack: [
           expect.objectContaining({
-            _type: 'RootLocationContext',
+            _type: LocationContextName.RootLocationContext,
             ...rootLocationContextProps,
           }),
         ],
@@ -85,7 +85,7 @@ describe('RootLocationContextWrapper', () => {
         _type: 'PressEvent',
         location_stack: [
           expect.objectContaining({
-            _type: 'RootLocationContext',
+            _type: LocationContextName.RootLocationContext,
             ...rootLocationContextProps,
           }),
         ],

--- a/tracker/core/react/tests/SectionContextWrapper.test.tsx
+++ b/tracker/core/react/tests/SectionContextWrapper.test.tsx
@@ -2,7 +2,7 @@
  * Copyright 2021-2022 Objectiv B.V.
  */
 
-import { Tracker } from '@objectiv/tracker-core';
+import { LocationContextName, Tracker } from '@objectiv/tracker-core';
 import { fireEvent, getByText, render } from '@testing-library/react';
 import React from 'react';
 import { ContentContextWrapper, ObjectivProvider, trackPressEvent, usePressEventTracker, LocationTree } from '../src';
@@ -46,7 +46,7 @@ describe('ContentContextWrapper', () => {
         _type: 'PressEvent',
         location_stack: [
           expect.objectContaining({
-            _type: 'ContentContext',
+            _type: LocationContextName.ContentContext,
             ...sectionContextProps,
           }),
         ],
@@ -79,7 +79,7 @@ describe('ContentContextWrapper', () => {
         _type: 'PressEvent',
         location_stack: [
           expect.objectContaining({
-            _type: 'ContentContext',
+            _type: LocationContextName.ContentContext,
             ...sectionContextProps,
           }),
         ],

--- a/tracker/core/react/tests/SuccessEvent.test.tsx
+++ b/tracker/core/react/tests/SuccessEvent.test.tsx
@@ -2,7 +2,7 @@
  * Copyright 2021-2022 Objectiv B.V.
  */
 
-import { makeContentContext, makeSuccessEvent, Tracker } from '@objectiv/tracker-core';
+import { LocationContextName, makeContentContext, makeSuccessEvent, Tracker } from '@objectiv/tracker-core';
 import { render } from '@testing-library/react';
 import React from 'react';
 import { trackSuccessEvent, TrackingContextProvider, useSuccessEventTracker } from '../src';
@@ -85,7 +85,7 @@ describe('SuccessEvent', () => {
       expect.objectContaining(
         makeSuccessEvent({
           message: 'ok',
-          location_stack: [expect.objectContaining({ _type: 'ContentContext', id: 'override' })],
+          location_stack: [expect.objectContaining({ _type: LocationContextName.ContentContext, id: 'override' })],
         })
       ),
       undefined

--- a/tracker/core/react/tests/TrackerProvider.test.tsx
+++ b/tracker/core/react/tests/TrackerProvider.test.tsx
@@ -4,7 +4,9 @@
 
 import { matchUUID, MockConsoleImplementation } from '@objectiv/testing-tools';
 import {
+  GlobalContextName,
   GlobalContextValidationRule,
+  LocationContextName,
   LocationContextValidationRule,
   Tracker,
   TrackerConsole,
@@ -42,12 +44,12 @@ describe('TrackerProvider', () => {
             validationRules: [
               new GlobalContextValidationRule({
                 logPrefix: 'OpenTaxonomyValidationPlugin',
-                contextName: 'ApplicationContext',
+                contextName: GlobalContextName.ApplicationContext,
                 once: true,
               }),
               new LocationContextValidationRule({
                 logPrefix: 'OpenTaxonomyValidationPlugin',
-                contextName: 'RootLocationContext',
+                contextName: LocationContextName.RootLocationContext,
                 once: true,
                 position: 0,
               }),
@@ -57,7 +59,7 @@ describe('TrackerProvider', () => {
             applicationContext: {
               __instance_id: matchUUID,
               __global_context: true,
-              _type: 'ApplicationContext',
+              _type: GlobalContextName.ApplicationContext,
               id: 'app-id',
             },
             pluginName: 'ApplicationContextPlugin',

--- a/tracker/core/react/tests/TrackingContextProvider.test.tsx
+++ b/tracker/core/react/tests/TrackingContextProvider.test.tsx
@@ -4,7 +4,9 @@
 
 import { expectToThrow, matchUUID, MockConsoleImplementation } from '@objectiv/testing-tools';
 import {
+  GlobalContextName,
   GlobalContextValidationRule,
+  LocationContextName,
   LocationContextValidationRule,
   makeContentContext,
   Tracker,
@@ -45,12 +47,12 @@ describe('TrackingContextProvider', () => {
             validationRules: [
               new GlobalContextValidationRule({
                 logPrefix: 'OpenTaxonomyValidationPlugin',
-                contextName: 'ApplicationContext',
+                contextName: GlobalContextName.ApplicationContext,
                 once: true,
               }),
               new LocationContextValidationRule({
                 logPrefix: 'OpenTaxonomyValidationPlugin',
-                contextName: 'RootLocationContext',
+                contextName: LocationContextName.RootLocationContext,
                 once: true,
                 position: 0,
               }),
@@ -60,7 +62,7 @@ describe('TrackingContextProvider', () => {
             applicationContext: {
               __instance_id: matchUUID,
               __global_context: true,
-              _type: 'ApplicationContext',
+              _type: GlobalContextName.ApplicationContext,
               id: 'app-id',
             },
             pluginName: 'ApplicationContextPlugin',

--- a/tracker/core/react/tests/Visibility.test.tsx
+++ b/tracker/core/react/tests/Visibility.test.tsx
@@ -2,7 +2,13 @@
  * Copyright 2021-2022 Objectiv B.V.
  */
 
-import { makeContentContext, makeHiddenEvent, makeVisibleEvent, Tracker } from '@objectiv/tracker-core';
+import {
+  LocationContextName,
+  makeContentContext,
+  makeHiddenEvent,
+  makeVisibleEvent,
+  Tracker,
+} from '@objectiv/tracker-core';
 import { render } from '@testing-library/react';
 import React from 'react';
 import { TrackingContextProvider, trackVisibility, useVisibilityTracker } from '../src';
@@ -80,7 +86,7 @@ describe('Visibility', () => {
       1,
       expect.objectContaining(
         makeHiddenEvent({
-          location_stack: [expect.objectContaining({ _type: 'ContentContext', id: 'override' })],
+          location_stack: [expect.objectContaining({ _type: LocationContextName.ContentContext, id: 'override' })],
         })
       ),
       undefined
@@ -151,7 +157,7 @@ describe('Visibility', () => {
       1,
       expect.objectContaining(
         makeVisibleEvent({
-          location_stack: [expect.objectContaining({ _type: 'ContentContext', id: 'override' })],
+          location_stack: [expect.objectContaining({ _type: LocationContextName.ContentContext, id: 'override' })],
         })
       ),
       undefined

--- a/tracker/core/react/tests/VisibleEvent.test.tsx
+++ b/tracker/core/react/tests/VisibleEvent.test.tsx
@@ -2,7 +2,7 @@
  * Copyright 2021-2022 Objectiv B.V.
  */
 
-import { makeContentContext, makeVisibleEvent, Tracker } from '@objectiv/tracker-core';
+import { LocationContextName, makeContentContext, makeVisibleEvent, Tracker } from '@objectiv/tracker-core';
 import { render } from '@testing-library/react';
 import React from 'react';
 import { TrackingContextProvider, trackVisibleEvent, useVisibleEventTracker } from '../src';
@@ -71,7 +71,7 @@ describe('VisibleEvent', () => {
       1,
       expect.objectContaining(
         makeVisibleEvent({
-          location_stack: [expect.objectContaining({ _type: 'ContentContext', id: 'override' })],
+          location_stack: [expect.objectContaining({ _type: LocationContextName.ContentContext, id: 'override' })],
         })
       ),
       undefined

--- a/tracker/core/schema/src/abstracts.d.ts
+++ b/tracker/core/schema/src/abstracts.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2022 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 /**

--- a/tracker/core/schema/src/events.d.ts
+++ b/tracker/core/schema/src/events.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2022 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { AbstractInteractiveEvent, AbstractNonInteractiveEvent, AbstractMediaEvent } from './abstracts';

--- a/tracker/core/schema/src/global_contexts.d.ts
+++ b/tracker/core/schema/src/global_contexts.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2022 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { AbstractGlobalContext } from './abstracts';

--- a/tracker/core/schema/src/index.d.ts
+++ b/tracker/core/schema/src/index.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2022 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 export * from './abstracts';

--- a/tracker/core/schema/src/location_contexts.d.ts
+++ b/tracker/core/schema/src/location_contexts.d.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2022 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import { AbstractLocationContext, AbstractPressableContext } from './abstracts';

--- a/tracker/core/tracker/package.json
+++ b/tracker/core/tracker/package.json
@@ -40,7 +40,7 @@
   "scripts": {
     "build": "tsup src/index.ts --format cjs,esm --legacy-output --minify --dts --sourcemap --clean",
     "prettify": "prettier --write .",
-    "prettify:generated": "yarn prettier --write ./src/ContextFactories.ts ./src/EventFactories.ts",
+    "prettify:generated": "yarn prettier --write ./src/ContextFactories.ts ./src/ContextNames.ts ./src/EventFactories.ts",
     "tsc": "tsc --noEmit",
     "test": "jest --silent --runInBand",
     "test:ci": "jest --silent --ci --runInBand",

--- a/tracker/core/tracker/src/ContextFactories.ts
+++ b/tracker/core/tracker/src/ContextFactories.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2022 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import {

--- a/tracker/core/tracker/src/ContextFactories.ts
+++ b/tracker/core/tracker/src/ContextFactories.ts
@@ -19,6 +19,7 @@ import {
   RootLocationContext,
   SessionContext,
 } from '@objectiv/schema';
+import { GlobalContextName, LocationContextName } from './ContextNames';
 import { generateUUID } from './helpers';
 
 /** Creates instance of ApplicationContext
@@ -30,7 +31,7 @@ import { generateUUID } from './helpers';
 export const makeApplicationContext = (props: { id: string }): ApplicationContext => ({
   __instance_id: generateUUID(),
   __global_context: true,
-  _type: 'ApplicationContext',
+  _type: GlobalContextName.ApplicationContext,
   id: props.id,
 });
 
@@ -43,7 +44,7 @@ export const makeApplicationContext = (props: { id: string }): ApplicationContex
 export const makeContentContext = (props: { id: string }): ContentContext => ({
   __instance_id: generateUUID(),
   __location_context: true,
-  _type: 'ContentContext',
+  _type: LocationContextName.ContentContext,
   id: props.id,
 });
 
@@ -57,7 +58,7 @@ export const makeContentContext = (props: { id: string }): ContentContext => ({
 export const makeCookieIdContext = (props: { id: string; cookie_id: string }): CookieIdContext => ({
   __instance_id: generateUUID(),
   __global_context: true,
-  _type: 'CookieIdContext',
+  _type: GlobalContextName.CookieIdContext,
   id: props.id,
   cookie_id: props.cookie_id,
 });
@@ -71,7 +72,7 @@ export const makeCookieIdContext = (props: { id: string; cookie_id: string }): C
 export const makeExpandableContext = (props: { id: string }): ExpandableContext => ({
   __instance_id: generateUUID(),
   __location_context: true,
-  _type: 'ExpandableContext',
+  _type: LocationContextName.ExpandableContext,
   id: props.id,
 });
 
@@ -92,7 +93,7 @@ export const makeHttpContext = (props: {
 }): HttpContext => ({
   __instance_id: generateUUID(),
   __global_context: true,
-  _type: 'HttpContext',
+  _type: GlobalContextName.HttpContext,
   id: props.id,
   referrer: props.referrer,
   user_agent: props.user_agent,
@@ -108,7 +109,7 @@ export const makeHttpContext = (props: {
 export const makeInputContext = (props: { id: string }): InputContext => ({
   __instance_id: generateUUID(),
   __location_context: true,
-  _type: 'InputContext',
+  _type: LocationContextName.InputContext,
   id: props.id,
 });
 
@@ -123,7 +124,7 @@ export const makeLinkContext = (props: { id: string; href: string }): LinkContex
   __instance_id: generateUUID(),
   __location_context: true,
   __pressable_context: true,
-  _type: 'LinkContext',
+  _type: LocationContextName.LinkContext,
   id: props.id,
   href: props.href,
 });
@@ -150,7 +151,7 @@ export const makeMarketingContext = (props: {
 }): MarketingContext => ({
   __instance_id: generateUUID(),
   __global_context: true,
-  _type: 'MarketingContext',
+  _type: GlobalContextName.MarketingContext,
   id: props.id,
   source: props.source,
   medium: props.medium,
@@ -168,7 +169,7 @@ export const makeMarketingContext = (props: {
 export const makeMediaPlayerContext = (props: { id: string }): MediaPlayerContext => ({
   __instance_id: generateUUID(),
   __location_context: true,
-  _type: 'MediaPlayerContext',
+  _type: LocationContextName.MediaPlayerContext,
   id: props.id,
 });
 
@@ -181,7 +182,7 @@ export const makeMediaPlayerContext = (props: { id: string }): MediaPlayerContex
 export const makeNavigationContext = (props: { id: string }): NavigationContext => ({
   __instance_id: generateUUID(),
   __location_context: true,
-  _type: 'NavigationContext',
+  _type: LocationContextName.NavigationContext,
   id: props.id,
 });
 
@@ -195,7 +196,7 @@ export const makeNavigationContext = (props: { id: string }): NavigationContext 
 export const makeOverlayContext = (props: { id: string }): OverlayContext => ({
   __instance_id: generateUUID(),
   __location_context: true,
-  _type: 'OverlayContext',
+  _type: LocationContextName.OverlayContext,
   id: props.id,
 });
 
@@ -208,7 +209,7 @@ export const makeOverlayContext = (props: { id: string }): OverlayContext => ({
 export const makePathContext = (props: { id: string }): PathContext => ({
   __instance_id: generateUUID(),
   __global_context: true,
-  _type: 'PathContext',
+  _type: GlobalContextName.PathContext,
   id: props.id,
 });
 
@@ -223,7 +224,7 @@ export const makePressableContext = (props: { id: string }): PressableContext =>
   __instance_id: generateUUID(),
   __location_context: true,
   __pressable_context: true,
-  _type: 'PressableContext',
+  _type: LocationContextName.PressableContext,
   id: props.id,
 });
 
@@ -236,7 +237,7 @@ export const makePressableContext = (props: { id: string }): PressableContext =>
 export const makeRootLocationContext = (props: { id: string }): RootLocationContext => ({
   __instance_id: generateUUID(),
   __location_context: true,
-  _type: 'RootLocationContext',
+  _type: LocationContextName.RootLocationContext,
   id: props.id,
 });
 
@@ -250,7 +251,7 @@ export const makeRootLocationContext = (props: { id: string }): RootLocationCont
 export const makeSessionContext = (props: { id: string; hit_number: number }): SessionContext => ({
   __instance_id: generateUUID(),
   __global_context: true,
-  _type: 'SessionContext',
+  _type: GlobalContextName.SessionContext,
   id: props.id,
   hit_number: props.hit_number,
 });

--- a/tracker/core/tracker/src/ContextNames.ts
+++ b/tracker/core/tracker/src/ContextNames.ts
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2022 Objectiv B.V.
+ */
+
+export enum GlobalContextName {
+  ApplicationContext = 'ApplicationContext',
+  CookieIdContext = 'CookieIdContext',
+  HttpContext = 'HttpContext',
+  MarketingContext = 'MarketingContext',
+  PathContext = 'PathContext',
+  SessionContext = 'SessionContext',
+}
+
+export enum LocationContextName {
+  ContentContext = 'ContentContext',
+  ExpandableContext = 'ExpandableContext',
+  InputContext = 'InputContext',
+  LinkContext = 'LinkContext',
+  MediaPlayerContext = 'MediaPlayerContext',
+  NavigationContext = 'NavigationContext',
+  OverlayContext = 'OverlayContext',
+  PressableContext = 'PressableContext',
+  RootLocationContext = 'RootLocationContext',
+}

--- a/tracker/core/tracker/src/EventFactories.ts
+++ b/tracker/core/tracker/src/EventFactories.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2022 Objectiv B.V.
+ * Copyright 2022 Objectiv B.V.
  */
 
 import {

--- a/tracker/core/tracker/src/index.ts
+++ b/tracker/core/tracker/src/index.ts
@@ -13,6 +13,7 @@ export * from './validationRules/logEventValidationRuleError';
 export * from './cleanObjectFromInternalProperties';
 export * from './Context';
 export * from './ContextFactories';
+export * from './ContextNames';
 export * from './EventFactories';
 export * from './helpers';
 export * from './NoopConsoleImplementation';

--- a/tracker/core/tracker/src/plugins/OpenTaxonomyValidationPlugin.ts
+++ b/tracker/core/tracker/src/plugins/OpenTaxonomyValidationPlugin.ts
@@ -2,6 +2,7 @@
  * Copyright 2022 Objectiv B.V.
  */
 
+import { GlobalContextName, LocationContextName } from '../ContextNames';
 import { isDevMode } from '../helpers';
 import { TrackerConsole } from '../TrackerConsole';
 import { TrackerEvent } from '../TrackerEvent';
@@ -26,12 +27,12 @@ export class OpenTaxonomyValidationPlugin implements TrackerPluginInterface {
     this.validationRules = [
       new GlobalContextValidationRule({
         logPrefix: this.pluginName,
-        contextName: 'ApplicationContext',
+        contextName: GlobalContextName.ApplicationContext,
         once: true,
       }),
       new LocationContextValidationRule({
         logPrefix: this.pluginName,
-        contextName: 'RootLocationContext',
+        contextName: LocationContextName.RootLocationContext,
         once: true,
         position: 0,
       }),

--- a/tracker/core/tracker/tests/ApplicationContextPlugin.test.ts
+++ b/tracker/core/tracker/tests/ApplicationContextPlugin.test.ts
@@ -7,6 +7,7 @@ import {
   ApplicationContextPlugin,
   ContextsConfig,
   generateUUID,
+  GlobalContextName,
   Tracker,
   TrackerConfig,
   TrackerConsole,
@@ -29,7 +30,7 @@ describe('ApplicationContextPlugin', () => {
         applicationContext: {
           __instance_id: matchUUID,
           __global_context: true,
-          _type: 'ApplicationContext',
+          _type: GlobalContextName.ApplicationContext,
           id: 'app-id',
         },
       })
@@ -61,7 +62,7 @@ describe('ApplicationContextPlugin', () => {
         {
           __instance_id: matchUUID,
           __global_context: true,
-          _type: 'ApplicationContext',
+          _type: GlobalContextName.ApplicationContext,
           id: 'app-id',
         },
       ])

--- a/tracker/core/tracker/tests/ContextFactories.test.ts
+++ b/tracker/core/tracker/tests/ContextFactories.test.ts
@@ -4,6 +4,8 @@
 
 import { matchUUID } from '@objectiv/testing-tools';
 import {
+  GlobalContextName,
+  LocationContextName,
   makeApplicationContext,
   makeContentContext,
   makeCookieIdContext,
@@ -22,50 +24,50 @@ import {
 } from '../src';
 
 describe('Context Factories', () => {
-  it('ApplicationContext', () => {
+  it(GlobalContextName.ApplicationContext, () => {
     expect(makeApplicationContext({ id: 'app' })).toStrictEqual({
       __instance_id: matchUUID,
       __global_context: true,
-      _type: 'ApplicationContext',
+      _type: GlobalContextName.ApplicationContext,
       id: 'app',
     });
   });
 
-  it('ContentContext', () => {
+  it(LocationContextName.ContentContext, () => {
     expect(makeContentContext({ id: 'content-A' })).toStrictEqual({
       __instance_id: matchUUID,
       __location_context: true,
-      _type: 'ContentContext',
+      _type: LocationContextName.ContentContext,
       id: 'content-A',
     });
   });
 
-  it('CookieIdContext', () => {
+  it(GlobalContextName.CookieIdContext, () => {
     expect(makeCookieIdContext({ id: 'error-id', cookie_id: '12345' })).toStrictEqual({
       __instance_id: matchUUID,
       __global_context: true,
-      _type: 'CookieIdContext',
+      _type: GlobalContextName.CookieIdContext,
       id: 'error-id',
       cookie_id: '12345', // Note: the cookieId parameter is mapped to cookie_id
     });
   });
 
-  it('ExpandableContext', () => {
+  it(LocationContextName.ExpandableContext, () => {
     expect(makeExpandableContext({ id: 'accordion-a' })).toStrictEqual({
       __instance_id: matchUUID,
       __location_context: true,
-      _type: 'ExpandableContext',
+      _type: LocationContextName.ExpandableContext,
       id: 'accordion-a',
     });
   });
 
-  it('HttpContext', () => {
+  it(GlobalContextName.HttpContext, () => {
     expect(
       makeHttpContext({ id: 'http', referrer: 'referrer', user_agent: 'ua', remote_address: '0.0.0.0' })
     ).toStrictEqual({
       __instance_id: matchUUID,
       __global_context: true,
-      _type: 'HttpContext',
+      _type: GlobalContextName.HttpContext,
       id: 'http',
       referrer: 'referrer',
       user_agent: 'ua',
@@ -75,7 +77,7 @@ describe('Context Factories', () => {
     expect(makeHttpContext({ id: 'http', referrer: 'referrer', user_agent: 'ua' })).toStrictEqual({
       __instance_id: matchUUID,
       __global_context: true,
-      _type: 'HttpContext',
+      _type: GlobalContextName.HttpContext,
       id: 'http',
       referrer: 'referrer',
       user_agent: 'ua',
@@ -83,27 +85,27 @@ describe('Context Factories', () => {
     });
   });
 
-  it('InputContext', () => {
+  it(LocationContextName.InputContext, () => {
     expect(makeInputContext({ id: 'input-1' })).toStrictEqual({
       __instance_id: matchUUID,
       __location_context: true,
-      _type: 'InputContext',
+      _type: LocationContextName.InputContext,
       id: 'input-1',
     });
   });
 
-  it('LinkContext', () => {
+  it(LocationContextName.LinkContext, () => {
     expect(makeLinkContext({ id: 'confirm-data', href: '/some/url' })).toStrictEqual({
       __instance_id: matchUUID,
       __location_context: true,
       __pressable_context: true,
-      _type: 'LinkContext',
+      _type: LocationContextName.LinkContext,
       id: 'confirm-data',
       href: '/some/url',
     });
   });
 
-  it('MarketingContext', () => {
+  it(GlobalContextName.MarketingContext, () => {
     expect(
       makeMarketingContext({
         id: 'utm',
@@ -114,7 +116,7 @@ describe('Context Factories', () => {
     ).toStrictEqual({
       __instance_id: matchUUID,
       __global_context: true,
-      _type: 'MarketingContext',
+      _type: GlobalContextName.MarketingContext,
       id: 'utm',
       campaign: 'test-campaign',
       medium: 'test-medium',
@@ -135,7 +137,7 @@ describe('Context Factories', () => {
     ).toStrictEqual({
       __instance_id: matchUUID,
       __global_context: true,
-      _type: 'MarketingContext',
+      _type: GlobalContextName.MarketingContext,
       id: 'utm',
       campaign: 'test-campaign',
       medium: 'test-medium',
@@ -145,66 +147,66 @@ describe('Context Factories', () => {
     });
   });
 
-  it('MediaPlayerContext', () => {
+  it(LocationContextName.MediaPlayerContext, () => {
     expect(makeMediaPlayerContext({ id: 'player-1' })).toStrictEqual({
       __instance_id: matchUUID,
       __location_context: true,
-      _type: 'MediaPlayerContext',
+      _type: LocationContextName.MediaPlayerContext,
       id: 'player-1',
     });
   });
 
-  it('NavigationContext', () => {
+  it(LocationContextName.NavigationContext, () => {
     expect(makeNavigationContext({ id: 'top-nav' })).toStrictEqual({
       __instance_id: matchUUID,
       __location_context: true,
-      _type: 'NavigationContext',
+      _type: LocationContextName.NavigationContext,
       id: 'top-nav',
     });
   });
 
-  it('OverlayContext', () => {
+  it(LocationContextName.OverlayContext, () => {
     expect(makeOverlayContext({ id: 'top-menu' })).toStrictEqual({
       __instance_id: matchUUID,
       __location_context: true,
-      _type: 'OverlayContext',
+      _type: LocationContextName.OverlayContext,
       id: 'top-menu',
     });
   });
 
-  it('PathContext', () => {
+  it(GlobalContextName.PathContext, () => {
     expect(makePathContext({ id: '/some/path' })).toStrictEqual({
       __instance_id: matchUUID,
       __global_context: true,
-      _type: 'PathContext',
+      _type: GlobalContextName.PathContext,
       id: '/some/path',
     });
   });
 
-  it('PressableContext', () => {
+  it(LocationContextName.PressableContext, () => {
     expect(makePressableContext({ id: 'confirm-data' })).toStrictEqual({
       __instance_id: matchUUID,
       __location_context: true,
       __pressable_context: true,
-      _type: 'PressableContext',
+      _type: LocationContextName.PressableContext,
       id: 'confirm-data',
     });
   });
 
-  it('RootLocationContext', () => {
+  it(LocationContextName.RootLocationContext, () => {
     expect(makeRootLocationContext({ id: 'page-A' })).toStrictEqual({
       __instance_id: matchUUID,
       __location_context: true,
-      _type: 'RootLocationContext',
+      _type: LocationContextName.RootLocationContext,
       id: 'page-A',
     });
   });
 
-  it('SessionContext', () => {
+  it(GlobalContextName.SessionContext, () => {
     expect(makeSessionContext({ id: 'session-id', hit_number: 123 })).toStrictEqual({
       __instance_id: matchUUID,
       __global_context: true,
-      _type: 'SessionContext',
+      _type: GlobalContextName.SessionContext,
       id: 'session-id',
       hit_number: 123,
     });

--- a/tracker/core/tracker/tests/OpenTaxonomyValidationPlugin.test.ts
+++ b/tracker/core/tracker/tests/OpenTaxonomyValidationPlugin.test.ts
@@ -4,6 +4,7 @@
 
 import { MockConsoleImplementation } from '@objectiv/testing-tools';
 import {
+  GlobalContextName,
   LocationContextName,
   makeApplicationContext,
   makeContentContext,
@@ -20,7 +21,7 @@ describe('OpenTaxonomyValidationPlugin', () => {
     jest.resetAllMocks();
   });
 
-  describe('ApplicationContext', () => {
+  describe(GlobalContextName.ApplicationContext, () => {
     it('should succeed', () => {
       const testOpenTaxonomyValidationPlugin = new OpenTaxonomyValidationPlugin();
       const validEvent = new TrackerEvent({

--- a/tracker/core/tracker/tests/OpenTaxonomyValidationPlugin.test.ts
+++ b/tracker/core/tracker/tests/OpenTaxonomyValidationPlugin.test.ts
@@ -4,6 +4,7 @@
 
 import { MockConsoleImplementation } from '@objectiv/testing-tools';
 import {
+  LocationContextName,
   makeApplicationContext,
   makeContentContext,
   makeRootLocationContext,
@@ -75,7 +76,7 @@ describe('OpenTaxonomyValidationPlugin', () => {
     });
   });
 
-  describe('RootLocationContext', () => {
+  describe(LocationContextName.RootLocationContext, () => {
     it('should succeed', () => {
       const testOpenTaxonomyValidationPlugin = new OpenTaxonomyValidationPlugin();
       const validEvent = new TrackerEvent({

--- a/tracker/core/tracker/tests/Tracker.test.ts
+++ b/tracker/core/tracker/tests/Tracker.test.ts
@@ -16,6 +16,7 @@ import {
   TrackerQueue,
   TrackerQueueMemoryStore,
 } from '../src';
+import { GlobalContextName, LocationContextName } from '../src/ContextNames';
 
 TrackerConsole.setImplementation(MockConsoleImplementation);
 
@@ -37,12 +38,12 @@ describe('Tracker', () => {
         validationRules: [
           new GlobalContextValidationRule({
             logPrefix: 'OpenTaxonomyValidationPlugin',
-            contextName: 'ApplicationContext',
+            contextName: GlobalContextName.ApplicationContext,
             once: true,
           }),
           new LocationContextValidationRule({
             logPrefix: 'OpenTaxonomyValidationPlugin',
-            contextName: 'RootLocationContext',
+            contextName: LocationContextName.RootLocationContext,
             once: true,
             position: 0,
           }),
@@ -53,7 +54,7 @@ describe('Tracker', () => {
         applicationContext: {
           __instance_id: matchUUID,
           __global_context: true,
-          _type: 'ApplicationContext',
+          _type: GlobalContextName.ApplicationContext,
           id: 'app-id',
         },
       },
@@ -77,12 +78,12 @@ describe('Tracker', () => {
         validationRules: [
           new GlobalContextValidationRule({
             logPrefix: 'OpenTaxonomyValidationPlugin',
-            contextName: 'ApplicationContext',
+            contextName: GlobalContextName.ApplicationContext,
             once: true,
           }),
           new LocationContextValidationRule({
             logPrefix: 'OpenTaxonomyValidationPlugin',
-            contextName: 'RootLocationContext',
+            contextName: LocationContextName.RootLocationContext,
             once: true,
             position: 0,
           }),
@@ -93,7 +94,7 @@ describe('Tracker', () => {
         applicationContext: {
           __instance_id: matchUUID,
           __global_context: true,
-          _type: 'ApplicationContext',
+          _type: GlobalContextName.ApplicationContext,
           id: 'app-id',
         },
       },
@@ -120,12 +121,12 @@ describe('Tracker', () => {
         validationRules: [
           new GlobalContextValidationRule({
             logPrefix: 'OpenTaxonomyValidationPlugin',
-            contextName: 'ApplicationContext',
+            contextName: GlobalContextName.ApplicationContext,
             once: true,
           }),
           new LocationContextValidationRule({
             logPrefix: 'OpenTaxonomyValidationPlugin',
-            contextName: 'RootLocationContext',
+            contextName: LocationContextName.RootLocationContext,
             once: true,
             position: 0,
           }),
@@ -284,7 +285,7 @@ describe('Tracker', () => {
         { __instance_id: matchUUID, __global_context: true, _type: 'global', id: 'X' },
         { __instance_id: matchUUID, __global_context: true, _type: 'global', id: 'Y' },
         { __instance_id: matchUUID, __global_context: true, _type: 'global', id: 'Z' },
-        { __instance_id: matchUUID, __global_context: true, _type: 'ApplicationContext', id: 'app-id' },
+        { __instance_id: matchUUID, __global_context: true, _type: GlobalContextName.ApplicationContext, id: 'app-id' },
       ]);
     });
 

--- a/tracker/core/utilities/src/generator.js
+++ b/tracker/core/utilities/src/generator.js
@@ -21,7 +21,7 @@ const fs = require('fs');
 const JSON5 = require('json5');
 
 const COPYRIGHT = `/*
- * Copyright 2021-${new Date().getFullYear()} Objectiv B.V.
+ * Copyright ${new Date().getFullYear()} Objectiv B.V.
  */
  \n
 `;
@@ -707,6 +707,30 @@ Object.keys(object_declarations).forEach((definition_type) => {
   );
   console.log(`Written ${Object.values(object_declarations[definition_type]).length} definitions to ${filename}`);
 });
+
+// Generate ContextNames.ts enum definitions in Core Tracker
+const filename = `${core_tracker_package_dir}ContextNames.ts`;
+let content = '';
+
+Object.keys(object_declarations).forEach((definition_type) => {
+  // generate context names enum if we are writing core tracker location_contexts or global_contexts definitions
+  if (['location_contexts', 'global_contexts'].includes(definition_type)) {
+    const enumName = definition_type === 'location_contexts' ? 'LocationContextName' : 'GlobalContextName';
+    const contextNames = Object.keys(object_declarations[definition_type]).sort();
+
+    // generate enum
+    content += `export enum ${enumName} { 
+      ${contextNames.map((name) => `${name} = '${name}'`).join(',\n')}
+    }\n\n`;
+  }
+});
+
+// write ContextNames.ts to file, if we have any
+if (content) {
+  fs.writeFileSync(filename, COPYRIGHT);
+  fs.appendFileSync(filename, content);
+  console.log(`Written Context Names Enums definitions to ${filename}`);
+}
 
 // generate index for all declarations
 // this includes all generated types, as well as those in static.d.ts

--- a/tracker/core/utilities/src/generator.js
+++ b/tracker/core/utilities/src/generator.js
@@ -146,7 +146,8 @@ function createFactory(
   // by parent classes.
   const object_discriminator = {};
   if (params.object_type === 'context') {
-    object_discriminator[CONTEXT_DISCRIMINATOR] = { value: `'${params.class_name}'` };
+    const enumName = params.stack_type === 'location_contexts' ? 'LocationContextName' : 'GlobalContextName';
+    object_discriminator[CONTEXT_DISCRIMINATOR] = { value: `${enumName}.${params.class_name}` };
   } else {
     object_discriminator[EVENT_DISCRIMINATOR] = { value: `'${params.class_name}'` };
   }
@@ -667,6 +668,7 @@ Object.keys(object_factories).forEach((factory_type) => {
   const import_statements = [`import { \n\t${imports.join(',\n\t')}\n} from '@objectiv/schema';`];
 
   if (factory_type === 'ContextFactories') {
+    import_statements.push(`import { GlobalContextName, LocationContextName } from "./ContextNames";`);
     import_statements.push(`import { generateUUID } from "./helpers";`);
   }
 

--- a/tracker/plugins/http-context/src/HttpContextPlugin.ts
+++ b/tracker/plugins/http-context/src/HttpContextPlugin.ts
@@ -3,6 +3,7 @@
  */
 
 import {
+  GlobalContextName,
   GlobalContextValidationRule,
   makeHttpContext,
   TrackerConsole,
@@ -27,7 +28,7 @@ export class HttpContextPlugin implements TrackerPluginInterface {
     this.validationRules = [
       new GlobalContextValidationRule({
         logPrefix: this.pluginName,
-        contextName: 'HttpContext',
+        contextName: GlobalContextName.HttpContext,
         once: true,
       }),
     ];

--- a/tracker/plugins/http-context/tests/HttpContextPlugin.test.ts
+++ b/tracker/plugins/http-context/tests/HttpContextPlugin.test.ts
@@ -6,6 +6,7 @@ import { matchUUID, MockConsoleImplementation } from '@objectiv/testing-tools';
 import {
   ContextsConfig,
   generateUUID,
+  GlobalContextName,
   makeHttpContext,
   Tracker,
   TrackerConsole,
@@ -51,7 +52,7 @@ describe('HttpContextPlugin', () => {
         {
           __instance_id: matchUUID,
           __global_context: true,
-          _type: 'HttpContext',
+          _type: GlobalContextName.HttpContext,
           id: 'http_context',
           referrer: 'MOCK_REFERRER',
           remote_address: null,
@@ -85,7 +86,7 @@ describe('HttpContextPlugin', () => {
         {
           __instance_id: matchUUID,
           __global_context: true,
-          _type: 'HttpContext',
+          _type: GlobalContextName.HttpContext,
           id: 'http_context',
           referrer: '',
           remote_address: null,

--- a/tracker/plugins/path-context-from-url/src/PathContextFromURLPlugin.ts
+++ b/tracker/plugins/path-context-from-url/src/PathContextFromURLPlugin.ts
@@ -4,6 +4,7 @@
 
 import {
   ContextsConfig,
+  GlobalContextName,
   GlobalContextValidationRule,
   makePathContext,
   TrackerConsole,
@@ -31,7 +32,7 @@ export class PathContextFromURLPlugin implements TrackerPluginInterface {
     this.validationRules = [
       new GlobalContextValidationRule({
         logPrefix: this.pluginName,
-        contextName: 'PathContext',
+        contextName: GlobalContextName.PathContext,
         once: true,
       }),
     ];

--- a/tracker/plugins/path-context-from-url/tests/PathContextFromURLPlugin.test.ts
+++ b/tracker/plugins/path-context-from-url/tests/PathContextFromURLPlugin.test.ts
@@ -5,7 +5,8 @@
 import { matchUUID, MockConsoleImplementation } from '@objectiv/testing-tools';
 import {
   ContextsConfig,
-  generateUUID, GlobalContextName,
+  generateUUID,
+  GlobalContextName,
   makePathContext,
   Tracker,
   TrackerConsole,

--- a/tracker/plugins/path-context-from-url/tests/PathContextFromURLPlugin.test.ts
+++ b/tracker/plugins/path-context-from-url/tests/PathContextFromURLPlugin.test.ts
@@ -5,7 +5,7 @@
 import { matchUUID, MockConsoleImplementation } from '@objectiv/testing-tools';
 import {
   ContextsConfig,
-  generateUUID,
+  generateUUID, GlobalContextName,
   makePathContext,
   Tracker,
   TrackerConsole,
@@ -46,7 +46,7 @@ describe('PathContextFromURLPlugin', () => {
         {
           __instance_id: matchUUID,
           __global_context: true,
-          _type: 'PathContext',
+          _type: GlobalContextName.PathContext,
           id: 'http://localhost/',
         },
       ])

--- a/tracker/plugins/react-navigation/tests/TrackedLink.test.tsx
+++ b/tracker/plugins/react-navigation/tests/TrackedLink.test.tsx
@@ -307,8 +307,8 @@ describe('TrackedLink', () => {
       expect.objectContaining({
         _type: 'ApplicationLoadedEvent',
         global_contexts: [
-          expect.objectContaining({ _type: 'ApplicationContext', id: 'app-id' }),
-          expect.objectContaining({ _type: 'PathContext', id: '/Home/Messages' }),
+          expect.objectContaining({ _type: GlobalContextName.ApplicationContext, id: 'app-id' }),
+          expect.objectContaining({ _type: GlobalContextName.PathContext, id: '/Home/Messages' }),
         ],
         location_stack: [expect.objectContaining({ _type: LocationContextName.RootLocationContext, id: 'Messages' })],
       })

--- a/tracker/plugins/react-navigation/tests/TrackedLink.test.tsx
+++ b/tracker/plugins/react-navigation/tests/TrackedLink.test.tsx
@@ -3,7 +3,7 @@
  */
 
 import { MockConsoleImplementation } from '@objectiv/testing-tools';
-import { TrackerConsole } from '@objectiv/tracker-core';
+import { GlobalContextName, LocationContextName, TrackerConsole } from '@objectiv/tracker-core';
 import {
   ContentContextWrapper,
   ObjectivProvider,
@@ -99,10 +99,12 @@ describe('TrackedLink', () => {
         expect.objectContaining({
           _type: 'ApplicationLoadedEvent',
           global_contexts: [
-            expect.objectContaining({ _type: 'ApplicationContext', id: 'app-id' }),
-            expect.objectContaining({ _type: 'PathContext', ...pathContext }),
+            expect.objectContaining({ _type: GlobalContextName.ApplicationContext, id: 'app-id' }),
+            expect.objectContaining({ _type: GlobalContextName.PathContext, ...pathContext }),
           ],
-          location_stack: [expect.objectContaining({ _type: 'RootLocationContext', ...rootLocationContext })],
+          location_stack: [
+            expect.objectContaining({ _type: LocationContextName.RootLocationContext, ...rootLocationContext }),
+          ],
         })
       );
       expect(spyTransport.handle).toHaveBeenNthCalledWith(
@@ -110,12 +112,12 @@ describe('TrackedLink', () => {
         expect.objectContaining({
           _type: 'PressEvent',
           global_contexts: [
-            expect.objectContaining({ _type: 'ApplicationContext', id: 'app-id' }),
-            expect.objectContaining({ _type: 'PathContext', ...pathContext }),
+            expect.objectContaining({ _type: GlobalContextName.ApplicationContext, id: 'app-id' }),
+            expect.objectContaining({ _type: GlobalContextName.PathContext, ...pathContext }),
           ],
           location_stack: [
-            expect.objectContaining({ _type: 'RootLocationContext', ...rootLocationContext }),
-            expect.objectContaining({ _type: 'LinkContext', ...linkContext }),
+            expect.objectContaining({ _type: LocationContextName.RootLocationContext, ...rootLocationContext }),
+            expect.objectContaining({ _type: LocationContextName.LinkContext, ...linkContext }),
           ],
         })
       );
@@ -213,7 +215,9 @@ describe('TrackedLink', () => {
     const contexts = { location_stack: [], global_contexts: [] };
     testContextsFromReactNavigationPlugin.enrich(contexts);
 
-    expect(contexts.location_stack).toEqual([expect.objectContaining({ _type: 'RootLocationContext', id: 'home' })]);
+    expect(contexts.location_stack).toEqual([
+      expect.objectContaining({ _type: LocationContextName.RootLocationContext, id: 'home' }),
+    ]);
   });
 
   it('should fallback to defaults when navigationContainerRef is not ready', async () => {
@@ -224,8 +228,12 @@ describe('TrackedLink', () => {
     const contexts = { location_stack: [], global_contexts: [] };
     testContextsFromReactNavigationPlugin.enrich(contexts);
 
-    expect(contexts.location_stack).toEqual([expect.objectContaining({ _type: 'RootLocationContext', id: 'home' })]);
-    expect(contexts.global_contexts).toEqual([expect.objectContaining({ _type: 'PathContext', id: '/' })]);
+    expect(contexts.location_stack).toEqual([
+      expect.objectContaining({ _type: LocationContextName.RootLocationContext, id: 'home' }),
+    ]);
+    expect(contexts.global_contexts).toEqual([
+      expect.objectContaining({ _type: GlobalContextName.PathContext, id: '/' }),
+    ]);
   });
 
   it('should correctly generate RootLocation and Path Contexts with nested navigators', async () => {
@@ -302,7 +310,7 @@ describe('TrackedLink', () => {
           expect.objectContaining({ _type: 'ApplicationContext', id: 'app-id' }),
           expect.objectContaining({ _type: 'PathContext', id: '/Home/Messages' }),
         ],
-        location_stack: [expect.objectContaining({ _type: 'RootLocationContext', id: 'Messages' })],
+        location_stack: [expect.objectContaining({ _type: LocationContextName.RootLocationContext, id: 'Messages' })],
       })
     );
     expect(spyTransport.handle).toHaveBeenNthCalledWith(
@@ -310,12 +318,12 @@ describe('TrackedLink', () => {
       expect.objectContaining({
         _type: 'PressEvent',
         global_contexts: [
-          expect.objectContaining({ _type: 'ApplicationContext', id: 'app-id' }),
-          expect.objectContaining({ _type: 'PathContext', id: '/Home/Messages' }),
+          expect.objectContaining({ _type: GlobalContextName.ApplicationContext, id: 'app-id' }),
+          expect.objectContaining({ _type: GlobalContextName.PathContext, id: '/Home/Messages' }),
         ],
         location_stack: [
-          expect.objectContaining({ _type: 'RootLocationContext', id: 'Messages' }),
-          expect.objectContaining({ _type: 'LinkContext', id: 'go-to-home', href: '/Home' }),
+          expect.objectContaining({ _type: LocationContextName.RootLocationContext, id: 'Messages' }),
+          expect.objectContaining({ _type: LocationContextName.LinkContext, id: 'go-to-home', href: '/Home' }),
         ],
       })
     );

--- a/tracker/plugins/react-navigation/tests/makeLinkPressListener.test.tsx
+++ b/tracker/plugins/react-navigation/tests/makeLinkPressListener.test.tsx
@@ -3,7 +3,7 @@
  */
 
 import { MockConsoleImplementation } from '@objectiv/testing-tools';
-import { TrackerConsole } from '@objectiv/tracker-core';
+import { GlobalContextName, LocationContextName, TrackerConsole } from '@objectiv/tracker-core';
 import {
   NavigationContextWrapper,
   ObjectivProvider,
@@ -70,17 +70,17 @@ describe('makePressListener', () => {
       1,
       expect.objectContaining({
         _type: 'ApplicationLoadedEvent',
-        global_contexts: [expect.objectContaining({ _type: 'ApplicationContext', id: 'app-id' })],
+        global_contexts: [expect.objectContaining({ _type: GlobalContextName.ApplicationContext, id: 'app-id' })],
       })
     );
     expect(spyTransport.handle).toHaveBeenNthCalledWith(
       2,
       expect.objectContaining({
         _type: 'PressEvent',
-        global_contexts: [expect.objectContaining({ _type: 'ApplicationContext', id: 'app-id' })],
+        global_contexts: [expect.objectContaining({ _type: GlobalContextName.ApplicationContext, id: 'app-id' })],
         location_stack: [
-          expect.objectContaining({ _type: 'NavigationContext', id: 'bottom-tabs' }),
-          expect.objectContaining({ _type: 'LinkContext', id: 'ScreenA', href: '/ScreenB' }),
+          expect.objectContaining({ _type: LocationContextName.NavigationContext, id: 'bottom-tabs' }),
+          expect.objectContaining({ _type: LocationContextName.LinkContext, id: 'ScreenA', href: '/ScreenB' }),
         ],
       })
     );
@@ -88,10 +88,10 @@ describe('makePressListener', () => {
       3,
       expect.objectContaining({
         _type: 'PressEvent',
-        global_contexts: [expect.objectContaining({ _type: 'ApplicationContext', id: 'app-id' })],
+        global_contexts: [expect.objectContaining({ _type: GlobalContextName.ApplicationContext, id: 'app-id' })],
         location_stack: [
-          expect.objectContaining({ _type: 'NavigationContext', id: 'bottom-tabs' }),
-          expect.objectContaining({ _type: 'LinkContext', id: 'ScreenB', href: '/ScreenA' }),
+          expect.objectContaining({ _type: LocationContextName.NavigationContext, id: 'bottom-tabs' }),
+          expect.objectContaining({ _type: LocationContextName.LinkContext, id: 'ScreenB', href: '/ScreenA' }),
         ],
       })
     );

--- a/tracker/plugins/react-router-tracked-components/tests/TrackedLink.test.tsx
+++ b/tracker/plugins/react-router-tracked-components/tests/TrackedLink.test.tsx
@@ -3,7 +3,7 @@
  */
 
 import { SpyTransport } from '@objectiv/testing-tools';
-import { Tracker } from '@objectiv/tracker-core';
+import { LocationContextName, Tracker } from '@objectiv/tracker-core';
 import {
   ObjectivProvider,
   TrackedDiv,
@@ -102,7 +102,7 @@ describe('TrackedLink', () => {
           _type: 'PressEvent',
           location_stack: [
             expect.objectContaining({
-              _type: 'LinkContext',
+              _type: LocationContextName.LinkContext,
               ...expectedAttributes,
             }),
           ],
@@ -209,7 +209,7 @@ describe('TrackedLink', () => {
         _type: 'PressEvent',
         location_stack: expect.arrayContaining([
           expect.objectContaining({
-            _type: 'LinkContext',
+            _type: LocationContextName.LinkContext,
             id: 'press-me',
           }),
         ]),

--- a/tracker/plugins/react-router-tracked-components/tests/TrackedNavLink.test.tsx
+++ b/tracker/plugins/react-router-tracked-components/tests/TrackedNavLink.test.tsx
@@ -3,7 +3,7 @@
  */
 
 import { SpyTransport } from '@objectiv/testing-tools';
-import { Tracker } from '@objectiv/tracker-core';
+import { LocationContextName, Tracker } from '@objectiv/tracker-core';
 import {
   ObjectivProvider,
   TrackedDiv,
@@ -96,7 +96,7 @@ describe('TrackedNavLink', () => {
           _type: 'PressEvent',
           location_stack: [
             expect.objectContaining({
-              _type: 'LinkContext',
+              _type: LocationContextName.LinkContext,
               ...expectedAttributes,
             }),
           ],
@@ -205,7 +205,7 @@ describe('TrackedNavLink', () => {
         _type: 'PressEvent',
         location_stack: expect.arrayContaining([
           expect.objectContaining({
-            _type: 'LinkContext',
+            _type: LocationContextName.LinkContext,
             id: 'press-me',
           }),
         ]),

--- a/tracker/plugins/root-location-context-from-url/tests/RootLocationContextFromURLPlugin.test.ts
+++ b/tracker/plugins/root-location-context-from-url/tests/RootLocationContextFromURLPlugin.test.ts
@@ -3,7 +3,14 @@
  */
 
 import { matchUUID, MockConsoleImplementation } from '@objectiv/testing-tools';
-import { ContextsConfig, generateUUID, Tracker, TrackerConsole, TrackerEvent } from '@objectiv/tracker-core';
+import {
+  ContextsConfig,
+  generateUUID,
+  LocationContextName,
+  Tracker,
+  TrackerConsole,
+  TrackerEvent,
+} from '@objectiv/tracker-core';
 import { RootLocationContextFromURLPlugin } from '../src';
 
 TrackerConsole.setImplementation(MockConsoleImplementation);
@@ -36,7 +43,7 @@ describe('RootLocationContextFromURLPlugin', () => {
     expect(trackedEvent.location_stack[0]).toEqual({
       __instance_id: matchUUID,
       __location_context: true,
-      _type: 'RootLocationContext',
+      _type: LocationContextName.RootLocationContext,
       id: 'home',
     });
     expect(trackedEvent.global_contexts).toHaveLength(2);
@@ -62,7 +69,7 @@ describe('RootLocationContextFromURLPlugin', () => {
     expect(trackedEvent.location_stack[0]).toEqual({
       __instance_id: matchUUID,
       __location_context: true,
-      _type: 'RootLocationContext',
+      _type: LocationContextName.RootLocationContext,
       id: 'home',
     });
   });
@@ -87,7 +94,7 @@ describe('RootLocationContextFromURLPlugin', () => {
     expect(trackedEvent.location_stack[0]).toEqual({
       __instance_id: matchUUID,
       __location_context: true,
-      _type: 'RootLocationContext',
+      _type: LocationContextName.RootLocationContext,
       id: 'home',
     });
   });
@@ -112,7 +119,7 @@ describe('RootLocationContextFromURLPlugin', () => {
     expect(trackedEvent.location_stack[0]).toEqual({
       __instance_id: matchUUID,
       __location_context: true,
-      _type: 'RootLocationContext',
+      _type: LocationContextName.RootLocationContext,
       id: 'dashboard',
     });
   });
@@ -165,7 +172,7 @@ describe('RootLocationContextFromURLPlugin', () => {
     expect(trackedEvent.location_stack[0]).toEqual({
       __instance_id: matchUUID,
       __location_context: true,
-      _type: 'RootLocationContext',
+      _type: LocationContextName.RootLocationContext,
       id: 'welcome',
     });
   });

--- a/tracker/trackers/browser/src/common/guards/isLocationContext.ts
+++ b/tracker/trackers/browser/src/common/guards/isLocationContext.ts
@@ -3,6 +3,7 @@
  */
 
 import { AbstractLocationContext } from '@objectiv/schema';
+import { LocationContextName } from '@objectiv/tracker-core';
 import { AnyLocationContext } from '../../definitions/LocationContext';
 
 /**
@@ -21,15 +22,5 @@ export const isLocationContext = (locationContext: AbstractLocationContext): loc
     return false;
   }
 
-  return [
-    'ContentContext',
-    'ExpandableContext',
-    'InputContext',
-    'LinkContext',
-    'MediaPlayerContext',
-    'NavigationContext',
-    'OverlayContext',
-    'PressableContext',
-    'RootLocationContext',
-  ].includes(locationContext._type);
+  return Object.keys(LocationContextName).includes(locationContext._type);
 };

--- a/tracker/trackers/browser/src/common/guards/isLocationContext.ts
+++ b/tracker/trackers/browser/src/common/guards/isLocationContext.ts
@@ -21,6 +21,9 @@ export const isLocationContext = (locationContext: AbstractLocationContext): loc
     return false;
   }
 
+  // FIXME restrict AbstractLocationContext._type to LocationContextName
+  // then this can be replaced by
+  // return Object.values(LocationContextName).includes(locationContext._type);
   return [
     'ContentContext',
     'ExpandableContext',

--- a/tracker/trackers/browser/src/common/guards/isLocationContext.ts
+++ b/tracker/trackers/browser/src/common/guards/isLocationContext.ts
@@ -21,9 +21,6 @@ export const isLocationContext = (locationContext: AbstractLocationContext): loc
     return false;
   }
 
-  // FIXME restrict AbstractLocationContext._type to LocationContextName
-  // then this can be replaced by
-  // return Object.values(LocationContextName).includes(locationContext._type);
   return [
     'ContentContext',
     'ExpandableContext',

--- a/tracker/trackers/browser/src/common/guards/isPressableContext.ts
+++ b/tracker/trackers/browser/src/common/guards/isPressableContext.ts
@@ -2,10 +2,17 @@
  * Copyright 2021-2022 Objectiv B.V.
  */
 
+import { LocationContextName } from '@objectiv/tracker-core';
 import { AnyLocationContext, AnyPressableContext } from '../../definitions/LocationContext';
 
 /**
  * A type guard to determine if the given LocationContext supports PressEvent.
  */
-export const isPressableContext = (locationContext: AnyLocationContext): locationContext is AnyPressableContext =>
-  ['PressableContext', 'LinkContext'].includes(locationContext._type);
+export const isPressableContext = (locationContext: AnyLocationContext): locationContext is AnyPressableContext => {
+  const pressableLocationContextNames = [
+    LocationContextName.PressableContext.toString(),
+    LocationContextName.LinkContext.toString(),
+  ];
+
+  return pressableLocationContextNames.includes(locationContext._type);
+};

--- a/tracker/trackers/browser/src/common/guards/isPressableContext.ts
+++ b/tracker/trackers/browser/src/common/guards/isPressableContext.ts
@@ -8,7 +8,4 @@ import { AnyLocationContext, AnyPressableContext } from '../../definitions/Locat
  * A type guard to determine if the given LocationContext supports PressEvent.
  */
 export const isPressableContext = (locationContext: AnyLocationContext): locationContext is AnyPressableContext =>
-  // FIXME restrict AbstractLocationContext._type to LocationContextName
-  // then this can be replaced by
-  // return Object.values(LocationContextName).includes(locationContext._type);
   ['PressableContext', 'LinkContext'].includes(locationContext._type);

--- a/tracker/trackers/browser/src/common/guards/isPressableContext.ts
+++ b/tracker/trackers/browser/src/common/guards/isPressableContext.ts
@@ -8,4 +8,7 @@ import { AnyLocationContext, AnyPressableContext } from '../../definitions/Locat
  * A type guard to determine if the given LocationContext supports PressEvent.
  */
 export const isPressableContext = (locationContext: AnyLocationContext): locationContext is AnyPressableContext =>
+  // FIXME restrict AbstractLocationContext._type to LocationContextName
+  // then this can be replaced by
+  // return Object.values(LocationContextName).includes(locationContext._type);
   ['PressableContext', 'LinkContext'].includes(locationContext._type);

--- a/tracker/trackers/browser/src/common/guards/isShowableContext.ts
+++ b/tracker/trackers/browser/src/common/guards/isShowableContext.ts
@@ -2,10 +2,17 @@
  * Copyright 2021-2022 Objectiv B.V.
  */
 
+import { LocationContextName } from '@objectiv/tracker-core';
 import { AnyLocationContext, AnyShowableContext } from '../../definitions/LocationContext';
 
 /**
  * A type guard to determine if the given LocationContext supports HiddenEvent and VisibleEvent.
  */
-export const isShowableContext = (locationContext: AnyLocationContext): locationContext is AnyShowableContext =>
-  ['OverlayContext', 'ExpandableContext'].includes(locationContext._type);
+export const isShowableContext = (locationContext: AnyLocationContext): locationContext is AnyShowableContext => {
+  const showableLocationContextNames = [
+    LocationContextName.OverlayContext.toString(),
+    LocationContextName.ExpandableContext.toString(),
+  ];
+
+  return showableLocationContextNames.includes(locationContext._type);
+};

--- a/tracker/trackers/browser/src/common/guards/isShowableContext.ts
+++ b/tracker/trackers/browser/src/common/guards/isShowableContext.ts
@@ -8,7 +8,4 @@ import { AnyLocationContext, AnyShowableContext } from '../../definitions/Locati
  * A type guard to determine if the given LocationContext supports HiddenEvent and VisibleEvent.
  */
 export const isShowableContext = (locationContext: AnyLocationContext): locationContext is AnyShowableContext =>
-  // FIXME restrict AbstractLocationContext._type to LocationContextName
-  // then this can be replaced by
-  // return Object.values(LocationContextName).includes(locationContext._type);
   ['OverlayContext', 'ExpandableContext'].includes(locationContext._type);

--- a/tracker/trackers/browser/src/common/guards/isShowableContext.ts
+++ b/tracker/trackers/browser/src/common/guards/isShowableContext.ts
@@ -8,4 +8,7 @@ import { AnyLocationContext, AnyShowableContext } from '../../definitions/Locati
  * A type guard to determine if the given LocationContext supports HiddenEvent and VisibleEvent.
  */
 export const isShowableContext = (locationContext: AnyLocationContext): locationContext is AnyShowableContext =>
+  // FIXME restrict AbstractLocationContext._type to LocationContextName
+  // then this can be replaced by
+  // return Object.values(LocationContextName).includes(locationContext._type);
   ['OverlayContext', 'ExpandableContext'].includes(locationContext._type);

--- a/tracker/trackers/browser/src/locationTaggers/tagLocation.ts
+++ b/tracker/trackers/browser/src/locationTaggers/tagLocation.ts
@@ -2,7 +2,7 @@
  * Copyright 2021-2022 Objectiv B.V.
  */
 
-import { generateUUID, getObjectKeys } from '@objectiv/tracker-core';
+import { generateUUID, getObjectKeys, LocationContextName } from '@objectiv/tracker-core';
 import { isPressableContext } from '../common/guards/isPressableContext';
 import { isShowableContext } from '../common/guards/isShowableContext';
 import { isTagLocationParameters } from '../common/guards/isTagLocationParameters';
@@ -40,7 +40,7 @@ export const tagLocation = (parameters: TagLocationParameters): TagLocationRetur
 
     // Determine Context type
     const isPressable = isPressableContext(instance);
-    const isInput = instance._type === 'InputContext';
+    const isInput = instance._type === LocationContextName.InputContext;
     const isShowable = isShowableContext(instance);
 
     // Process options. Gather default attribute values

--- a/tracker/trackers/browser/tests/BrowserTracker.test.ts
+++ b/tracker/trackers/browser/tests/BrowserTracker.test.ts
@@ -4,6 +4,7 @@
 
 import { MockConsoleImplementation } from '@objectiv/testing-tools';
 import {
+  GlobalContextName,
   TrackerConsole,
   TrackerEvent,
   TrackerQueue,
@@ -166,15 +167,15 @@ describe('BrowserTracker', () => {
       expect(trackedEvent.global_contexts).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            _type: 'HttpContext',
+            _type: GlobalContextName.HttpContext,
             id: 'http_context',
           }),
           expect.objectContaining({
-            _type: 'ApplicationContext',
+            _type: GlobalContextName.ApplicationContext,
             id: 'app-id',
           }),
           expect.objectContaining({
-            _type: 'PathContext',
+            _type: GlobalContextName.PathContext,
             id: 'http://localhost/',
           }),
         ])

--- a/tracker/trackers/browser/tests/makeBlurEventHandler.test.ts
+++ b/tracker/trackers/browser/tests/makeBlurEventHandler.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { matchUUID, MockConsoleImplementation } from '@objectiv/testing-tools';
-import { generateUUID, makeInputChangeEvent, TrackerConsole } from '@objectiv/tracker-core';
+import { generateUUID, LocationContextName, makeInputChangeEvent, TrackerConsole } from '@objectiv/tracker-core';
 import { BrowserTracker, getTracker, getTrackerRepository, makeTracker } from '../src/';
 import { makeBlurEventHandler } from '../src/mutationObserver/makeBlurEventHandler';
 import { makeTaggedElement } from './mocks/makeTaggedElement';
@@ -81,7 +81,9 @@ describe('makeBlurEventHandler', () => {
     expect(getTracker().trackEvent).toHaveBeenNthCalledWith(
       1,
       expect.objectContaining(
-        makeInputChangeEvent({ location_stack: [expect.objectContaining({ _type: 'InputContext', id: 'input' })] })
+        makeInputChangeEvent({
+          location_stack: [expect.objectContaining({ _type: LocationContextName.InputContext, id: 'input' })],
+        })
       )
     );
   });

--- a/tracker/trackers/browser/tests/makeClickEventHandler.test.ts
+++ b/tracker/trackers/browser/tests/makeClickEventHandler.test.ts
@@ -5,6 +5,7 @@
 import { matchUUID, MockConsoleImplementation } from '@objectiv/testing-tools';
 import {
   generateUUID,
+  LocationContextName,
   makePressEvent,
   TrackerConsole,
   TrackerQueue,
@@ -92,7 +93,7 @@ describe('makeClickEventHandler', () => {
       1,
       expect.objectContaining(
         makePressEvent({
-          location_stack: [expect.objectContaining({ _type: 'PressableContext', id: 'button' })],
+          location_stack: [expect.objectContaining({ _type: LocationContextName.PressableContext, id: 'button' })],
         })
       )
     );

--- a/tracker/trackers/browser/tests/startAutoTracking.test.ts
+++ b/tracker/trackers/browser/tests/startAutoTracking.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { matchUUID, MockConsoleImplementation } from '@objectiv/testing-tools';
-import { generateUUID, TrackerConsole } from '@objectiv/tracker-core';
+import { generateUUID, LocationContextName, TrackerConsole } from '@objectiv/tracker-core';
 import {
   AutoTrackingState,
   BrowserTracker,
@@ -94,7 +94,7 @@ describe('makeMutationCallback - new nodes', () => {
         _type: 'VisibleEvent',
         id: matchUUID,
         global_contexts: [],
-        location_stack: [expect.objectContaining({ _type: 'ContentContext', id: 'div' })],
+        location_stack: [expect.objectContaining({ _type: LocationContextName.ContentContext, id: 'div' })],
       })
     );
     expect(getTracker().trackEvent).toHaveBeenNthCalledWith(
@@ -103,7 +103,7 @@ describe('makeMutationCallback - new nodes', () => {
         _type: 'VisibleEvent',
         id: matchUUID,
         global_contexts: [],
-        location_stack: [expect.objectContaining({ _type: 'ContentContext', id: 'div' })],
+        location_stack: [expect.objectContaining({ _type: LocationContextName.ContentContext, id: 'div' })],
       })
     );
   });
@@ -168,7 +168,7 @@ describe('makeMutationCallback - removed nodes', () => {
         _type: 'HiddenEvent',
         id: matchUUID,
         global_contexts: [],
-        location_stack: [expect.objectContaining({ _type: 'ContentContext', id: 'div' })],
+        location_stack: [expect.objectContaining({ _type: LocationContextName.ContentContext, id: 'div' })],
       })
     );
   });

--- a/tracker/trackers/browser/tests/tagLocation.test.ts
+++ b/tracker/trackers/browser/tests/tagLocation.test.ts
@@ -13,6 +13,7 @@ import {
   makeOverlayContext,
   makeContentContext,
   TrackerConsole,
+  LocationContextName,
 } from '@objectiv/tracker-core';
 import { tagContent, TaggingAttribute, tagLocation, tagOverlay } from '../src';
 
@@ -49,7 +50,7 @@ describe('tagLocation', () => {
     // @ts-ignore
     expect(tagLocation({ instance: { _type: 'nope' } })).toBeUndefined();
     // @ts-ignore
-    expect(tagLocation({ instance: { _type: 'ContentContext' } })).toBeUndefined();
+    expect(tagLocation({ instance: { _type: LocationContextName.ContentContext } })).toBeUndefined();
     // @ts-ignore
     expect(tagLocation({ instance: { id: 'nope' } })).toBeUndefined();
     // @ts-ignore
@@ -121,7 +122,7 @@ describe('tagLocation', () => {
           ? JSON.parse(taggingAttributesA[TaggingAttribute.context]).__instance_id
           : null,
         __location_context: true,
-        _type: 'ContentContext',
+        _type: LocationContextName.ContentContext,
         id: 'test',
       }),
     });
@@ -139,7 +140,7 @@ describe('tagLocation', () => {
           ? JSON.parse(taggingAttributesB[TaggingAttribute.context]).__instance_id
           : null,
         __location_context: true,
-        _type: 'OverlayContext',
+        _type: LocationContextName.OverlayContext,
         id: 'test',
       }),
     });
@@ -159,7 +160,7 @@ describe('tagLocation', () => {
           ? JSON.parse(taggingAttributesC[TaggingAttribute.context]).__instance_id
           : null,
         __location_context: true,
-        _type: 'ContentContext',
+        _type: LocationContextName.ContentContext,
         id: 'test',
       }),
       [TaggingAttribute.trackClicks]: 'false',
@@ -178,7 +179,7 @@ describe('tagLocation', () => {
           ? JSON.parse(taggingAttributesA[TaggingAttribute.context]).__instance_id
           : null,
         __location_context: true,
-        _type: 'ContentContext',
+        _type: LocationContextName.ContentContext,
         id: 'test',
       }),
     });
@@ -192,7 +193,7 @@ describe('tagLocation', () => {
           ? JSON.parse(taggingAttributesB[TaggingAttribute.context]).__instance_id
           : null,
         __location_context: true,
-        _type: 'ContentContext',
+        _type: LocationContextName.ContentContext,
         id: 'test',
       }),
     });
@@ -209,7 +210,7 @@ describe('tagLocation', () => {
         __instance_id: taggingAttributes ? JSON.parse(taggingAttributes[TaggingAttribute.context]).__instance_id : null,
         __location_context: true,
         __pressable_context: true,
-        _type: 'PressableContext',
+        _type: LocationContextName.PressableContext,
         id: 'test-button',
       }),
       [TaggingAttribute.trackClicks]: 'true',
@@ -226,7 +227,7 @@ describe('tagLocation', () => {
       [TaggingAttribute.context]: JSON.stringify({
         __instance_id: taggingAttributes ? JSON.parse(taggingAttributes[TaggingAttribute.context]).__instance_id : null,
         __location_context: true,
-        _type: 'ContentContext',
+        _type: LocationContextName.ContentContext,
         id: 'test-section',
       }),
     };
@@ -244,7 +245,7 @@ describe('tagLocation', () => {
       [TaggingAttribute.context]: JSON.stringify({
         __instance_id: taggingAttributes ? JSON.parse(taggingAttributes[TaggingAttribute.context]).__instance_id : null,
         __location_context: true,
-        _type: 'ExpandableContext',
+        _type: LocationContextName.ExpandableContext,
         id: 'test-expandable',
       }),
       [TaggingAttribute.trackVisibility]: '{"mode":"auto"}',
@@ -261,7 +262,7 @@ describe('tagLocation', () => {
       [TaggingAttribute.context]: JSON.stringify({
         __instance_id: taggingAttributes ? JSON.parse(taggingAttributes[TaggingAttribute.context]).__instance_id : null,
         __location_context: true,
-        _type: 'InputContext',
+        _type: LocationContextName.InputContext,
         id: 'test-input',
       }),
       [TaggingAttribute.trackBlurs]: 'true',
@@ -281,7 +282,7 @@ describe('tagLocation', () => {
         __instance_id: taggingAttributes ? JSON.parse(taggingAttributes[TaggingAttribute.context]).__instance_id : null,
         __location_context: true,
         __pressable_context: true,
-        _type: 'LinkContext',
+        _type: LocationContextName.LinkContext,
         id: 'link',
         href: '/test',
       }),
@@ -299,7 +300,7 @@ describe('tagLocation', () => {
       [TaggingAttribute.context]: JSON.stringify({
         __instance_id: taggingAttributes ? JSON.parse(taggingAttributes[TaggingAttribute.context]).__instance_id : null,
         __location_context: true,
-        _type: 'MediaPlayerContext',
+        _type: LocationContextName.MediaPlayerContext,
         id: 'test-media-player',
       }),
     };
@@ -315,7 +316,7 @@ describe('tagLocation', () => {
       [TaggingAttribute.context]: JSON.stringify({
         __instance_id: taggingAttributes ? JSON.parse(taggingAttributes[TaggingAttribute.context]).__instance_id : null,
         __location_context: true,
-        _type: 'NavigationContext',
+        _type: LocationContextName.NavigationContext,
         id: 'test-nav',
       }),
     };
@@ -331,7 +332,7 @@ describe('tagLocation', () => {
       [TaggingAttribute.context]: JSON.stringify({
         __instance_id: taggingAttributes ? JSON.parse(taggingAttributes[TaggingAttribute.context]).__instance_id : null,
         __location_context: true,
-        _type: 'OverlayContext',
+        _type: LocationContextName.OverlayContext,
         id: 'test-overlay',
       }),
       [TaggingAttribute.trackVisibility]: '{"mode":"auto"}',

--- a/tracker/trackers/browser/tests/tagLocationHelpers.test.ts
+++ b/tracker/trackers/browser/tests/tagLocationHelpers.test.ts
@@ -4,6 +4,7 @@
 
 import { matchUUID, MockConsoleImplementation } from '@objectiv/testing-tools';
 import {
+  LocationContextName,
   tagContent,
   tagExpandable,
   TaggingAttribute,
@@ -74,7 +75,7 @@ describe('tagLocationHelpers', () => {
         __instance_id: taggingAttributes ? JSON.parse(taggingAttributes[TaggingAttribute.context]).__instance_id : null,
         __location_context: true,
         __pressable_context: true,
-        _type: 'PressableContext',
+        _type: LocationContextName.PressableContext,
         id: 'test-button',
       }),
       [TaggingAttribute.trackClicks]: 'true',
@@ -91,7 +92,7 @@ describe('tagLocationHelpers', () => {
       [TaggingAttribute.context]: JSON.stringify({
         __instance_id: taggingAttributes ? JSON.parse(taggingAttributes[TaggingAttribute.context]).__instance_id : null,
         __location_context: true,
-        _type: 'ContentContext',
+        _type: LocationContextName.ContentContext,
         id: 'test-section',
       }),
     };
@@ -107,7 +108,7 @@ describe('tagLocationHelpers', () => {
       [TaggingAttribute.context]: JSON.stringify({
         __instance_id: taggingAttributes ? JSON.parse(taggingAttributes[TaggingAttribute.context]).__instance_id : null,
         __location_context: true,
-        _type: 'ExpandableContext',
+        _type: LocationContextName.ExpandableContext,
         id: 'test-expandable',
       }),
       [TaggingAttribute.trackVisibility]: '{"mode":"auto"}',
@@ -124,7 +125,7 @@ describe('tagLocationHelpers', () => {
       [TaggingAttribute.context]: JSON.stringify({
         __instance_id: taggingAttributes ? JSON.parse(taggingAttributes[TaggingAttribute.context]).__instance_id : null,
         __location_context: true,
-        _type: 'InputContext',
+        _type: LocationContextName.InputContext,
         id: 'test-input',
       }),
       [TaggingAttribute.trackBlurs]: 'true',
@@ -142,7 +143,7 @@ describe('tagLocationHelpers', () => {
         __instance_id: taggingAttributes ? JSON.parse(taggingAttributes[TaggingAttribute.context]).__instance_id : null,
         __location_context: true,
         __pressable_context: true,
-        _type: 'LinkContext',
+        _type: LocationContextName.LinkContext,
         id: 'link',
         href: '/test',
       }),
@@ -160,7 +161,7 @@ describe('tagLocationHelpers', () => {
       [TaggingAttribute.context]: JSON.stringify({
         __instance_id: taggingAttributes ? JSON.parse(taggingAttributes[TaggingAttribute.context]).__instance_id : null,
         __location_context: true,
-        _type: 'MediaPlayerContext',
+        _type: LocationContextName.MediaPlayerContext,
         id: 'test-media-player',
       }),
     };
@@ -176,7 +177,7 @@ describe('tagLocationHelpers', () => {
       [TaggingAttribute.context]: JSON.stringify({
         __instance_id: taggingAttributes ? JSON.parse(taggingAttributes[TaggingAttribute.context]).__instance_id : null,
         __location_context: true,
-        _type: 'NavigationContext',
+        _type: LocationContextName.NavigationContext,
         id: 'test-nav',
       }),
     };
@@ -192,7 +193,7 @@ describe('tagLocationHelpers', () => {
       [TaggingAttribute.context]: JSON.stringify({
         __instance_id: taggingAttributes ? JSON.parse(taggingAttributes[TaggingAttribute.context]).__instance_id : null,
         __location_context: true,
-        _type: 'OverlayContext',
+        _type: LocationContextName.OverlayContext,
         id: 'test-overlay',
       }),
       [TaggingAttribute.trackVisibility]: '{"mode":"auto"}',
@@ -209,7 +210,7 @@ describe('tagLocationHelpers', () => {
       [TaggingAttribute.context]: JSON.stringify({
         __instance_id: taggingAttributes ? JSON.parse(taggingAttributes[TaggingAttribute.context]).__instance_id : null,
         __location_context: true,
-        _type: 'RootLocationContext',
+        _type: LocationContextName.RootLocationContext,
         id: 'test-page',
       }),
     };

--- a/tracker/trackers/browser/tests/trackEvent.test.ts
+++ b/tracker/trackers/browser/tests/trackEvent.test.ts
@@ -5,6 +5,7 @@
 import { matchUUID, MockConsoleImplementation } from '@objectiv/testing-tools';
 import {
   generateUUID,
+  LocationContextName,
   makeApplicationLoadedEvent,
   makeContentContext,
   makeFailureEvent,
@@ -108,10 +109,10 @@ describe('trackEvent', () => {
         id: matchUUID,
         global_contexts: [],
         location_stack: [
-          expect.objectContaining({ _type: 'ContentContext', id: 'main' }),
-          expect.objectContaining({ _type: 'ContentContext', id: 'parent' }),
-          expect.objectContaining({ _type: 'ContentContext', id: 'child' }),
-          expect.objectContaining({ _type: 'PressableContext', id: 'button' }),
+          expect.objectContaining({ _type: LocationContextName.ContentContext, id: 'main' }),
+          expect.objectContaining({ _type: LocationContextName.ContentContext, id: 'parent' }),
+          expect.objectContaining({ _type: LocationContextName.ContentContext, id: 'child' }),
+          expect.objectContaining({ _type: LocationContextName.PressableContext, id: 'button' }),
         ],
       })
     );
@@ -125,7 +126,7 @@ describe('trackEvent', () => {
         _type: 'PressEvent',
         id: matchUUID,
         global_contexts: [],
-        location_stack: [expect.objectContaining({ _type: 'ContentContext', id: 'custom' })],
+        location_stack: [expect.objectContaining({ _type: LocationContextName.ContentContext, id: 'custom' })],
       })
     );
 
@@ -138,7 +139,7 @@ describe('trackEvent', () => {
         _type: 'PressEvent',
         id: matchUUID,
         global_contexts: [],
-        location_stack: [expect.objectContaining({ _type: 'ContentContext', id: 'custom' })],
+        location_stack: [expect.objectContaining({ _type: LocationContextName.ContentContext, id: 'custom' })],
       })
     );
   });
@@ -193,10 +194,10 @@ describe('trackEvent', () => {
       expect.objectContaining({
         ...makePressEvent(),
         location_stack: expect.arrayContaining([
-          expect.objectContaining({ _type: 'ContentContext', id: 'top' }),
-          expect.objectContaining({ _type: 'ContentContext', id: 'mid' }),
-          expect.objectContaining({ _type: 'ContentContext', id: 'div' }),
-          expect.objectContaining({ _type: 'ContentContext', id: 'test' }),
+          expect.objectContaining({ _type: LocationContextName.ContentContext, id: 'top' }),
+          expect.objectContaining({ _type: LocationContextName.ContentContext, id: 'mid' }),
+          expect.objectContaining({ _type: LocationContextName.ContentContext, id: 'div' }),
+          expect.objectContaining({ _type: LocationContextName.ContentContext, id: 'test' }),
         ]),
       })
     );
@@ -227,9 +228,9 @@ describe('trackEvent', () => {
       expect.objectContaining({
         ...makePressEvent(),
         location_stack: expect.arrayContaining([
-          expect.objectContaining({ _type: 'ContentContext', id: 'top' }),
-          expect.objectContaining({ _type: 'ContentContext', id: 'mid' }),
-          expect.objectContaining({ _type: 'ContentContext', id: 'div' }),
+          expect.objectContaining({ _type: LocationContextName.ContentContext, id: 'top' }),
+          expect.objectContaining({ _type: LocationContextName.ContentContext, id: 'mid' }),
+          expect.objectContaining({ _type: LocationContextName.ContentContext, id: 'div' }),
         ]),
       })
     );

--- a/tracker/trackers/browser/tests/trackNewElement.test.ts
+++ b/tracker/trackers/browser/tests/trackNewElement.test.ts
@@ -5,6 +5,7 @@
 import { matchUUID, MockConsoleImplementation } from '@objectiv/testing-tools';
 import {
   generateUUID,
+  LocationContextName,
   makeInputContext,
   makePressableContext,
   TrackerConsole,
@@ -106,7 +107,7 @@ describe('trackNewElement', () => {
         _type: 'VisibleEvent',
         id: matchUUID,
         global_contexts: [],
-        location_stack: [expect.objectContaining({ _type: 'ContentContext', id: 'test' })],
+        location_stack: [expect.objectContaining({ _type: LocationContextName.ContentContext, id: 'test' })],
       })
     );
   });

--- a/tracker/trackers/browser/tests/trackNewElements.test.ts
+++ b/tracker/trackers/browser/tests/trackNewElements.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { matchUUID, MockConsoleImplementation } from '@objectiv/testing-tools';
-import { generateUUID, TrackerConsole } from '@objectiv/tracker-core';
+import { generateUUID, LocationContextName, TrackerConsole } from '@objectiv/tracker-core';
 import {
   BrowserTracker,
   getTracker,
@@ -67,7 +67,7 @@ describe('trackNewElements', () => {
         _type: 'VisibleEvent',
         id: matchUUID,
         global_contexts: [],
-        location_stack: [expect.objectContaining({ _type: 'OverlayContext', id: 'child-div' })],
+        location_stack: [expect.objectContaining({ _type: LocationContextName.OverlayContext, id: 'child-div' })],
       })
     );
   });

--- a/tracker/trackers/browser/tests/trackRemovedElements.test.ts
+++ b/tracker/trackers/browser/tests/trackRemovedElements.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { matchUUID, MockConsoleImplementation } from '@objectiv/testing-tools';
-import { generateUUID, TrackerConsole } from '@objectiv/tracker-core';
+import { generateUUID, LocationContextName, TrackerConsole } from '@objectiv/tracker-core';
 import { BrowserTracker, getTracker, getTrackerRepository, makeTracker, TaggingAttribute } from '../src';
 import { trackRemovedElements } from '../src/mutationObserver/trackRemovedElements';
 import { makeTaggedElement } from './mocks/makeTaggedElement';
@@ -68,7 +68,7 @@ describe('trackRemovedElements', () => {
         _type: 'HiddenEvent',
         id: matchUUID,
         global_contexts: [],
-        location_stack: [expect.objectContaining({ _type: 'ContentContext', id: 'div' })],
+        location_stack: [expect.objectContaining({ _type: LocationContextName.ContentContext, id: 'div' })],
       })
     );
   });

--- a/tracker/trackers/react-native/tests/ReactNativeTracker.test.ts
+++ b/tracker/trackers/react-native/tests/ReactNativeTracker.test.ts
@@ -3,7 +3,13 @@
  */
 
 import { MockConsoleImplementation } from '@objectiv/testing-tools';
-import { TrackerConsole, TrackerEvent, TrackerQueue, TrackerTransportRetry } from '@objectiv/tracker-core';
+import {
+  GlobalContextName,
+  TrackerConsole,
+  TrackerEvent,
+  TrackerQueue,
+  TrackerTransportRetry,
+} from '@objectiv/tracker-core';
 import { DebugTransport } from '@objectiv/transport-debug';
 import { defaultFetchFunction, FetchTransport } from '@objectiv/transport-fetch';
 import fetchMock from 'jest-fetch-mock';
@@ -135,7 +141,7 @@ describe('ReactNativeTracker', () => {
       expect(trackedEvent.global_contexts).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            _type: 'ApplicationContext',
+            _type: GlobalContextName.ApplicationContext,
             id: 'app-id',
           }),
         ])

--- a/tracker/trackers/react-native/tests/TrackedButton.test.tsx
+++ b/tracker/trackers/react-native/tests/TrackedButton.test.tsx
@@ -3,7 +3,7 @@
  */
 
 import { MockConsoleImplementation, SpyTransport } from '@objectiv/testing-tools';
-import { TrackerConsole } from '@objectiv/tracker-core';
+import { LocationContextName, TrackerConsole } from '@objectiv/tracker-core';
 import { fireEvent, render } from '@testing-library/react-native';
 import React from 'react';
 import {
@@ -49,7 +49,7 @@ describe('TrackedButton', () => {
         _type: 'PressEvent',
         location_stack: expect.arrayContaining([
           expect.objectContaining({
-            _type: 'PressableContext',
+            _type: LocationContextName.PressableContext,
             id: 'trigger-event',
           }),
         ]),

--- a/tracker/trackers/react-native/tests/TrackedPressable.test.tsx
+++ b/tracker/trackers/react-native/tests/TrackedPressable.test.tsx
@@ -3,7 +3,7 @@
  */
 
 import { MockConsoleImplementation, SpyTransport } from '@objectiv/testing-tools';
-import { TrackerConsole } from '@objectiv/tracker-core';
+import { LocationContextName, TrackerConsole } from '@objectiv/tracker-core';
 import { fireEvent, render } from '@testing-library/react-native';
 import React from 'react';
 import {
@@ -49,7 +49,7 @@ describe('TrackedPressable', () => {
         _type: 'PressEvent',
         location_stack: expect.arrayContaining([
           expect.objectContaining({
-            _type: 'PressableContext',
+            _type: LocationContextName.PressableContext,
             id: 'trigger-event',
           }),
         ]),

--- a/tracker/trackers/react-native/tests/TrackedSwitch.test.tsx
+++ b/tracker/trackers/react-native/tests/TrackedSwitch.test.tsx
@@ -3,7 +3,7 @@
  */
 
 import { MockConsoleImplementation, SpyTransport } from '@objectiv/testing-tools';
-import { TrackerConsole } from '@objectiv/tracker-core';
+import { LocationContextName, TrackerConsole } from '@objectiv/tracker-core';
 import { fireEvent, render } from '@testing-library/react-native';
 import React from 'react';
 import {
@@ -49,7 +49,7 @@ describe('TrackedSwitch', () => {
         _type: 'InputChangeEvent',
         location_stack: expect.arrayContaining([
           expect.objectContaining({
-            _type: 'InputContext',
+            _type: LocationContextName.InputContext,
             id: 'test-switch',
           }),
         ]),

--- a/tracker/trackers/react-native/tests/TrackedText.test.tsx
+++ b/tracker/trackers/react-native/tests/TrackedText.test.tsx
@@ -3,7 +3,7 @@
  */
 
 import { MockConsoleImplementation, SpyTransport } from '@objectiv/testing-tools';
-import { TrackerConsole } from '@objectiv/tracker-core';
+import { LocationContextName, TrackerConsole } from '@objectiv/tracker-core';
 import { fireEvent, render } from '@testing-library/react-native';
 import React from 'react';
 import {
@@ -49,7 +49,7 @@ describe('TrackedText', () => {
         _type: 'PressEvent',
         location_stack: expect.arrayContaining([
           expect.objectContaining({
-            _type: 'PressableContext',
+            _type: LocationContextName.PressableContext,
             id: 'trigger-event',
           }),
         ]),

--- a/tracker/trackers/react-native/tests/TrackedTextInput.test.tsx
+++ b/tracker/trackers/react-native/tests/TrackedTextInput.test.tsx
@@ -3,7 +3,7 @@
  */
 
 import { MockConsoleImplementation, SpyTransport } from '@objectiv/testing-tools';
-import { TrackerConsole } from '@objectiv/tracker-core';
+import { LocationContextName, TrackerConsole } from '@objectiv/tracker-core';
 import { fireEvent, render } from '@testing-library/react-native';
 import React from 'react';
 import {
@@ -49,7 +49,7 @@ describe('TrackedTextInput', () => {
         _type: 'InputChangeEvent',
         location_stack: expect.arrayContaining([
           expect.objectContaining({
-            _type: 'InputContext',
+            _type: LocationContextName.InputContext,
             id: 'test-switch',
           }),
         ]),

--- a/tracker/trackers/react-native/tests/TrackedTouchableHighlight.test.tsx
+++ b/tracker/trackers/react-native/tests/TrackedTouchableHighlight.test.tsx
@@ -3,7 +3,7 @@
  */
 
 import { MockConsoleImplementation, SpyTransport } from '@objectiv/testing-tools';
-import { TrackerConsole } from '@objectiv/tracker-core';
+import { LocationContextName, TrackerConsole } from '@objectiv/tracker-core';
 import { fireEvent, render } from '@testing-library/react-native';
 import React from 'react';
 import { Text } from 'react-native';
@@ -54,7 +54,7 @@ describe('TrackedTouchableHighlight', () => {
         _type: 'PressEvent',
         location_stack: expect.arrayContaining([
           expect.objectContaining({
-            _type: 'PressableContext',
+            _type: LocationContextName.PressableContext,
             id: 'trigger-event',
           }),
         ]),

--- a/tracker/trackers/react-native/tests/TrackedTouchableNativeFeedback.test.tsx
+++ b/tracker/trackers/react-native/tests/TrackedTouchableNativeFeedback.test.tsx
@@ -3,7 +3,7 @@
  */
 
 import { MockConsoleImplementation, SpyTransport } from '@objectiv/testing-tools';
-import { TrackerConsole } from '@objectiv/tracker-core';
+import { LocationContextName, TrackerConsole } from '@objectiv/tracker-core';
 import { fireEvent, render } from '@testing-library/react-native';
 import React from 'react';
 import { Text } from 'react-native';
@@ -54,7 +54,7 @@ describe('TrackedTouchableNativeFeedback', () => {
         _type: 'PressEvent',
         location_stack: expect.arrayContaining([
           expect.objectContaining({
-            _type: 'PressableContext',
+            _type: LocationContextName.PressableContext,
             id: 'trigger-event',
           }),
         ]),

--- a/tracker/trackers/react-native/tests/TrackedTouchableOpacity.test.tsx
+++ b/tracker/trackers/react-native/tests/TrackedTouchableOpacity.test.tsx
@@ -3,7 +3,7 @@
  */
 
 import { MockConsoleImplementation, SpyTransport } from '@objectiv/testing-tools';
-import { TrackerConsole } from '@objectiv/tracker-core';
+import { LocationContextName, TrackerConsole } from '@objectiv/tracker-core';
 import { fireEvent, render } from '@testing-library/react-native';
 import React from 'react';
 import { Text } from 'react-native';
@@ -54,7 +54,7 @@ describe('TrackedTouchableOpacity', () => {
         _type: 'PressEvent',
         location_stack: expect.arrayContaining([
           expect.objectContaining({
-            _type: 'PressableContext',
+            _type: LocationContextName.PressableContext,
             id: 'trigger-event',
           }),
         ]),

--- a/tracker/trackers/react-native/tests/TrackedTouchableWithoutFeedback.test.tsx
+++ b/tracker/trackers/react-native/tests/TrackedTouchableWithoutFeedback.test.tsx
@@ -3,7 +3,7 @@
  */
 
 import { MockConsoleImplementation, SpyTransport } from '@objectiv/testing-tools';
-import { TrackerConsole } from '@objectiv/tracker-core';
+import { LocationContextName, TrackerConsole } from '@objectiv/tracker-core';
 import { fireEvent, render } from '@testing-library/react-native';
 import React from 'react';
 import { Text } from 'react-native';
@@ -54,7 +54,7 @@ describe('TrackedTouchableWithoutFeedback', () => {
         _type: 'PressEvent',
         location_stack: expect.arrayContaining([
           expect.objectContaining({
-            _type: 'PressableContext',
+            _type: LocationContextName.PressableContext,
             id: 'trigger-event',
           }),
         ]),

--- a/tracker/trackers/react/tests/ReactTracker.test.ts
+++ b/tracker/trackers/react/tests/ReactTracker.test.ts
@@ -4,6 +4,7 @@
 
 import { MockConsoleImplementation } from '@objectiv/testing-tools';
 import {
+  GlobalContextName,
   TrackerConsole,
   TrackerEvent,
   TrackerQueue,
@@ -157,15 +158,15 @@ describe('ReactTracker', () => {
       expect(trackedEvent.global_contexts).toEqual(
         expect.arrayContaining([
           expect.objectContaining({
-            _type: 'HttpContext',
+            _type: GlobalContextName.HttpContext,
             id: 'http_context',
           }),
           expect.objectContaining({
-            _type: 'ApplicationContext',
+            _type: GlobalContextName.ApplicationContext,
             id: 'app-id',
           }),
           expect.objectContaining({
-            _type: 'PathContext',
+            _type: GlobalContextName.PathContext,
             id: 'http://localhost/',
           }),
         ])

--- a/tracker/trackers/react/tests/TrackedAnchor.test.tsx
+++ b/tracker/trackers/react/tests/TrackedAnchor.test.tsx
@@ -3,7 +3,7 @@
  */
 
 import { MockConsoleImplementation, SpyTransport } from '@objectiv/testing-tools';
-import { TrackerConsole } from '@objectiv/tracker-core';
+import { LocationContextName, TrackerConsole } from '@objectiv/tracker-core';
 import { fireEvent, getByText, render } from '@testing-library/react';
 import React from 'react';
 import { LocationTree, ObjectivProvider, ReactTracker, TrackedAnchor } from '../src';
@@ -41,7 +41,7 @@ describe('TrackedAnchor', () => {
         _type: 'PressEvent',
         location_stack: expect.arrayContaining([
           expect.objectContaining({
-            _type: 'LinkContext',
+            _type: LocationContextName.LinkContext,
             id: 'trigger-event',
             href: '/some-url',
           }),

--- a/tracker/trackers/react/tests/TrackedButton.test.tsx
+++ b/tracker/trackers/react/tests/TrackedButton.test.tsx
@@ -3,7 +3,7 @@
  */
 
 import { MockConsoleImplementation, SpyTransport } from '@objectiv/testing-tools';
-import { TrackerConsole } from '@objectiv/tracker-core';
+import { LocationContextName, TrackerConsole } from '@objectiv/tracker-core';
 import { fireEvent, getByText, render } from '@testing-library/react';
 import React from 'react';
 import { LocationTree, ObjectivProvider, ReactTracker, TrackedButton } from '../src';
@@ -41,7 +41,7 @@ describe('TrackedButton', () => {
         _type: 'PressEvent',
         location_stack: expect.arrayContaining([
           expect.objectContaining({
-            _type: 'PressableContext',
+            _type: LocationContextName.PressableContext,
             id: 'trigger-event',
           }),
         ]),

--- a/tracker/trackers/react/tests/TrackedContentContext.test.tsx
+++ b/tracker/trackers/react/tests/TrackedContentContext.test.tsx
@@ -3,7 +3,7 @@
  */
 
 import { MockConsoleImplementation, SpyTransport } from '@objectiv/testing-tools';
-import { TrackerConsole } from '@objectiv/tracker-core';
+import { LocationContextName, TrackerConsole } from '@objectiv/tracker-core';
 import { fireEvent, getByText, render, screen } from '@testing-library/react';
 import React, { createRef } from 'react';
 import { LocationTree, ObjectivProvider, ReactTracker, TrackedContentContext, usePressEventTracker } from '../src';
@@ -53,7 +53,7 @@ describe('TrackedContentContext', () => {
         _type: 'PressEvent',
         location_stack: expect.arrayContaining([
           expect.objectContaining({
-            _type: 'ContentContext',
+            _type: LocationContextName.ContentContext,
             id: 'content-id',
           }),
         ]),

--- a/tracker/trackers/react/tests/TrackedDiv.test.tsx
+++ b/tracker/trackers/react/tests/TrackedDiv.test.tsx
@@ -3,7 +3,7 @@
  */
 
 import { MockConsoleImplementation, SpyTransport } from '@objectiv/testing-tools';
-import { TrackerConsole } from '@objectiv/tracker-core';
+import { LocationContextName, TrackerConsole } from '@objectiv/tracker-core';
 import { fireEvent, getByText, render } from '@testing-library/react';
 import React from 'react';
 import { LocationTree, ObjectivProvider, ReactTracker, TrackedDiv, usePressEventTracker } from '../src';
@@ -48,7 +48,7 @@ describe('TrackedDiv', () => {
         _type: 'PressEvent',
         location_stack: expect.arrayContaining([
           expect.objectContaining({
-            _type: 'ContentContext',
+            _type: LocationContextName.ContentContext,
             id: 'div-id',
           }),
         ]),

--- a/tracker/trackers/react/tests/TrackedExpandableContext.test.tsx
+++ b/tracker/trackers/react/tests/TrackedExpandableContext.test.tsx
@@ -3,7 +3,7 @@
  */
 
 import { MockConsoleImplementation, SpyTransport } from '@objectiv/testing-tools';
-import { TrackerConsole } from '@objectiv/tracker-core';
+import { LocationContextName, TrackerConsole } from '@objectiv/tracker-core';
 import { fireEvent, getByText, render, screen } from '@testing-library/react';
 import React, { createRef } from 'react';
 import { LocationTree, ObjectivProvider, ReactTracker, TrackedExpandableContext, usePressEventTracker } from '../src';
@@ -53,7 +53,7 @@ describe('TrackedExpandableContext', () => {
         _type: 'PressEvent',
         location_stack: expect.arrayContaining([
           expect.objectContaining({
-            _type: 'ExpandableContext',
+            _type: LocationContextName.ExpandableContext,
             id: 'expandable-id',
           }),
         ]),

--- a/tracker/trackers/react/tests/TrackedFooter.test.tsx
+++ b/tracker/trackers/react/tests/TrackedFooter.test.tsx
@@ -3,7 +3,7 @@
  */
 
 import { MockConsoleImplementation, SpyTransport } from '@objectiv/testing-tools';
-import { TrackerConsole } from '@objectiv/tracker-core';
+import { LocationContextName, TrackerConsole } from '@objectiv/tracker-core';
 import { fireEvent, getByText, render } from '@testing-library/react';
 import React from 'react';
 import { LocationTree, ObjectivProvider, ReactTracker, TrackedFooter, usePressEventTracker } from '../src';
@@ -48,7 +48,7 @@ describe('TrackedFooter', () => {
         _type: 'PressEvent',
         location_stack: expect.arrayContaining([
           expect.objectContaining({
-            _type: 'ContentContext',
+            _type: LocationContextName.ContentContext,
             id: 'footer',
           }),
         ]),
@@ -84,7 +84,7 @@ describe('TrackedFooter', () => {
         _type: 'PressEvent',
         location_stack: expect.arrayContaining([
           expect.objectContaining({
-            _type: 'ContentContext',
+            _type: LocationContextName.ContentContext,
             id: 'secondary-footer',
           }),
         ]),

--- a/tracker/trackers/react/tests/TrackedHeader.test.tsx
+++ b/tracker/trackers/react/tests/TrackedHeader.test.tsx
@@ -3,7 +3,7 @@
  */
 
 import { MockConsoleImplementation, SpyTransport } from '@objectiv/testing-tools';
-import { TrackerConsole } from '@objectiv/tracker-core';
+import { LocationContextName, TrackerConsole } from '@objectiv/tracker-core';
 import { fireEvent, getByText, render } from '@testing-library/react';
 import React from 'react';
 import { LocationTree, ObjectivProvider, ReactTracker, TrackedHeader, usePressEventTracker } from '../src';
@@ -48,7 +48,7 @@ describe('TrackedHeader', () => {
         _type: 'PressEvent',
         location_stack: expect.arrayContaining([
           expect.objectContaining({
-            _type: 'ContentContext',
+            _type: LocationContextName.ContentContext,
             id: 'header',
           }),
         ]),
@@ -84,7 +84,7 @@ describe('TrackedHeader', () => {
         _type: 'PressEvent',
         location_stack: expect.arrayContaining([
           expect.objectContaining({
-            _type: 'ContentContext',
+            _type: LocationContextName.ContentContext,
             id: 'secondary-header',
           }),
         ]),

--- a/tracker/trackers/react/tests/TrackedInput.test.tsx
+++ b/tracker/trackers/react/tests/TrackedInput.test.tsx
@@ -3,7 +3,7 @@
  */
 
 import { MockConsoleImplementation, SpyTransport } from '@objectiv/testing-tools';
-import { TrackerConsole } from '@objectiv/tracker-core';
+import { LocationContextName, TrackerConsole } from '@objectiv/tracker-core';
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
 import { LocationTree, ObjectivProvider, ReactTracker, TrackedInput } from '../src';
@@ -41,7 +41,7 @@ describe('TrackedInputContext', () => {
         _type: 'InputChangeEvent',
         location_stack: expect.arrayContaining([
           expect.objectContaining({
-            _type: 'InputContext',
+            _type: LocationContextName.InputContext,
             id: 'input-id',
           }),
         ]),

--- a/tracker/trackers/react/tests/TrackedInputContext.test.tsx
+++ b/tracker/trackers/react/tests/TrackedInputContext.test.tsx
@@ -3,7 +3,7 @@
  */
 
 import { MockConsoleImplementation, SpyTransport } from '@objectiv/testing-tools';
-import { TrackerConsole } from '@objectiv/tracker-core';
+import { LocationContextName, TrackerConsole } from '@objectiv/tracker-core';
 import { fireEvent, render, screen } from '@testing-library/react';
 import React, { createRef } from 'react';
 import { LocationTree, ObjectivProvider, ReactTracker, TrackedInputContext } from '../src';
@@ -94,7 +94,7 @@ describe('TrackedInputContext', () => {
         _type: 'InputChangeEvent',
         location_stack: expect.arrayContaining([
           expect.objectContaining({
-            _type: 'InputContext',
+            _type: LocationContextName.InputContext,
             id: 'input-id',
           }),
         ]),

--- a/tracker/trackers/react/tests/TrackedLinkContext.test.tsx
+++ b/tracker/trackers/react/tests/TrackedLinkContext.test.tsx
@@ -3,7 +3,7 @@
  */
 
 import { MockConsoleImplementation, SpyTransport } from '@objectiv/testing-tools';
-import { TrackerConsole } from '@objectiv/tracker-core';
+import { LocationContextName, TrackerConsole } from '@objectiv/tracker-core';
 import { fireEvent, getByText, render, screen, waitFor } from '@testing-library/react';
 import React, { createRef } from 'react';
 import {
@@ -57,7 +57,7 @@ describe('TrackedLinkContext', () => {
         _type: 'PressEvent',
         location_stack: expect.arrayContaining([
           expect.objectContaining({
-            _type: 'LinkContext',
+            _type: LocationContextName.LinkContext,
             id: 'link-id',
           }),
         ]),
@@ -250,7 +250,7 @@ describe('TrackedLinkContext', () => {
         _type: 'PressEvent',
         location_stack: expect.arrayContaining([
           expect.objectContaining({
-            _type: 'LinkContext',
+            _type: LocationContextName.LinkContext,
             id: 'press-me',
           }),
         ]),

--- a/tracker/trackers/react/tests/TrackedMain.test.tsx
+++ b/tracker/trackers/react/tests/TrackedMain.test.tsx
@@ -3,7 +3,7 @@
  */
 
 import { MockConsoleImplementation, SpyTransport } from '@objectiv/testing-tools';
-import { TrackerConsole } from '@objectiv/tracker-core';
+import { LocationContextName, TrackerConsole } from '@objectiv/tracker-core';
 import { fireEvent, getByText, render } from '@testing-library/react';
 import React from 'react';
 import { LocationTree, ObjectivProvider, ReactTracker, TrackedMain, usePressEventTracker } from '../src';
@@ -48,7 +48,7 @@ describe('TrackedMain', () => {
         _type: 'PressEvent',
         location_stack: expect.arrayContaining([
           expect.objectContaining({
-            _type: 'ContentContext',
+            _type: LocationContextName.ContentContext,
             id: 'main',
           }),
         ]),
@@ -84,7 +84,7 @@ describe('TrackedMain', () => {
         _type: 'PressEvent',
         location_stack: expect.arrayContaining([
           expect.objectContaining({
-            _type: 'ContentContext',
+            _type: LocationContextName.ContentContext,
             id: 'hero-element',
           }),
         ]),

--- a/tracker/trackers/react/tests/TrackedMediaPlayerContext.test.tsx
+++ b/tracker/trackers/react/tests/TrackedMediaPlayerContext.test.tsx
@@ -3,7 +3,7 @@
  */
 
 import { MockConsoleImplementation, SpyTransport } from '@objectiv/testing-tools';
-import { TrackerConsole } from '@objectiv/tracker-core';
+import { LocationContextName, TrackerConsole } from '@objectiv/tracker-core';
 import { fireEvent, getByText, render, screen } from '@testing-library/react';
 import React, { createRef } from 'react';
 import { LocationTree, ObjectivProvider, ReactTracker, TrackedMediaPlayerContext, usePressEventTracker } from '../src';
@@ -53,7 +53,7 @@ describe('TrackedMediaPlayerContext', () => {
         _type: 'PressEvent',
         location_stack: expect.arrayContaining([
           expect.objectContaining({
-            _type: 'MediaPlayerContext',
+            _type: LocationContextName.MediaPlayerContext,
             id: 'video-id',
           }),
         ]),

--- a/tracker/trackers/react/tests/TrackedNav.test.tsx
+++ b/tracker/trackers/react/tests/TrackedNav.test.tsx
@@ -3,7 +3,7 @@
  */
 
 import { MockConsoleImplementation, SpyTransport } from '@objectiv/testing-tools';
-import { TrackerConsole } from '@objectiv/tracker-core';
+import { LocationContextName, TrackerConsole } from '@objectiv/tracker-core';
 import { fireEvent, getByText, render } from '@testing-library/react';
 import React from 'react';
 import { LocationTree, ObjectivProvider, ReactTracker, TrackedNav, usePressEventTracker } from '../src';
@@ -48,7 +48,7 @@ describe('TrackedNav', () => {
         _type: 'PressEvent',
         location_stack: expect.arrayContaining([
           expect.objectContaining({
-            _type: 'NavigationContext',
+            _type: LocationContextName.NavigationContext,
             id: 'nav',
           }),
         ]),
@@ -84,7 +84,7 @@ describe('TrackedNav', () => {
         _type: 'PressEvent',
         location_stack: expect.arrayContaining([
           expect.objectContaining({
-            _type: 'NavigationContext',
+            _type: LocationContextName.NavigationContext,
             id: 'sidebar-nav',
           }),
         ]),

--- a/tracker/trackers/react/tests/TrackedNavigationContext.test.tsx
+++ b/tracker/trackers/react/tests/TrackedNavigationContext.test.tsx
@@ -3,7 +3,7 @@
  */
 
 import { MockConsoleImplementation, SpyTransport } from '@objectiv/testing-tools';
-import { TrackerConsole } from '@objectiv/tracker-core';
+import { LocationContextName, TrackerConsole } from '@objectiv/tracker-core';
 import { fireEvent, getByText, render, screen } from '@testing-library/react';
 import React, { createRef } from 'react';
 import { LocationTree, ObjectivProvider, ReactTracker, TrackedNavigationContext, usePressEventTracker } from '../src';
@@ -53,7 +53,7 @@ describe('TrackedNavigationContext', () => {
         _type: 'PressEvent',
         location_stack: expect.arrayContaining([
           expect.objectContaining({
-            _type: 'NavigationContext',
+            _type: LocationContextName.NavigationContext,
             id: 'nav-id',
           }),
         ]),

--- a/tracker/trackers/react/tests/TrackedOverlayContext.test.tsx
+++ b/tracker/trackers/react/tests/TrackedOverlayContext.test.tsx
@@ -3,7 +3,7 @@
  */
 
 import { MockConsoleImplementation, SpyTransport } from '@objectiv/testing-tools';
-import { TrackerConsole } from '@objectiv/tracker-core';
+import { LocationContextName, TrackerConsole } from '@objectiv/tracker-core';
 import { fireEvent, getByText, render, screen } from '@testing-library/react';
 import React, { createRef } from 'react';
 import { LocationTree, ObjectivProvider, ReactTracker, TrackedOverlayContext, usePressEventTracker } from '../src';
@@ -53,7 +53,7 @@ describe('TrackedOverlayContext', () => {
         _type: 'PressEvent',
         location_stack: expect.arrayContaining([
           expect.objectContaining({
-            _type: 'OverlayContext',
+            _type: LocationContextName.OverlayContext,
             id: 'modal-id',
           }),
         ]),

--- a/tracker/trackers/react/tests/TrackedPressableContext.test.tsx
+++ b/tracker/trackers/react/tests/TrackedPressableContext.test.tsx
@@ -3,7 +3,7 @@
  */
 
 import { MockConsoleImplementation, SpyTransport } from '@objectiv/testing-tools';
-import { TrackerConsole } from '@objectiv/tracker-core';
+import { LocationContextName, TrackerConsole } from '@objectiv/tracker-core';
 import { fireEvent, getByText, render, screen, waitFor } from '@testing-library/react';
 import React, { createRef } from 'react';
 import {
@@ -56,7 +56,7 @@ describe('TrackedPressableContext', () => {
         _type: 'PressEvent',
         location_stack: expect.arrayContaining([
           expect.objectContaining({
-            _type: 'PressableContext',
+            _type: LocationContextName.PressableContext,
             id: 'pressable-id',
           }),
         ]),

--- a/tracker/trackers/react/tests/TrackedRootLocationContext.test.tsx
+++ b/tracker/trackers/react/tests/TrackedRootLocationContext.test.tsx
@@ -3,7 +3,7 @@
  */
 
 import { MockConsoleImplementation, SpyTransport } from '@objectiv/testing-tools';
-import { TrackerConsole } from '@objectiv/tracker-core';
+import { LocationContextName, TrackerConsole } from '@objectiv/tracker-core';
 import { fireEvent, getByText, render, screen } from '@testing-library/react';
 import React, { createRef } from 'react';
 import { LocationTree, ObjectivProvider, ReactTracker, TrackedRootLocationContext, usePressEventTracker } from '../src';
@@ -53,7 +53,7 @@ describe('TrackedRootLocationContext', () => {
         _type: 'PressEvent',
         location_stack: expect.arrayContaining([
           expect.objectContaining({
-            _type: 'RootLocationContext',
+            _type: LocationContextName.RootLocationContext,
             id: 'root-id',
           }),
         ]),

--- a/tracker/trackers/react/tests/TrackedSection.test.tsx
+++ b/tracker/trackers/react/tests/TrackedSection.test.tsx
@@ -3,7 +3,7 @@
  */
 
 import { MockConsoleImplementation, SpyTransport } from '@objectiv/testing-tools';
-import { TrackerConsole } from '@objectiv/tracker-core';
+import { LocationContextName, TrackerConsole } from '@objectiv/tracker-core';
 import { fireEvent, getByText, render } from '@testing-library/react';
 import React from 'react';
 import { LocationTree, ObjectivProvider, ReactTracker, TrackedSection, usePressEventTracker } from '../src';

--- a/tracker/trackers/react/tests/TrackedSection.test.tsx
+++ b/tracker/trackers/react/tests/TrackedSection.test.tsx
@@ -48,7 +48,7 @@ describe('TrackedSection', () => {
         _type: 'PressEvent',
         location_stack: expect.arrayContaining([
           expect.objectContaining({
-            _type: 'ContentContext',
+            _type: LocationContextName.ContentContext,
             id: 'section-id',
           }),
         ]),


### PR DESCRIPTION
This PR removes (~~almost **~~) all hardcoded context name literals in the codebase and replaces them with automatically generated enums. 

Not only this makes it easier to maintain these literals, as they are defined now in a single place. It introduces a way of retrieving a list of Location Contexts or Global Context names, which is very useful for unit testing and will be used for error generation as well in a future PR.

Changes:
- The generator scripts creates now a new ContextNames.ts file in Core Tracker 
  - The file contains LocationContextName and GlobalContextName enums
  - Modified the prettify:generated script in the core tracker package.json to process this new file
- Updated all unit tests across the codebase to use the new Enums
- Updated all hardcoded Context name literals in the monorepo source code to use the new Enums

~~** A couple of guard functions in Browser Tracker still use literals, but that's a fair case~~

**Notes**
We could implement a similar generation for Event names, but since there's no use-case for those, as in: no auto generated tests, nor error messages, I've delayed it. Also, event names are entirely automated by the factories and there's no API requiring to specify them, so it's unlikely developers would need an enum for them.

Nonetheless, it will be easy to add if needed.
