### PR TITLE
Use unprotected branch for CLA signatures

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           path-to-signatures: '.github/cla/cla_signatures.json'
           path-to-document: 'https://objectiv.io/cla/'
-          branch: 'main'
+          branch: 'cla-signatures'
           allowlist: dependabot,jansenbob,hendrik-obj,ivarpruijn,KathiaBarahona,borft,afroald,sdirosa,thijs-obj,jansentom,vpapikya,vincenthoogsteder
           lock-pullrequest-aftermerge: true
           signed-commit-message: '$contributorName has signed the CLA in #$pullRequestNo'


### PR DESCRIPTION
`main` is protected, so the bot fails on it. This will use a new `cla-signatures` branch that's unprotected.