### PR TITLE
Bach BQ timestamp Series

### DIFF
--- a/bach/bach/dataframe.py
+++ b/bach/bach/dataframe.py
@@ -5,7 +5,7 @@ from copy import copy
 
 from typing import (
     List, Set, Union, Dict, Any, Optional, Tuple,
-    cast, NamedTuple, TYPE_CHECKING, Callable, Hashable, Sequence, overload,
+    cast, NamedTuple, TYPE_CHECKING, Callable, Hashable, Sequence, overload, Mapping,
 )
 
 import numpy
@@ -17,7 +17,7 @@ from bach.from_database import get_dtypes_from_table, get_dtypes_from_model
 from bach.sql_model import BachSqlModel, CurrentNodeSqlModel, get_variable_values_sql
 from bach.types import get_series_type_from_dtype, AllSupportedLiteralTypes
 from bach.utils import escape_parameter_characters
-from sql_models.constants import NotSet, not_set
+from sql_models.constants import NotSet, not_set, DBDialect
 from sql_models.graph_operations import update_placeholders_in_graph, get_all_placeholders
 from sql_models.model import SqlModel, Materialization, CustomSqlModelBuilder, RefPath
 
@@ -773,13 +773,13 @@ class DataFrame:
         self,
         engine: Optional[Engine] = None,
         base_node: Optional[BachSqlModel] = None,
-        index: Optional[Dict[str, 'Series']] = None,
-        series: Optional[Dict[str, 'Series']] = None,
+        index: Optional[Mapping[str, 'Series']] = None,
+        series: Optional[Mapping[str, 'Series']] = None,
         group_by: Optional[Union['GroupBy', NotSet]] = not_set,
         order_by: Optional[List[SortColumn]] = None,
         variables: Optional[Dict[DtypeNamePair, Hashable]] = None,
-        index_dtypes: Optional[Dict[str, str]] = None,
-        series_dtypes: Optional[Dict[str, str]] = None,
+        index_dtypes: Optional[Mapping[str, str]] = None,
+        series_dtypes: Optional[Mapping[str, str]] = None,
         single_value: bool = False,
         savepoints: Optional['Savepoints'] = None,
         **kwargs
@@ -1845,18 +1845,31 @@ class DataFrame:
         .. note::
             This function queries the database.
         """
-        with self.engine.connect() as conn:
-            sql = self.view_sql(limit=limit)
-            dtype = {name: series.dtype_to_pandas for name, series in self.all_series.items()
-                     if series.dtype_to_pandas is not None}
+        db_dialect = DBDialect.from_engine(self.engine)
 
+        sql = self.view_sql(limit=limit)
+
+        series_name_to_dtype = {}
+        for series in self.all_series.values():
+            pandas_info = series.to_pandas_info.get(db_dialect)
+            if pandas_info is not None:
+                series_name_to_dtype[series.name] = pandas_info.dtype
+
+        with self.engine.connect() as conn:
             # read_sql_query expects a parameterized query, so we need to escape the parameter characters
             sql = escape_parameter_characters(conn, sql)
-            pandas_df = pandas.read_sql_query(sql, conn).astype(dtype)
+            pandas_df = pandas.read_sql_query(sql, conn, dtype=series_name_to_dtype)
 
-            if len(self._index):
-                return pandas_df.set_index(list(self._index.keys()))
-            return pandas_df
+        # Post-process any columns if needed. e.g. in BigQuery we represent UUIDs as text, so we convert
+        # the strings that the query gives us into UUID objects
+        for name, series in self.data.items():
+            to_pandas_info = series.to_pandas_info.get(db_dialect)
+            if to_pandas_info is not None and to_pandas_info.function is not None:
+                pandas_df[name] = pandas_df[name].apply(to_pandas_info.function)
+
+        if self.index:
+            pandas_df = pandas_df.set_index(list(self.index.keys()))
+        return pandas_df
 
     def head(self, n: int = 5) -> pandas.DataFrame:
         """

--- a/bach/bach/types.py
+++ b/bach/bach/types.py
@@ -26,7 +26,7 @@ AllSupportedLiteralTypes = Union[
     bool,
     None,
     str,
-    datetime.date, datetime.time, datetime.datetime, datetime.timedelta, numpy.timedelta64,
+    datetime.date, datetime.time, datetime.datetime, numpy.datetime64, datetime.timedelta, numpy.timedelta64,
     UUID,
     dict,
     list
@@ -150,6 +150,7 @@ class TypeRegistry:
         self._register_value_klass(datetime.date, SeriesDate)
         self._register_value_klass(datetime.time, SeriesTime)
         self._register_value_klass(datetime.datetime, SeriesTimestamp)
+        self._register_value_klass(numpy.datetime64, SeriesTimestamp)
         self._register_value_klass(datetime.timedelta, SeriesTimedelta)
         self._register_value_klass(numpy.timedelta64, SeriesTimedelta)
         self._register_value_klass(UUID, SeriesUuid)

--- a/bach/tests/functional/bach/test_data_and_utils.py
+++ b/bach/tests/functional/bach/test_data_and_utils.py
@@ -291,14 +291,10 @@ def _get_to_pandas_data(df: DataFrame):
     pdf = df.to_pandas()
     # Convert pdf to the same format as _get_view_sql_data gives
     column_names = list(pdf.index.names) + list(pdf.columns)
-    pdf.reset_index()
+    pdf = pdf.reset_index()
     db_values = []
-    for index_row, value_row in zip(pdf.index.values.tolist(), pdf.values.tolist()):
-        if isinstance(index_row, tuple):
-            index_row = list(index_row)
-        elif not isinstance(index_row, list):
-            index_row = [index_row]
-        db_values.append(index_row + value_row)
+    for value_row in pdf.to_numpy().tolist():
+        db_values.append(value_row)
     print(db_values)
     return column_names, db_values
 

--- a/bach/tests/functional/bach/test_df_astype.py
+++ b/bach/tests/functional/bach/test_df_astype.py
@@ -135,6 +135,7 @@ def test_astype_to_timestamp(engine):
     bt = bt.astype('timestamp')
     assert_equals_data(
         bt,
+        use_to_pandas=True,
         expected_columns=['_index_skating_order', 'd', 's'],
         expected_data=[
             [1, datetime(2022, 3, 31, 0, 0), datetime(2022, 2, 15, 13, 37)],

--- a/bach/tests/functional/bach/test_df_from.py
+++ b/bach/tests/functional/bach/test_df_from.py
@@ -19,7 +19,7 @@ def _create_test_table(engine: Engine, table_name: str):
               f'create table {table_name}(a bigint, b text, c double precision, d date, e timestamp); '
     elif is_bigquery(engine):
         sql = f'drop table if exists {table_name}; ' \
-              f'create table {table_name}(a int64, b string, c float64, d date, e datetime); '
+              f'create table {table_name}(a int64, b string, c float64, d date, e timestamp); '
     else:
         raise Exception('Incomplete tests')
     with engine.connect() as conn:

--- a/bach/tests/functional/bach/test_df_from_pandas.py
+++ b/bach/tests/functional/bach/test_df_from_pandas.py
@@ -1,7 +1,10 @@
 """
 Copyright 2021 Objectiv B.V.
 """
+from typing import List, Any
+
 import pytest
+from sqlalchemy.engine import Dialect
 
 from bach import DataFrame
 from sql_models.util import is_bigquery, is_postgres
@@ -325,14 +328,16 @@ def test_from_pandas_columns_w_nulls(engine) -> None:
         convert_objects=True,
         materialization='cte'
     )
+    expected_data = [
+        [0, 'a', None, None],
+        [1, None, 1, pd.Timestamp("1940-04-25")],
+        [2, 'c', 2, None],
+    ]
+    expected_data = _convert_expected_data_timestamps(engine.dialect, expected_data)
     assert_equals_data(
         result,
         expected_columns=['_index_0', 'a', 'b', 'c'],
-        expected_data=[
-            [0, 'a', None, None],
-            [1, None, 1, pd.Timestamp("1940-04-25")],
-            [2, 'c', 2, None],
-        ],
+        expected_data=expected_data
     )
 
     pdf['d'] = pdf['d'].astype(str)
@@ -342,12 +347,24 @@ def test_from_pandas_columns_w_nulls(engine) -> None:
         convert_objects=True,
         materialization='cte'
     )
+
+    expected_data = [
+        [0, 'a', None, None, 'None'],
+        [1, None, 1, pd.Timestamp("1940-04-25"), 'None'],
+        [2, 'c', 2, None, 'None'],
+    ]
+    expected_data = _convert_expected_data_timestamps(engine.dialect, expected_data)
     assert_equals_data(
         result,
         expected_columns=['_index_0', 'a', 'b', 'c', 'd'],
-        expected_data=[
-            [0, 'a', None, None, 'None'],
-            [1, None, 1, pd.Timestamp("1940-04-25"), 'None'],
-            [2, 'c', 2, None, 'None'],
-        ],
+        expected_data=expected_data
     )
+
+
+def _convert_expected_data_timestamps(dialect: Dialect, data: List[List[Any]]) -> List[List[Any]]:
+    """ Set UTC timezone on datetime objects if dialect is BigQuery. """
+    def set_tz(value):
+        if not isinstance(value, (datetime.datetime, datetime.date)) or not is_bigquery(dialect):
+            return value
+        return value.replace(tzinfo=datetime.timezone.utc)
+    return [[set_tz(cell) for cell in row] for row in data]

--- a/bach/tests/functional/bach/test_df_setitem.py
+++ b/bach/tests/functional/bach/test_df_setitem.py
@@ -2,7 +2,6 @@
 Copyright 2021 Objectiv B.V.
 """
 import datetime
-import math
 from typing import Type, Any, List
 import pytest
 
@@ -11,10 +10,9 @@ import numpy as np
 from bach import SeriesInt64, SeriesString, SeriesFloat64, SeriesDate, SeriesTimestamp, \
     SeriesTime, SeriesTimedelta, Series, \
     SeriesJsonb, SeriesBoolean
-from sql_models.util import is_postgres
 from tests.conftest import get_postgres_engine_dialect
 from tests.functional.bach.test_data_and_utils import get_bt_with_test_data, assert_postgres_type, \
-    assert_equals_data, CITIES_INDEX_AND_COLUMNS, get_bt_with_railway_data, get_df_with_test_data, run_query, \
+    assert_equals_data, CITIES_INDEX_AND_COLUMNS, get_bt_with_railway_data, get_df_with_test_data, \
     get_df_with_railway_data
 
 
@@ -32,6 +30,7 @@ def check_set_const(engine, constants: List[Any], expected_series: Type[Series],
 
     assert_equals_data(
         bt,
+        use_to_pandas=True,
         expected_columns=[
             '_index_skating_order',  # index
             'skating_order', 'city', 'municipality', 'inhabitants', 'founding',  # original columns
@@ -88,7 +87,9 @@ def test_set_const_date(engine):
 
 def test_set_const_datetime(engine):
     constants = [
-        datetime.datetime.now()
+        datetime.datetime.now(),
+        datetime.datetime(1999, 1, 15, 13, 37, 1, 23),
+        np.datetime64('2022-01-01 12:34:56.7800'),
     ]
     check_set_const(engine, constants, SeriesTimestamp, 'timestamp without time zone')
 

--- a/bach/tests/functional/bach/test_series_timestamp.py
+++ b/bach/tests/functional/bach/test_series_timestamp.py
@@ -4,42 +4,50 @@ Copyright 2021 Objectiv B.V.
 import datetime
 from typing import List, Any
 
+import numpy
 import pytest
 from sqlalchemy.engine import Engine
 
-from sql_models.util import is_bigquery
-from tests.functional.bach.test_data_and_utils import assert_equals_data, get_bt_with_food_data, \
-    get_bt_with_test_data, get_df_with_test_data, get_df_with_food_data
+from tests.functional.bach.test_data_and_utils import assert_equals_data, get_df_with_test_data,\
+    get_df_with_food_data
 
 
-def test_timestamp_data():
-    mt = get_bt_with_food_data()[['moment']]
-    from datetime import datetime
+def test_timestamp_data(engine):
+    mt = get_df_with_food_data(engine)[['moment']]
+    mt['const1'] = datetime.datetime(1999, 12, 31, 23, 59, 59, 999999)
+    mt['const2'] = numpy.datetime64('2022-02-03 12:34:56.789', 'ns')
+    mt['const3'] = numpy.datetime64('2022-02-03 12:34:56.789123', 'ns')
+    mt['const4'] = numpy.datetime64('2022-02-03 12:34:56.789123456', 'ns')
+    expected_constants = [
+        datetime.datetime(1999, 12, 31, 23, 59, 59, 999999),
+        datetime.datetime(2022,  2,  3, 12, 34, 56, 789000),
+        datetime.datetime(2022,  2,  3, 12, 34, 56, 789123),
+        datetime.datetime(2022,  2,  3, 12, 34, 56, 789123),
+    ]
     assert_equals_data(
         mt,
-        expected_columns=['_index_skating_order', 'moment'],
+        # raw sqlAlchemy will give datetime with timezone UTC on some Databases, because of the used db types
+        # so set use_to_pandas=True to do our data normalization in the DataFrame.to_pandas() function
+        use_to_pandas=True,
+        expected_columns=['_index_skating_order', 'moment', 'const1', 'const2', 'const3', 'const4'],
         expected_data=[
-            [1, datetime(2021, 5, 3, 11, 28, 36, 388000)],
-            [2, datetime(2021, 5, 4, 23, 28, 36, 388000)],
-            [4, datetime(2022, 5, 3, 14, 13, 13, 388000)]
+            [1, datetime.datetime(2021, 5, 3, 11, 28, 36, 388000)] + expected_constants,
+            [2, datetime.datetime(2021, 5, 4, 23, 28, 36, 388000)] + expected_constants,
+            [4, datetime.datetime(2022, 5, 3, 14, 13, 13, 388000)] + expected_constants
         ]
     )
 
 
-def test_to_pandas():
-    bt = get_bt_with_test_data()
+def test_to_pandas(engine):
+    bt = get_df_with_test_data(engine)
     bt['dt'] = datetime.datetime(2021, 5, 3, 11, 28, 36, 388000)
-    bt[['dt']].to_pandas()
-    from numpy import array
-    # TODO, this is not great, but at least it does not error when imported into pandas,
-    # and it looks good over there
-    assert bt[['dt']].to_numpy()[0] == [array(['2021-05-03T11:28:36.388000000'], dtype='datetime64[ns]')]
+    result_pdf = bt.to_pandas()
+    assert result_pdf['dt'].to_numpy()[0] == [numpy.array(['2021-05-03T11:28:36.388000000'], dtype='datetime64[ns]')]
 
 
 @pytest.mark.parametrize("asstring", [True, False])
-def test_timestamp_comparator(asstring: bool):
-    # TODO: BigQuery
-    mt = get_bt_with_food_data()[['moment']]
+def test_timestamp_comparator(engine, asstring: bool):
+    mt = get_df_with_food_data(engine)[['moment']]
     from datetime import datetime
     dt = datetime(2021, 5, 3, 11, 28, 36, 388000)
 
@@ -49,6 +57,9 @@ def test_timestamp_comparator(asstring: bool):
     result = mt[mt['moment'] == dt]
     assert_equals_data(
         result,
+        # raw sqlAlchemy will give datetime with timezone UTC on some Databases, because of the used db types
+        # so set use_to_pandas=True to do our data normalization in the DataFrame.to_pandas() function
+        use_to_pandas=True,
         expected_columns=['_index_skating_order', 'moment'],
         expected_data=[
             [1, datetime(2021, 5, 3, 11, 28, 36, 388000)]
@@ -57,6 +68,7 @@ def test_timestamp_comparator(asstring: bool):
 
     assert_equals_data(
         mt[mt['moment'] >= dt],
+        use_to_pandas=True,
         expected_columns=['_index_skating_order', 'moment'],
         expected_data=[
             [1, datetime(2021, 5, 3, 11, 28, 36, 388000)],
@@ -67,6 +79,7 @@ def test_timestamp_comparator(asstring: bool):
 
     assert_equals_data(
         mt[mt['moment'] > dt],
+        use_to_pandas=True,
         expected_columns=['_index_skating_order', 'moment'],
         expected_data=[
             [2, datetime(2021, 5, 4, 23, 28, 36, 388000)],
@@ -80,6 +93,7 @@ def test_timestamp_comparator(asstring: bool):
 
     assert_equals_data(
         mt[mt['moment'] <= dt],
+        use_to_pandas=True,
         expected_columns=['_index_skating_order', 'moment'],
         expected_data=[
             [1, datetime(2021, 5, 3, 11, 28, 36, 388000)],
@@ -90,6 +104,7 @@ def test_timestamp_comparator(asstring: bool):
 
     assert_equals_data(
         mt[mt['moment'] < dt],
+        use_to_pandas=True,
         expected_columns=['_index_skating_order', 'moment'],
         expected_data=[
             [1, datetime(2021, 5, 3, 11, 28, 36, 388000)],

--- a/bach/tests/unit/bach/test_series_timestamp.py
+++ b/bach/tests/unit/bach/test_series_timestamp.py
@@ -1,0 +1,70 @@
+"""
+Copyright 2022 Objectiv B.V.
+"""
+import datetime
+
+import numpy
+import pytest
+
+from bach import SeriesTimestamp
+from bach.expression import Expression
+
+
+def test_supported_value_to_literal(dialect):
+    def assert_call(value, expected_token_value: str):
+        result = SeriesTimestamp.supported_value_to_literal(dialect, value)
+        assert result == Expression.string_value(expected_token_value)
+
+    # ## datetime
+    assert_call(datetime.datetime(1999, 1, 15, 13, 37, 1, 23), '1999-01-15 13:37:01.000023')
+    assert_call(datetime.datetime(1969, 12, 31, 1, 2, 3, 00),  '1969-12-31 01:02:03.000000')
+    assert_call(datetime.datetime(2050, 7, 7, 7, 7, 7, 7),     '2050-07-07 07:07:07.000007')
+
+    # TODO: datetime with timezone set
+
+    # ## date
+    assert_call(datetime.date(1999, 1, 15),  '1999-01-15 00:00:00.000000')
+    assert_call(datetime.date(1969, 12, 31), '1969-12-31 00:00:00.000000')
+    assert_call(datetime.date(2050, 7, 7),   '2050-07-07 00:00:00.000000')
+
+    # ## np.datetime64
+    assert_call(numpy.datetime64('2022-01-01 12:34:56.7800'),                   '2022-01-01 12:34:56.780000')
+    assert_call(numpy.datetime64('2022-01-03'),                                 '2022-01-03 00:00:00.000000')
+    assert_call(numpy.datetime64('1995-03-31 01:33:37.123456'),                 '1995-03-31 01:33:37.123456')
+    # datetime64 objects with differing precision. We only support up to milliseconds
+    assert_call(numpy.datetime64('1995-03-31 01:33:37.1234567'),                '1995-03-31 01:33:37.123456')
+    assert_call(numpy.datetime64('1995-03-31 01:33:37.123456789012', 's'),      '1995-03-31 01:33:37.000000')
+    assert_call(numpy.datetime64('1995-03-31 01:33:37.123456789012', 'ms'),     '1995-03-31 01:33:37.123000')
+    assert_call(numpy.datetime64('1995-03-31 01:33:37.123456789012', 'us'),     '1995-03-31 01:33:37.123456')
+    assert_call(numpy.datetime64('1995-03-31 01:33:37.123456789012', 'ns'),     '1995-03-31 01:33:37.123456')
+    # rounding can be a bit unexpected because of limited precision, therefore we always truncate excess precision
+    assert_call(numpy.datetime64('1995-03-31 01:33:37.123456001', 'ns'),        '1995-03-31 01:33:37.123456')
+    assert_call(numpy.datetime64('1995-03-31 01:33:37.123456499', 'ns'),        '1995-03-31 01:33:37.123456')
+    assert_call(numpy.datetime64('1995-03-31 01:33:37.123456500', 'ns'),        '1995-03-31 01:33:37.123456')
+    assert_call(numpy.datetime64('1995-03-31 01:33:37.123456569', 'ns'),        '1995-03-31 01:33:37.123456')
+    assert_call(numpy.datetime64('1995-03-31 01:33:37.123456999', 'ns'),        '1995-03-31 01:33:37.123456')
+
+    # Special case: Not-a-Time will be represented as NULL
+    nat = numpy.datetime64('NaT')
+    assert SeriesTimestamp.supported_value_to_literal(dialect, nat) == Expression.construct('NULL')
+
+    # ## strings
+    assert_call('2022-01-01 12:34:56.7800',    '2022-01-01 12:34:56.780000')
+    assert_call('1995-03-31 01:33:37.123456',  '1995-03-31 01:33:37.123456')
+    assert_call('1999-12-31 23:59:59',         '1999-12-31 23:59:59.000000')
+    assert_call('1999-12-31 23:59',            '1999-12-31 23:59:00.000000')
+    assert_call('2022-01-03',                  '2022-01-03 00:00:00.000000')
+
+    # ## None
+    assert SeriesTimestamp.supported_value_to_literal(dialect, None) == Expression.construct('NULL')
+
+
+def test_supported_value_to_literal_str_non_happy_path(dialect):
+    with pytest.raises(ValueError, match='Not a valid timestamp string literal'):
+        SeriesTimestamp.supported_value_to_literal(dialect, '2022-01-03 aa:bb')
+
+    with pytest.raises(ValueError, match='Not a valid timestamp string literal'):
+        SeriesTimestamp.supported_value_to_literal(dialect, '01/03/99 12:13:00')
+
+    with pytest.raises(ValueError, match='Not a valid timestamp string literal'):
+        SeriesTimestamp.supported_value_to_literal(dialect, '01/03/99 12:13:00')


### PR DESCRIPTION
Changes:
* Use TIMESTAMP instead of DATETIME on BigQuery
  *  This seems more consistent. And this matches the column type we have in our test db
* Be able to not just set a dtype but also a post-processing function per Series type. Which we then use in `DataFrame.to_pandas()`
* More tests
* Support `numpy.datetime64` literals. We already sort of used this in some tests, but it worked halfish. Now with real tests