### PR TITLE
`Series.mode` support for BigQuery

### DIFF
--- a/bach/bach/series/series.py
+++ b/bach/bach/series/series.py
@@ -22,6 +22,7 @@ from bach.sql_model import BachSqlModel
 from bach.types import value_to_dtype, DtypeOrAlias, AllSupportedLiteralTypes
 from bach.utils import is_valid_column_name
 from sql_models.constants import NotSet, not_set, DBDialect
+from sql_models.util import is_bigquery
 
 if TYPE_CHECKING:
     from bach.partitioning import GroupBy, Window
@@ -1311,9 +1312,16 @@ class Series(ABC):
         :param skipna: only ``skipna=True`` supported. This means NULL values are ignored.
         :returns: a new Series with the aggregation applied
         """
+        agg_expr = f'mode() within group (order by {{}})'
+        if is_bigquery(self.engine):
+            # BigQuery has no aggregate function for mode, therefore we use
+            # APPROX_TOP_COUNT which return an approximation of the exact result
+            # https://cloud.google.com/bigquery/docs/reference/standard-sql/approximate_aggregate_functions
+            agg_expr = f'approx_top_count({{}}, 1)[offset(0)].value'
+
         return self._derived_agg_func(
             partition=partition,
-            expression=AggregateFunctionExpression.construct(f'mode() within group (order by {{}})', self),
+            expression=AggregateFunctionExpression.construct(agg_expr, self),
             skipna=skipna
         )
 

--- a/bach/bach/series/series.py
+++ b/bach/bach/series/series.py
@@ -1311,6 +1311,14 @@ class Series(ABC):
         :param partition: The partition or window to apply
         :param skipna: only ``skipna=True`` supported. This means NULL values are ignored.
         :returns: a new Series with the aggregation applied
+
+        ..note::
+            BigQuery has no support for aggregation function ``MODE``, therefore ``APPROX_TOP_COUNT``
+            approximate aggregate function is used instead. Which means that an approximate result will
+            be produced instead of exact results.
+
+            For more information:
+            https://cloud.google.com/bigquery/docs/reference/standard-sql/approximate_aggregate_functions#approx_top_count
         """
         agg_expr = f'mode() within group (order by {{}})'
         if is_bigquery(self.engine):

--- a/bach/tests/functional/bach/test_data_and_utils.py
+++ b/bach/tests/functional/bach/test_data_and_utils.py
@@ -6,11 +6,12 @@ Utilities and a very simple dataset for testing Bach DataFrames.
 This file does not contain any test, but having the file's name start with `test_` makes pytest treat it
 as a test file. This makes pytest rewrite the asserts to give clearer errors.
 """
+import datetime
 from decimal import Decimal
 from typing import List, Union, Type, Dict, Any
 
 import sqlalchemy
-from sqlalchemy.engine import ResultProxy, Engine
+from sqlalchemy.engine import ResultProxy, Engine, Dialect
 
 from bach import DataFrame, Series
 from bach.types import get_series_type_from_db_dtype
@@ -344,3 +345,12 @@ def assert_postgres_type(
         assert db_type == expected_db_type
     series_type = get_series_type_from_db_dtype(DBDialect.POSTGRES, db_type)
     assert series_type == expected_series_type
+
+
+def convert_expected_data_timestamps(dialect: Dialect, data: List[List[Any]]) -> List[List[Any]]:
+    """ Set UTC timezone on datetime objects if dialect is BigQuery. """
+    def set_tz(value):
+        if not isinstance(value, (datetime.datetime, datetime.date)) or not is_bigquery(dialect):
+            return value
+        return value.replace(tzinfo=datetime.timezone.utc)
+    return [[set_tz(cell) for cell in row] for row in data]

--- a/bach/tests/functional/bach/test_df_from_pandas.py
+++ b/bach/tests/functional/bach/test_df_from_pandas.py
@@ -1,15 +1,12 @@
 """
 Copyright 2021 Objectiv B.V.
 """
-from typing import List, Any
-
 import pytest
-from sqlalchemy.engine import Dialect
 
 from bach import DataFrame
 from sql_models.util import is_bigquery, is_postgres
 from tests.functional.bach.test_data_and_utils import TEST_DATA_CITIES, CITIES_COLUMNS, \
-    assert_equals_data
+    assert_equals_data, convert_expected_data_timestamps
 import datetime
 from uuid import UUID
 import pandas as pd
@@ -333,7 +330,7 @@ def test_from_pandas_columns_w_nulls(engine) -> None:
         [1, None, 1, pd.Timestamp("1940-04-25")],
         [2, 'c', 2, None],
     ]
-    expected_data = _convert_expected_data_timestamps(engine.dialect, expected_data)
+    expected_data = convert_expected_data_timestamps(engine.dialect, expected_data)
     assert_equals_data(
         result,
         expected_columns=['_index_0', 'a', 'b', 'c'],
@@ -353,18 +350,10 @@ def test_from_pandas_columns_w_nulls(engine) -> None:
         [1, None, 1, pd.Timestamp("1940-04-25"), 'None'],
         [2, 'c', 2, None, 'None'],
     ]
-    expected_data = _convert_expected_data_timestamps(engine.dialect, expected_data)
+    expected_data = convert_expected_data_timestamps(engine.dialect, expected_data)
     assert_equals_data(
         result,
         expected_columns=['_index_0', 'a', 'b', 'c', 'd'],
         expected_data=expected_data
     )
 
-
-def _convert_expected_data_timestamps(dialect: Dialect, data: List[List[Any]]) -> List[List[Any]]:
-    """ Set UTC timezone on datetime objects if dialect is BigQuery. """
-    def set_tz(value):
-        if not isinstance(value, (datetime.datetime, datetime.date)) or not is_bigquery(dialect):
-            return value
-        return value.replace(tzinfo=datetime.timezone.utc)
-    return [[set_tz(cell) for cell in row] for row in data]


### PR DESCRIPTION
`DescribeOperation` is dependent on `Series.mode`, but MODE aggregate function is not supported by BigQuery. Therefore, decided to use APPROX_TOP_COUNT, which yields an approximate result.

Create another issue in order to revisit this, since we should have an implementation that returns the exact value as Pandas and PG does. https://github.com/objectiv/objectiv-analytics/issues/673. Also, had some problems when all values are unique, BQ will return the last value from the list (sadly, cannot change sort behavior for this function)