### PR TITLE
Port contest improvements from bach-bq-array-struct branch

### DIFF
--- a/bach/Makefile
+++ b/bach/Makefile
@@ -12,7 +12,7 @@ tests-bigquery:
 # against Postgres
 	mypy --check-untyped-defs bach sql_models
 	pycodestyle bach sql_models
-	pytest -n 4 --dist loadgroup --big-query tests/unit tests/functional tests/
+	pytest -n 8 --dist loadgroup --big-query tests/unit tests/functional tests/
 
 
 tests-all:
@@ -21,4 +21,4 @@ tests-all:
 # run against Postgres
 	mypy --check-untyped-defs bach sql_models
 	pycodestyle bach sql_models
-	pytest -n 4 --dist loadgroup --all tests/unit tests/functional tests/
+	pytest -n 8 --dist loadgroup --all tests/unit tests/functional tests/

--- a/bach/tests/conftest.py
+++ b/bach/tests/conftest.py
@@ -1,23 +1,48 @@
 """
 Copyright 2022 Objectiv B.V.
 
+### Fixtures
 There is some pytest 'magic' here that automatically fills out the 'engine' and 'dialect' parameters for
 test functions that have either of those.
 By default such a test function will get a Postgres dialect or engine. But if --big-query or --all is
-specified on the commandline, then it will (also) get a BigQuery dialect or engine.
+specified on the commandline, then it will (also) get a BigQuery dialect or engine. For specific
+tests, it is possible to disable postgres or bigquery testing, see 'marks' section below.
 
-Additionally we define a 'pg_engine' fixture here that always return a Postgres engine.
+Additionally we define a 'pg_engine' fixture here that always return a Postgres engine. This fixture should
+not be used for new functions tho! After fully implementing BigQuery it will be removed.
+
+### Marks and Test Categorization
+A lot of functionality needs to be tested for multiple databases. The 'engine' and 'dialects' fixtures
+mentioned above help with that. Additionally we have some marks (`@pytest.mark.<type>`) to make it explicit
+which databases we expect tests to run against.
+
+We broadly want 5 categories of tests:
+* unit-test: These don't interact with a database
+  * unit-tests that are tested with multiple database dialects (1)
+  * unit-tests that are database-dialect independent (2)
+* functional-tests: These interact with a database
+  *  functional-tests that run against all supported databases (3)
+  *  functional-tests that run against all supported databases except Postgres (4)
+  *  functional-tests that run against all supported databases except BigQuery (5)
+
+1 and 3 are the default for tests. These either get 'engine' or 'dialect' as fixture and run against all
+databases. Category 2 are tests that test generic code that is not geared to a specific database.
+Category 4 and 5 are for functionality that we explicitly not support on some databases.
+
+Category 2, 4, and 5 are the exception, these need to be marked with the `db_independent`, `skip_postgres`,
+or `skip_bigquery` marks.
 """
 import os
-from typing import NamedTuple, Optional, Dict
+from enum import Enum
+from typing import Dict
 
 import pytest
 from _pytest.main import Session
 from _pytest.python import Metafunc, Function
 from _pytest.config.argparsing import Parser
-import sqlalchemy
 from sqlalchemy import create_engine
-from sqlalchemy.engine import Engine, Dialect
+from sqlalchemy.engine import Engine
+
 
 DB_PG_TEST_URL = os.environ.get('OBJ_DB_PG_TEST_URL', 'postgresql://objectiv:@localhost:5432/objectiv')
 DB_BQ_TEST_URL = os.environ.get('OBJ_DB_BQ_TEST_URL', 'bigquery://objectiv-snowplow-test-2/bach_test')
@@ -27,9 +52,23 @@ DB_BQ_CREDENTIALS_PATH = os.environ.get(
 )
 
 
+MARK_DB_INDEPENDENT = 'db_independent'
+MARK_SKIP_POSTGRES = 'skip_postgres'
+MARK_SKIP_BIGQUERY = 'skip_bigquery'
+
+
+class DB(Enum):
+    POSTGRES = 'postgres'
+    BIGQUERY = 'bigquery'
+
+
+_ENGINE_CACHE: Dict[DB, Engine] = {}
+
+
 @pytest.fixture()
 def pg_engine() -> Engine:
-    return sqlalchemy.create_engine(DB_PG_TEST_URL)
+    # TODO: port all tests that use this to be multi-database. Or explicitly mark them as skip-bigquery
+    return _ENGINE_CACHE[DB.POSTGRES]
 
 
 def pytest_addoption(parser: Parser):
@@ -44,34 +83,22 @@ def pytest_addoption(parser: Parser):
     parser.addoption('--all', action='store_true', help='run the functional tests for BigQuery')
 
 
-class EngineDialect(NamedTuple):
-    engine: Optional[Engine]
-    dialect: Optional[Dialect]
-
-
-ENGINE_DIALECTS: Dict[str, EngineDialect] = {}
-
-
 def pytest_sessionstart(session: Session):
-    # Initialize ENGINE_DIALECTS per pytest-xdist worker session based on current pytest running config.
+    # Initialize _ENGINE_CACHE per pytest-xdist worker session based on current pytest running config.
     # This way we avoid the creation of a new engine per test, as this is quite inefficient and might
     # cause failures due to multiple clients trying to connect to db server.
 
     # For more information, please see:
     # https://pytest-xdist.readthedocs.io/en/latest/distribution.html
     # https://docs.pytest.org/en/6.2.x/reference.html#pytest.hookspec.pytest_sessionstart
-    load_engine = True
-    if session.config.args == ['tests/unit']:
-        # create dialect, only if we are running unit tests
-        load_engine = False
 
     if session.config.getoption("all"):
-        ENGINE_DIALECTS['postgres'] = get_postgres_engine_dialect(load_engine)
-        ENGINE_DIALECTS['bigquery'] = get_bigquery_engine_dialect(load_engine)
+        _ENGINE_CACHE[DB.POSTGRES] = _get_postgres_engine()
+        _ENGINE_CACHE[DB.BIGQUERY] = _get_bigquery_engine()
     elif session.config.getoption("big_query"):
-        ENGINE_DIALECTS['bigquery'] = get_bigquery_engine_dialect(load_engine)
+        _ENGINE_CACHE[DB.BIGQUERY] = _get_bigquery_engine()
     else:  # default option, don't even check if --postgres is set
-        ENGINE_DIALECTS['postgres'] = get_postgres_engine_dialect(load_engine)
+        _ENGINE_CACHE[DB.POSTGRES] = _get_postgres_engine()
 
 
 def pytest_generate_tests(metafunc: Metafunc):
@@ -80,53 +107,43 @@ def pytest_generate_tests(metafunc: Metafunc):
 
     # This function will automatically be called by pytest while it is creating the list of tests to run,
     # see: https://docs.pytest.org/en/6.2.x/reference.html#collection-hooks
-    engine_dialects = list(ENGINE_DIALECTS.values())
+    markers = list(metafunc.definition.iter_markers())
+    skip_postgres = any(mark.name == MARK_SKIP_POSTGRES for mark in markers)
+    skip_bigquery = any(mark.name == MARK_SKIP_BIGQUERY for mark in markers)
+
+    engines = []
+    for name, engine_dialect in _ENGINE_CACHE.items():
+        if name == DB.POSTGRES and skip_postgres:
+            continue
+        if name == DB.BIGQUERY and skip_bigquery:
+            continue
+        engines.append(engine_dialect)
+
     if 'dialect' in metafunc.fixturenames:
-        dialects = [ed.dialect for ed in engine_dialects]
+        dialects = [engine.dialect for engine in engines]
         metafunc.parametrize("dialect", dialects)
     if 'engine' in metafunc.fixturenames:
-        engines = [ed.engine for ed in engine_dialects]
         metafunc.parametrize("engine", engines)
 
 
 def pytest_runtest_setup(item: Function):
     # Here we check that tests that are marked as `db_independent`, that they do not have a `dialect` or
     # `engine` parameter.
-    #
-    #  ### Background ###
-    #  We broadly want two categories of tests:
-    #  1. tests that are database independent.
-    #  2. tests that we want to run against all supported databases.
-    #
-    # These categories shouldn't overlap. We use the `db_independent` mark to track category one, and we can
-    # distinguish tests from category two by their 'dialect' and 'engine' parameters. This way we can verify
-    # that all tests are clearly marked as being in either category.
 
     # This function will automatically be called by pytest before running a specific test function. See:
     # https://docs.pytest.org/en/6.2.x/reference.html#test-running-runtest-hooks
     fixture_names = item.fixturenames
-    is_db_independent_test = any(mark.name == 'db_independent' for mark in item.own_markers)
+    markers = list(item.iter_markers())
+    is_db_independent_test = any(mark.name == MARK_DB_INDEPENDENT for mark in markers)
     is_multi_db_test = 'dialect' in fixture_names or 'engine' in fixture_names
     if is_db_independent_test and is_multi_db_test:
         raise Exception('Test has both the `db_independent` mark as well as either the `dialect` or '
                         '`engine` parameter. Test can not be both database independent and multi-database.')
 
-# Below: helper functions for pytest_sessionstart
+
+def _get_postgres_engine() -> Engine:
+    return create_engine(DB_PG_TEST_URL)
 
 
-def get_postgres_engine_dialect(need_engine: bool = True) -> EngineDialect:
-    if need_engine:
-        engine = create_engine(DB_PG_TEST_URL)
-        return EngineDialect(engine, engine.dialect)
-    # Import locally. This way a missing library doesn't break anything, if we don't hit this code path
-    from sqlalchemy.dialects.postgresql.base import PGDialect
-    return EngineDialect(None, PGDialect())
-
-
-def get_bigquery_engine_dialect(need_engine: bool = True) -> EngineDialect:
-    if need_engine:
-        engine = create_engine(DB_BQ_TEST_URL, credentials_path=DB_BQ_CREDENTIALS_PATH)
-        return EngineDialect(engine, engine.dialect)
-    # Import locally. This way a missing library doesn't break anything, if we don't hit this code path
-    from sqlalchemy_bigquery import BigQueryDialect
-    return EngineDialect(None, BigQueryDialect())
+def _get_bigquery_engine() -> Engine:
+    return create_engine(DB_BQ_TEST_URL, credentials_path=DB_BQ_CREDENTIALS_PATH)

--- a/bach/tests/functional/bach/test_df_setitem.py
+++ b/bach/tests/functional/bach/test_df_setitem.py
@@ -10,7 +10,6 @@ import numpy as np
 from bach import SeriesInt64, SeriesString, SeriesFloat64, SeriesDate, SeriesTimestamp, \
     SeriesTime, SeriesTimedelta, Series, \
     SeriesJsonb, SeriesBoolean
-from tests.conftest import get_postgres_engine_dialect
 from tests.functional.bach.test_data_and_utils import get_bt_with_test_data, assert_postgres_type, \
     assert_equals_data, CITIES_INDEX_AND_COLUMNS, get_bt_with_railway_data, get_df_with_test_data, \
     get_df_with_railway_data
@@ -101,8 +100,8 @@ def test_set_const_time(engine):
     check_set_const(engine, constants, SeriesTime, 'time without time zone')
 
 
-def test_set_const_timedelta():
-    engine = get_postgres_engine_dialect().engine  # TODO: BigQuery
+def test_set_const_timedelta(pg_engine):
+    engine = pg_engine  # TODO: BigQuery
     constants = [
         np.datetime64('2005-02-25T03:30') - np.datetime64('2005-01-25T03:30'),
         datetime.datetime.now() - datetime.datetime(2015, 4, 6),
@@ -110,8 +109,8 @@ def test_set_const_timedelta():
     check_set_const(engine, constants, SeriesTimedelta, 'interval')
 
 
-def test_set_const_json():
-    engine = get_postgres_engine_dialect().engine  # TODO: BigQuery
+def test_set_const_json(pg_engine):
+    engine = pg_engine  # TODO: BigQuery
     constants = [
         ['a', 'b', 'c'],
         {'a': 'b', 'c': 'd'},

--- a/bach/tests/unit/sql_models/test_util.py
+++ b/bach/tests/unit/sql_models/test_util.py
@@ -7,14 +7,14 @@ from sql_models.util import extract_format_fields, quote_identifier, quote_strin
     is_bigquery
 
 
-pytestmark = [pytest.mark.db_independent]  # mark all tests here as database independent.
-
+@pytest.mark.db_independent
 def test_extract_format_fields():
     assert extract_format_fields('{test}') == {'test'}
     assert extract_format_fields('{test} more text {test}') == {'test'}
     assert extract_format_fields('text{test} more {{text}} {test2} te{x}t{test}') == {'test', 'test2', 'x'}
 
 
+@pytest.mark.db_independent
 def test_extract_format_fields_nested():
     # assert extract_format_fields('{test}', 2) == set()
     # assert extract_format_fields('{test} more text {test}', 2) == set()


### PR DESCRIPTION
Changes:
* Add two pytest marks:
  1. `skip_postgres` for tests that do not work on Postgres, and that we are okay with that they don't work.
  2. `skip_bigquery` for tests that do not work on BigQuery, and that we are okay with that they don't work.
* More parallelization