### PR TITLE
Fix quantile calculation for BigQuery

### DIFF
--- a/bach/bach/quantile.py
+++ b/bach/bach/quantile.py
@@ -74,7 +74,7 @@ def calculate_quantiles(
         df['q'] = df['q'].copy_override(
             expression=Expression.construct(
                 f"replace({{}}, '_', '.')",
-                df['q'].copy_override_type(SeriesString).str[2:],
+                df['q'].copy_override_type(SeriesString).str[4:],
             ),
         )
 


### PR DESCRIPTION
Forgot to change the index from the substring when parsing quantile values :cry: 