### PR TITLE
Add CLA workflow

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -18,7 +18,7 @@ jobs:
           path-to-signatures: '.github/cla/cla_signatures.json'
           path-to-document: 'https://objectiv.io/cla/'
           branch: 'main'
-          allowlist: dependabot,jansenbob,hendrik-obj,ivarpruijn,KathiaBarahona,borft,afroald,sdirosa,thijs-obj,thomashusken,jansentom,vincenthoogsteder
+          allowlist: dependabot,jansenbob,hendrik-obj,ivarpruijn,KathiaBarahona,borft,afroald,sdirosa,thijs-obj,jansentom,vincenthoogsteder
           lock-pullrequest-aftermerge: true
           signed-commit-message: '$contributorName has signed the CLA in #$pullRequestNo'
           custom-allsigned-prcomment: 'All contributors have signed the CLA.'

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -18,7 +18,7 @@ jobs:
           path-to-signatures: '.github/cla/cla_signatures.json'
           path-to-document: 'https://objectiv.io/cla/'
           branch: 'main'
-          allowlist: dependabot
+          allowlist: dependabot,jansenbob,hendrik-obj,ivarpruijn,KathiaBarahona,borft,afroald,sdirosa,thijs-obj,thomashusken,jansentom,vincenthoogsteder
           lock-pullrequest-aftermerge: true
           signed-commit-message: '$contributorName has signed the CLA in #$pullRequestNo'
           custom-allsigned-prcomment: 'All contributors have signed the CLA.'

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -18,7 +18,7 @@ jobs:
           path-to-signatures: '.github/cla/cla_signatures.json'
           path-to-document: 'https://objectiv.io/cla/'
           branch: 'main'
-          allowlist: dependabot,jansenbob,hendrik-obj,ivarpruijn,KathiaBarahona,borft,afroald,sdirosa,thijs-obj,jansentom,vincenthoogsteder
+          allowlist: dependabot,jansenbob,hendrik-obj,ivarpruijn,KathiaBarahona,borft,afroald,sdirosa,thijs-obj,jansentom,vpapikya,vincenthoogsteder
           lock-pullrequest-aftermerge: true
           signed-commit-message: '$contributorName has signed the CLA in #$pullRequestNo'
           custom-allsigned-prcomment: 'All contributors have signed the CLA.'

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,27 @@
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened,closed,synchronize]
+
+jobs:
+  CLAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: cla-assistant/github-action@v2.1.3-beta
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN : ${{ secrets.CLA_ACCESS_TOKEN }}
+        with:
+          path-to-signatures: '.github/cla/cla_signatures.json'
+          path-to-document: 'https://objectiv.io/cla/'
+          branch: 'main'
+          allowlist: dependabot
+          lock-pullrequest-aftermerge: true
+          signed-commit-message: '$contributorName has signed the CLA in #$pullRequestNo'
+          custom-allsigned-prcomment: 'All contributors have signed the CLA.'
+          create-file-commit-message: 'Creating file for storing CLA signatures'
+          custom-notsigned-prcomment: '<br/>Thank you for your contribution, we really appreciate it. Like many open-source projects, we ask that $you sign our [Contributor License Agreement (CLA)](https://testing.objectiv.io/cla/) before we can accept your contribution. Save this URL or store it as a PDF for later reference.<br /><br />You can sign the CLA by just posting the comment below in this PR.<br/>'
+          custom-pr-sign-comment: 'I have read the CLA Document and I hereby sign the CLA'


### PR DESCRIPTION
Adds a GH Action workflow to run the [CLA Assistant bot](https://github.com/marketplace/actions/cla-assistant-lite) for new pull requests.