### PR TITLE
Parallelization using pytest-xdist, engine dialect singleton

### DIFF
--- a/bach/Makefile
+++ b/bach/Makefile
@@ -12,7 +12,7 @@ tests-bigquery:
 # against Postgres
 	mypy --check-untyped-defs bach sql_models
 	pycodestyle bach sql_models
-	pytest --big-query tests/unit tests/functional tests/
+	pytest -n 4 --dist loadgroup --big-query tests/unit tests/functional tests/
 
 
 tests-all:
@@ -21,4 +21,4 @@ tests-all:
 # run against Postgres
 	mypy --check-untyped-defs bach sql_models
 	pycodestyle bach sql_models
-	pytest --all tests/unit tests/functional tests/
+	pytest -n 4 --dist loadgroup --all tests/unit tests/functional tests/

--- a/bach/pytest.ini
+++ b/bach/pytest.ini
@@ -4,7 +4,7 @@
 # Pytest commandline parameters that we always set
 # --strict-markers: Fail if a test function has an unknown marker (e.g. is decorated with @pytest.mark.not_existing)
 # -W error::DeprecationWarning: Raise an error if we encounter a DeprecationWarning
-addopts = --strict-markers -W error::DeprecationWarning -nauto
+addopts = --strict-markers -W error::DeprecationWarning
 
 # markers defines our custom markers
 markers =

--- a/bach/pytest.ini
+++ b/bach/pytest.ini
@@ -4,7 +4,7 @@
 # Pytest commandline parameters that we always set
 # --strict-markers: Fail if a test function has an unknown marker (e.g. is decorated with @pytest.mark.not_existing)
 # -W error::DeprecationWarning: Raise an error if we encounter a DeprecationWarning
-addopts = --strict-markers -W error::DeprecationWarning
+addopts = --strict-markers -W error::DeprecationWarning -nauto
 
 # markers defines our custom markers
 markers =

--- a/bach/requirements-dev.txt
+++ b/bach/requirements-dev.txt
@@ -1,4 +1,5 @@
 pytest==6.2.5
+pytest-xdist==2.5.0
 mypy==0.910
 pycodestyle==2.7.0
 ipython==7.31.1

--- a/bach/tests/conftest.py
+++ b/bach/tests/conftest.py
@@ -8,7 +8,6 @@ specified on the commandline, then it will (also) get a BigQuery dialect or engi
 
 Additionally we define a 'pg_engine' fixture here that always return a Postgres engine.
 """
-import logging
 import os
 from typing import NamedTuple, Optional, Dict
 
@@ -62,11 +61,8 @@ def pytest_sessionstart(session: Session):
     # https://pytest-xdist.readthedocs.io/en/latest/distribution.html
     # https://docs.pytest.org/en/6.2.x/reference.html#pytest.hookspec.pytest_sessionstart
     load_engine = True
-    if (
-        ('tests/unit' in session.config.args and len(session.config.args) == 1)
-        or session.config.getoption('markexpr') == 'db_independent'
-    ):
-        # create dialect only if we are running unit tests or db independent tests
+    if session.config.args == ['tests/unit']:
+        # create dialect, only if we are running unit tests
         load_engine = False
 
     if session.config.getoption("all"):
@@ -84,16 +80,7 @@ def pytest_generate_tests(metafunc: Metafunc):
 
     # This function will automatically be called by pytest while it is creating the list of tests to run,
     # see: https://docs.pytest.org/en/6.2.x/reference.html#collection-hooks
-    if metafunc.config.getoption("all"):
-        engine_dialects = [
-            ENGINE_DIALECTS['postgres'],
-            ENGINE_DIALECTS['bigquery']
-        ]
-    elif metafunc.config.getoption("big_query"):
-        engine_dialects = [ENGINE_DIALECTS['bigquery']]
-    else:  # default option, don't even check if --postgres is set
-        engine_dialects = [ENGINE_DIALECTS['postgres']]
-
+    engine_dialects = list(ENGINE_DIALECTS.values())
     if 'dialect' in metafunc.fixturenames:
         dialects = [ed.dialect for ed in engine_dialects]
         metafunc.parametrize("dialect", dialects)

--- a/bach/tests/functional/bach/test_df_from.py
+++ b/bach/tests/functional/bach/test_df_from.py
@@ -6,6 +6,7 @@ tests for:
  * DataFrame.from_model()
 
 """
+import pytest
 from sqlalchemy.engine import Engine
 
 from bach import DataFrame
@@ -26,6 +27,7 @@ def _create_test_table(engine: Engine, table_name: str):
         conn.execute(sql)
 
 
+@pytest.mark.xdist_group(name="test_table_writers")
 def test_from_table_basic(engine):
     table_name = 'test_df_from_table'
     _create_test_table(engine, table_name)
@@ -49,6 +51,7 @@ def test_from_table_basic(engine):
     assert df == df_all_dtypes
 
 
+@pytest.mark.xdist_group(name="test_table_writers")
 def test_from_model_basic(pg_engine):
     # This is essentially the same test as test_from_table_basic(), but tests creating the dataframe with
     # from_model instead of from_table
@@ -76,6 +79,7 @@ def test_from_model_basic(pg_engine):
     assert df == df_all_dtypes
 
 
+@pytest.mark.xdist_group(name="test_table_writers")
 def test_from_table_column_ordering(engine):
     # Create a Dataframe in which the index is not the first column in the table.
     table_name = 'test_df_from_table'
@@ -99,6 +103,7 @@ def test_from_table_column_ordering(engine):
     assert df == df_all_dtypes
 
 
+@pytest.mark.xdist_group(name="test_table_writers")
 def test_from_model_column_ordering(pg_engine):
     # This is essentially the same test as test_from_table_model_ordering(), but tests creating the dataframe with
     # from_model instead of from_table

--- a/bach/tests/functional/bach/test_df_savepoints.py
+++ b/bach/tests/functional/bach/test_df_savepoints.py
@@ -9,6 +9,7 @@ from tests.functional.bach.test_data_and_utils import get_bt_with_test_data, ass
 from tests.functional.bach.test_savepoints import remove_created_db_objects
 
 
+@pytest.mark.xdist_group(name="db_writers")
 def test_savepoint_materialization():
     df = get_bt_with_test_data()
 

--- a/bach/tests/functional/bach/test_savepoints.py
+++ b/bach/tests/functional/bach/test_savepoints.py
@@ -38,6 +38,7 @@ def test_add_savepoint_double():
         sps.add_savepoint('second', df, Materialization.QUERY)
 
 
+@pytest.mark.xdist_group(name="db_writers")
 def test_write_to_db_queries_only():
     df = get_bt_with_test_data()
     engine = df.engine
@@ -66,6 +67,7 @@ def test_write_to_db_queries_only():
     )
 
 
+@pytest.mark.xdist_group(name="db_writers")
 def test_write_to_db_create_objects():
     dialect = PGDialect()  # TODO: BigQuery
     df = get_bt_with_test_data()


### PR DESCRIPTION
Decided to use [pytest-xdist ](https://pytest-xdist.readthedocs.io/en/latest/distribution.html) since it was the most efficient one that I tried. 

Currently it uses [-n auto](https://pytest-xdist.readthedocs.io/en/latest/distribution.html#:~:text=pass%20-n%20auto%20to%20use%20as%20many%20processes%20as%20your%20computer%20has%20cpu%20cores.%20this%20can%20lead%20to%20considerable%20speed%20ups%2C%20especially%20if%20your%20test%20suite%20takes%20a%20noticeable%20amount%20of%20time.), so it creates workers based on the number of CPU cores available. 

**Results of Parallelization w/ 4 workers**
![image](https://user-images.githubusercontent.com/8259208/164022126-5b6b341d-ebcb-43e6-82b5-7387c5f3b385.png)

**Results wo/ Parallelization**
![image](https://user-images.githubusercontent.com/8259208/164024167-a1bfd5d8-a0f0-4394-9d94-f670641cf06c.png)
