### PR TITLE
Fix link to open model hub in User Intent docs

### DIFF
--- a/bach/docs/source/user_intent.rst
+++ b/bach/docs/source/user_intent.rst
@@ -48,7 +48,7 @@ The root_location context in the location_stack uniquely represents the top-leve
 
 Exploring session duration
 --------------------------
-The average `session_duration` model from the :ref:`open model hub <modelhub_intro>` is another good pointer to explore first for user intent.
+The average `session_duration` model from the `open model hub </docs/modeling/>`_ is another good pointer to explore first for user intent.
 
 .. code-block:: python
 


### PR DESCRIPTION
Uses an absolute URL as a workaround for now. Might revisit this later for a proper fix.