### PR TITLE
Add re-run check permissions for CLA bot

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -5,7 +5,11 @@ on:
     types: [opened,closed,synchronize]
 
 permissions:
+  # to post and edit PR comments
   pull-requests: write
+  # to rerun checks and read committer's details
+  actions: write
+  contents: write
 
 jobs:
   CLAssistant:


### PR DESCRIPTION
As our settings only allow workflows to read any content, we have to add 'actions' and 'contents' `write` permissions to the CLA bot workflow, so it can rerun the check and read the committer's details when they've accepted the CLA. This PR adds those permissions.