### PR TITLE
Fix PR write permission for CLA bot

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -4,6 +4,9 @@ on:
   pull_request_target:
     types: [opened,closed,synchronize]
 
+permissions:
+  pull-requests: write
+
 jobs:
   CLAssistant:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The CLA bot currently cannot post a comment to the opened PR. This should fix that by assigning it write permissions to PRs.