### PR TITLE
New modeling docs URLs in notebooks & READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Supports front-end engineers to [implement tracking instrumentation](https://www
  
 ### Open model hub
 
-A [growing collection of pre-built models](https://www.objectiv.io/docs/modeling/example_notebooks) that you run, combine or customize to quickly build in-depth analyses.
+A [growing collection of pre-built models](https://www.objectiv.io/docs/modeling/example-notebooks/) that you run, combine or customize to quickly build in-depth analyses.
 
 * All models work with any dataset that embraces the open analytics taxonomy
 * Currently covers common product analytics operations
@@ -58,7 +58,7 @@ A [growing collection of pre-built models](https://www.objectiv.io/docs/modeling
 
 ### Bach modeling library
 
-Python-based [modeling library](https://www.objectiv.io/docs/modeling/bach) that enables using pandas-like operations on the full SQL dataset.
+Python-based [modeling library](https://www.objectiv.io/docs/modeling/bach/) that enables using pandas-like operations on the full SQL dataset.
 
 * Includes specific operations to easily work with datasets that embrace the open analytics taxonomy
 * Pandas-compatible: use popular pandas ML libraries in your models

--- a/bach/docs/source/example-notebooks/user-intent.rst
+++ b/bach/docs/source/example-notebooks/user-intent.rst
@@ -50,7 +50,7 @@ The root_location context in the location_stack uniquely represents the top-leve
 
 Exploring session duration
 --------------------------
-The average `session_duration` model from the `open model hub </docs/modeling/>`_ is another good pointer to explore first for user intent.
+The average `session_duration` model from the `open model hub </docs/modeling/open-model-hub/>`_ is another good pointer to explore first for user intent.
 
 .. code-block:: python
 

--- a/bach/docs/source/open-model-hub/models/Aggregate/index.rst
+++ b/bach/docs/source/open-model-hub/models/Aggregate/index.rst
@@ -1,9 +1,9 @@
 .. _models_reference_aggregation:
 
 
-===========
-Aggregation
-===========
+=========
+Aggregate
+=========
 
 .. currentmodule:: modelhub
 

--- a/bach/docs/source/open-model-hub/models/Map/index.rst
+++ b/bach/docs/source/open-model-hub/models/Map/index.rst
@@ -1,9 +1,9 @@
 .. _models_reference_mapping:
 
 
-=======
-Mapping
-=======
+===
+Map
+===
 
 .. currentmodule:: modelhub
 

--- a/bach/docs/source/open-model-hub/models/index.rst
+++ b/bach/docs/source/open-model-hub/models/index.rst
@@ -25,7 +25,7 @@ Map
 .. currentmodule:: modelhub.Map
 
 .. autosummary::
-    :toctree: Mapping
+    :toctree: Map
 
     is_first_session
     is_new_user
@@ -38,7 +38,7 @@ Map
 .. toctree::
     :hidden:
 
-    Mapping/index
+    Map/index
 
 
 .. currentmodule:: modelhub.Aggregate
@@ -47,7 +47,7 @@ Aggregate
 ---------
 
 .. autosummary::
-    :toctree: Aggregation
+    :toctree: Aggregate
 
     unique_users
     unique_sessions
@@ -58,4 +58,4 @@ Aggregate
 .. toctree::
     :hidden:
 
-    Aggregation/index
+    Aggregate/index

--- a/modelhub/README.md
+++ b/modelhub/README.md
@@ -16,7 +16,7 @@ made (see below). All other instructions live in the README.md in the link above
 
 ### Your own code
 To use the model hub in your own code, you can import the package and use it to get a Bach DataFrame 
-([What is Bach?](https://www.objectiv.io/docs/modeling/bach_whatisbach)) to 
+([What is Bach?](https://www.objectiv.io/docs/modeling/bach/what-is-bach/)) to 
 perform your operations on. The object can be instantiated as follows, where the `db_url` and `table_name`
 should be adjusted depending on where the data is stored and how to access it.
 ```python

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -18,5 +18,5 @@ Metabase section in the modelhub [README.md](../modelhub/README.md).
 
 ## Notebooks 
 Please see the most complete list of examples at [the model hub example page on Objectiv.io](https://www.
-objectiv.io/docs/modeling/example_notebooks) 
+objectiv.io/docs/modeling/example-notebooks/) 
 or have a look at the files in this directory; most of them have a pretty decent introduction.

--- a/notebooks/basic-product-analytics.ipynb
+++ b/notebooks/basic-product-analytics.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "source": [
     "This is one of the Objectiv example notebooks. For more examples visit the \n",
-    "[example notebooks](https://objectiv.io/docs/modeling/example_notebooks/) section of our docs. The notebooks can run with the demo data set that comes with the our [quickstart](https://objectiv.io/docs/home/quickstart-guide/), but can be used to run on your own collected data as well.\n",
+    "[example notebooks](https://objectiv.io/docs/modeling/example-notebooks/) section of our docs. The notebooks can run with the demo data set that comes with the our [quickstart](https://objectiv.io/docs/home/quickstart-guide/), but can be used to run on your own collected data as well.\n",
     "\n",
     "All example notebooks are also available in our [quickstart](https://objectiv.io/docs/home/quickstart-guide/). With the quickstart you can spin up a fully functional Objectiv demo pipeline in five minutes. This also allows you to run these notebooks and experiment with them on a demo data set."
    ]

--- a/notebooks/basic-user-intent.ipynb
+++ b/notebooks/basic-user-intent.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "source": [
     "This is one of the Objectiv example notebooks. For more examples visit the \n",
-    "[example notebooks](https://objectiv.io/docs/modeling/example_notebooks/) section of our docs. The notebooks can run with the demo data set that comes with the our [quickstart](https://objectiv.io/docs/home/quickstart-guide/), but can be used to run on your own collected data as well.\n",
+    "[example notebooks](https://objectiv.io/docs/modeling/example-notebooks/) section of our docs. The notebooks can run with the demo data set that comes with the our [quickstart](https://objectiv.io/docs/home/quickstart-guide/), but can be used to run on your own collected data as well.\n",
     "\n",
     "All example notebooks are also available in our [quickstart](https://objectiv.io/docs/home/quickstart-guide/). With the quickstart you can spin up a fully functional Objectiv demo pipeline in five minutes. This also allows you to run these notebooks and experiment with them on a demo data set."
    ]
@@ -305,7 +305,7 @@
     "- What kind of intent users come from different marketing campaigns? \n",
     "- How can we drive more users to the 'Implement' stage? Look at different product features that users with the 'Implement' intent use, compared to 'Explore'.\n",
     "\n",
-    "A good starting point for these analyses on top of the user intent buckets is the basic product analytics example in the [example notebooks](https://objectiv.io/docs/modeling/example_notebooks/)."
+    "A good starting point for these analyses on top of the user intent buckets is the basic product analytics example in the [example notebooks](https://objectiv.io/docs/modeling/example-notebooks/)."
    ]
   },
   {

--- a/notebooks/basic-user-intent.ipynb
+++ b/notebooks/basic-user-intent.ipynb
@@ -129,7 +129,8 @@
    "metadata": {},
    "source": [
     "## Exploring session duration\n",
-    "The average `session_duration` model from the [open model hub](https://objectiv.io/docs/modeling/) is another good pointer to explore first for user intent. "
+    "The average `session_duration` model from the [open model hub](https://objectiv.io/docs/modeling/open-model-hub/) is\n",
+    "another good pointer to explore first for user intent."
    ]
   },
   {

--- a/notebooks/feature-engineering.ipynb
+++ b/notebooks/feature-engineering.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "source": [
     "This is one of the Objectiv example notebooks. For more examples visit the \n",
-    "[example notebooks](https://objectiv.io/docs/modeling/example_notebooks/) section of our docs. The notebooks can run with the demo data set that comes with the our [quickstart](https://objectiv.io/docs/home/quickstart-guide/), but can be used to run on your own collected data as well.\n",
+    "[example notebooks](https://objectiv.io/docs/modeling/example-notebooks/) section of our docs. The notebooks can run with the demo data set that comes with the our [quickstart](https://objectiv.io/docs/home/quickstart-guide/), but can be used to run on your own collected data as well.\n",
     "\n",
     "All example notebooks are also available in our [quickstart](https://objectiv.io/docs/home/quickstart-guide/). With the quickstart you can spin up a fully functional Objectiv demo pipeline in five minutes. This also allows you to run these notebooks and experiment with them on a demo data set."
    ]
@@ -19,7 +19,7 @@
     "This example shows how Bach can be used for feature engineering. We'll go through describing the data, finding\n",
     "outliers, transforming data and grouping and aggregating data so that a useful feature set is created that\n",
     "can be used for machine learning. We have a separate example available that goes into the details of how a\n",
-    "data set prepared in Bach can be used for machine learning with sklearn [here](https://objectiv.io/docs/modeling/machine_learning/)."
+    "data set prepared in Bach can be used for machine learning with sklearn [here](https://objectiv.io/docs/modeling/example-notebooks/machine-learning/)."
    ]
   },
   {
@@ -385,7 +385,7 @@
     "Now that we have our data set, we can use it for machine learning, using for example sklearn. To do so\n",
     "we call `to_pandas()` to get a pandas DataFrame that can be used in sklearn.\n",
     "\n",
-    "Here is our example on how to use Objectiv data and [sklearn](https://objectiv.io/docs/modeling/machine_learning/)."
+    "Here is our example on how to use Objectiv data and [sklearn](https://objectiv.io/docs/modeling/example-notebooks/machine-learning/)."
    ]
   },
   {

--- a/notebooks/model-hub-demo-notebook.ipynb
+++ b/notebooks/model-hub-demo-notebook.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "source": [
     "This is one of the Objectiv example notebooks. For more examples visit the \n",
-    "[example notebooks](https://objectiv.io/docs/modeling/example_notebooks/) section of our docs. The notebooks can run with the demo data set that comes with the our [quickstart](https://objectiv.io/docs/home/quickstart-guide/), but can be used to run on your own collected data as well.\n",
+    "[example notebooks](https://objectiv.io/docs/modeling/example-notebooks/) section of our docs. The notebooks can run with the demo data set that comes with the our [quickstart](https://objectiv.io/docs/home/quickstart-guide/), but can be used to run on your own collected data as well.\n",
     "\n",
     "All example notebooks are also available in our [quickstart](https://objectiv.io/docs/home/quickstart-guide/). With the quickstart you can spin up a fully functional Objectiv demo pipeline in five minutes. This also allows you to run these notebooks and experiment with them on a demo data set."
    ]
@@ -21,7 +21,7 @@
     "\n",
     "This example uses real, unaltered data that was collected from https://objectiv.io/ with Objectiv’s Tracker. All models in the open model hub are compatible with datasets that have been validated against the [open analytics taxonomy](https://objectiv.io/docs/taxonomy/).\n",
     "\n",
-    "For an overview of all available models, check out the [open model hub docs](https://objectiv.io/docs/modeling/models/)."
+    "For an overview of all available models, check out the [open model hub docs](https://objectiv.io/docs/modeling/open-model-hub/models/)."
    ]
   },
   {
@@ -146,7 +146,7 @@
    "id": "d46cba1e",
    "metadata": {},
    "source": [
-    "Or we can label conversion events. To do this we first have to define what a conversion is by setting the type of event and the location on the product at which this event was triggered with `add_conversion_event` (this is called the location stack, see [here](https://objectiv.io/docs/modeling/open_taxonomy/#location-stack) for info)."
+    "Or we can label conversion events. To do this we first have to define what a conversion is by setting the type of event and the location on the product at which this event was triggered with `add_conversion_event` (this is called the location stack, see [here](https://objectiv.io/docs/modeling/example-notebooks/open-taxonomy/#location_stack) for info)."
    ]
   },
   {
@@ -359,8 +359,8 @@
    "id": "670dde5e",
    "metadata": {},
    "source": [
-    "There is another [example](https://objectiv.io/docs/modeling/bach_examples/) that demonstrates what you can do with the Bach modeling\n",
-    "library, or head over to the [api reference](https://objectiv.io/docs/modeling/bach_reference/) for a complete overview of the possibilities."
+    "There is another [example](https://objectiv.io/docs/modeling/bach/examples/) that demonstrates what you can do with the Bach modeling\n",
+    "library, or head over to the [api reference](https://objectiv.io/docs/modeling/bach/api-reference/) for a complete overview of the possibilities."
    ]
   },
   {
@@ -396,7 +396,7 @@
     "\n",
     "We hope you’ve gotten a taste of the power and flexibility of the open model hub to quickly answer common product analytics questions. You can take it a lot further and build highly specific model stacks for in-depth analysis and exploration.\n",
     "\n",
-    "For a complete overview of all available and upcoming models, check out the [model hub docs](https://objectiv.io/docs/modeling/models/)."
+    "For a complete overview of all available and upcoming models, check out the [model hub docs](https://objectiv.io/docs/modeling/open-model-hub/models/)."
    ]
   }
  ],

--- a/notebooks/open-taxonomy-how-to.ipynb
+++ b/notebooks/open-taxonomy-how-to.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "source": [
     "This is one of the Objectiv example notebooks. For more examples visit the \n",
-    "[example notebooks](https://objectiv.io/docs/modeling/example_notebooks/) section of our docs. The notebooks can run with the demo data set that comes with the our [quickstart](https://objectiv.io/docs/home/quickstart-guide/), but can be used to run on your own collected data as well.\n",
+    "[example notebooks](https://objectiv.io/docs/modeling/example-notebooks/) section of our docs. The notebooks can run with the demo data set that comes with the our [quickstart](https://objectiv.io/docs/home/quickstart-guide/), but can be used to run on your own collected data as well.\n",
     "\n",
     "All example notebooks are also available in our [quickstart](https://objectiv.io/docs/home/quickstart-guide/). With the quickstart you can spin up a fully functional Objectiv demo pipeline in five minutes. This also allows you to run these notebooks and experiment with them on a demo data set."
    ]
@@ -24,7 +24,7 @@
     "The Objectiv Bach API is heavily inspired by the pandas API. We believe this provides a great, generic interface to handle large amounts of data in a python environment while supporting multiple data stores.\n",
     "\n",
     "For an intro into the pandas api see: https://pandas.pydata.org/pandas-docs/stable/user_guide/10min.html  \n",
-    "The full Objectiv Bach api reference is available here: https://objectiv.io/docs/modeling/bach_reference/"
+    "The full Objectiv Bach api reference is available here: https://objectiv.io/modeling/bach/api-reference/"
    ]
   },
   {
@@ -90,11 +90,11 @@
    "metadata": {},
    "source": [
     "The data for the DataFrame is still in the database and the database is not queried before any of the data is loaded to the python environment. The methods that query the database are: \n",
-    "* [`head()`](https://objectiv.io/docs/modeling/DataFrame/bach.DataFrame.head/)\n",
-    "* [`to_pandas()`](https://objectiv.io/docs/modeling/DataFrame/bach.DataFrame.to_pandas/)\n",
-    "* [`get_sample()`](https://objectiv.io/docs/modeling/DataFrame/bach.DataFrame.get_sample/)\n",
-    "* [`to_numpy()`](https://objectiv.io/docs/modeling/DataFrame/bach.DataFrame.to_numpy/)\n",
-    "* The property accessors [`Series.array`](https://objectiv.io/docs/modeling/Series/bach.Series.array/), [`Series.value`](https://objectiv.io/docs/modeling/Series/bach.Series.value/)\n",
+    "* [`head()`](https://objectiv.io/docs/modeling/bach/api-reference/DataFrame/head/)\n",
+    "* [`to_pandas()`](https://objectiv.io/docs/modeling/bach/api-reference/DataFrame/to_pandas/)\n",
+    "* [`get_sample()`](https://objectiv.io/docs/modeling/bach/api-reference/DataFrame/get_sample/)\n",
+    "* [`to_numpy()`](https://objectiv.io/docs/modeling/bach/api-reference/DataFrame/to_numpy/)\n",
+    "* The property accessors [`Series.array`](https://objectiv.io/docs/modeling/bach/api-reference/Series/array/), [`Series.value`](https://objectiv.io/docs/modeling/bach/api-reference/Series/value/)\n",
     "\n",
     "For demo puposes of this notebook, these methods are called often to show the results of our operations. To limit the number of executed queries on the full data set it is recommended to use these methods less often or [to sample the data first](#Sampling)."
    ]
@@ -262,7 +262,7 @@
     " {'id': 'DataFrame', '_type': 'ExpandableContext'},\n",
     " {'id': 'Overview', '_type': 'LinkContext'}]\n",
     "```\n",
-    "In case a json array does not contain the object, `None` is returned. More info at the api reference: https://objectiv.io/docs/modeling/Series/bach.SeriesJsonb.json/#bach.SeriesJsonb.json"
+    "In case a json array does not contain the object, `None` is returned. More info at the api reference: https://objectiv.io/docs/modeling/bach/api-reference/Series/Jsonb/json/"
    ]
   },
   {
@@ -274,8 +274,8 @@
     "The `location_stack` column in the DataFrame stores the information on the exact location where the event is triggered in the product. The example used above is the location stack of the link to the DataFrame api reference in the menu on our docs page.\n",
     "\n",
     "Because of the specific way the location information is labeled, validated, and stored using the Open Taxonomy, it can be used to slice and group your products' features in an efficient and easy way. The column is set as an `objectiv_location_stack` type, and therefore location stack specific methods can be used to access the data from the `location_stack`. These methods can be used using the `.ls` accessor on the column. The methods are:\n",
-    "* The property accessors [`.ls.navigation_features`](https://objectiv.io/docs/modeling/modelhub_api_reference/modelhub.SeriesLocationStack.ls/), [`.ls.feature_stack`](https://objectiv.io/docs/modeling/modelhub_api_reference/modelhub.SeriesLocationStack.ls/), [`.ls.nice_name`](https://objectiv.io/docs/modeling/modelhub_api_reference/modelhub.SeriesLocationStack.ls/)\n",
-    "* all [methods](https://objectiv.io/docs/modeling/Series/bach.SeriesJsonb.json/) for the json(b) type can also be accessed using `.ls`\n",
+    "* The property accessors [`.ls.navigation_features`](https://objectiv.io/docs/modeling/open-model-hub/api-reference/SeriesLocationStack/ls/), [`.ls.feature_stack`](https://objectiv.io/docs/modeling/open-model-hub/api-reference/SeriesLocationStack/ls/), [`.ls.nice_name`](https://objectiv.io/docs/modeling/open-model-hub/api-reference/SeriesLocationStack/ls/)\n",
+    "* all [methods](https://objectiv.io/docs/modeling/bach/api-reference/Series/Jsonb/json/) for the json(b) type can also be accessed using `.ls`\n",
     "\n",
     "For example,\n",
     "```python\n",
@@ -303,9 +303,9 @@
    "source": [
     "### global_contexts\n",
     "The `global_contexts` column in the DataFrame contain all information that is relevant to the logged event. As it is set as an `objectiv_global_context` type, specific methods can be used to access the data from the `global_contexts`. These methods can be used using the `.gc` accessor on the column. The methods are:\n",
-    "* [`.gc.get_from_context_with_type_series(type, key)`](https://objectiv.io/docs/modeling/modelhub_api_reference/modelhub.SeriesGlobalContexts.obj/)\n",
-    "* The property accessors [`.gc.cookie_id`](https://objectiv.io/docs/modeling/modelhub_api_reference/modelhub.SeriesGlobalContexts.gc/), [`.gc.user_agent`](https://objectiv.io/docs/modeling/modelhub_api_reference/modelhub.SeriesGlobalContexts.gc/), [`.gc.application`](https://objectiv.io/docs/modeling/modelhub_api_reference/modelhub.SeriesGlobalContexts.gc/)\n",
-    "* all [methods](https://objectiv.io/docs/modeling/Series/bach.SeriesJsonb.json/) for the json(b) type can also be accessed using `.gc`\n",
+    "* [`.gc.get_from_context_with_type_series(type, key)`](https://objectiv.io/docs/modeling/open-model-hub/api-reference/SeriesGlobalContexts/obj/)\n",
+    "* The property accessors [`.gc.cookie_id`](https://objectiv.io/docs/modeling/open-model-hub/api-reference/SeriesGlobalContexts/gc/), [`.gc.user_agent`](https://objectiv.io/docs/modeling/open-model-hub/api-reference/SeriesGlobalContexts/gc/), [`.gc.application`](https://objectiv.io/docs/modeling/open-model-hub/api-reference/SeriesGlobalContexts/gc/)\n",
+    "* all [methods](https://objectiv.io/docs/modeling/bach/api-reference/Series/Jsonb/json/) for the json(b) type can also be accessed using `.gc`\n",
     "\n",
     "The full reference of global contexts is [here](https://objectiv.io/docs/taxonomy/global-contexts/). An example is queried below:"
    ]
@@ -431,9 +431,9 @@
     "\n",
     "We’ve demonstrated a handful of the operations that Bach supports and hope you’ve gotten a taste of what Bach can do for your modeling workflow. \n",
     "\n",
-    "The full Objectiv Bach API reference is available here: https://objectiv.io/docs/modeling/bach_reference/\n",
+    "The full Objectiv Bach API reference is available here: https://objectiv.io/docs/modeling/bach/api-reference/\n",
     "\n",
-    "There is another example that focuses on using the [open model hub](https://objectiv.io/docs/modeling/modelhub_basics/), demonstrating\n",
+    "There is another example that focuses on using the [open model hub](https://objectiv.io/docs/modeling/example-notebooks/modelhub-basics/), demonstrating\n",
     "how you can use the model hub and Bach to quickly answer common product analytics questions."
    ]
   }

--- a/notebooks/sklearn-example.ipynb
+++ b/notebooks/sklearn-example.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "source": [
     "This is one of the Objectiv example notebooks. For more examples visit the \n",
-    "[example notebooks](https://objectiv.io/docs/modeling/example_notebooks/) section of our docs. The notebooks can run with the demo data set that comes with the our [quickstart](https://objectiv.io/docs/home/quickstart-guide/), but can be used to run on your own collected data as well.\n",
+    "[example notebooks](https://objectiv.io/docs/modeling/example-notebooks/) section of our docs. The notebooks can run with the demo data set that comes with the our [quickstart](https://objectiv.io/docs/home/quickstart-guide/), but can be used to run on your own collected data as well.\n",
     "\n",
     "All example notebooks are also available in our [quickstart](https://objectiv.io/docs/home/quickstart-guide/). With the quickstart you can spin up a fully functional Objectiv demo pipeline in five minutes. This also allows you to run these notebooks and experiment with them on a demo data set."
    ]
@@ -19,7 +19,7 @@
     "With Objectiv you can do all your analysis and Machine Learning directly on the raw data in your SQL database.\n",
     "This example shows in the simplest way possible how you can use Objectiv to create a basic feature set and use\n",
     "sklearn to do machine learning on this data set. We also have an example that goes deeper into\n",
-    "feature engineering [here](https://objectiv.io/docs/modeling/feature_engineering/)."
+    "feature engineering [here](https://objectiv.io/docs/modeling/example-notebooks/feature-engineering/)."
    ]
   },
   {
@@ -69,7 +69,7 @@
    "id": "20c780fa",
    "metadata": {},
    "source": [
-    "We create a data set of per user all the root locations that the user clicked on. For the ins and outs on feature engineering see our feature [engineering example](https://objectiv.io/docs/modeling/feature_engineering/)."
+    "We create a data set of per user all the root locations that the user clicked on. For the ins and outs on feature engineering see our feature [engineering example](https://objectiv.io/docs/modeling/example-notebooks/feature-engineering/)."
    ]
   },
   {


### PR DESCRIPTION
Updates the notebooks and READMEs to the new URLs in the Modeling docs. 

Redirects are in place, but once we deploy the docs, we should merge the objectiv-analytics branches, and rebuild the Docker containers.