### PR TITLE
Modeling docs: support targets & attributes + smaller fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Supports front-end engineers to [implement tracking instrumentation](https://www
  
 ### Open model hub
 
-A [growing collection of pre-built models](https://www.objectiv.io/docs/modeling/example_notebooks) that you run, combine or customize to quickly build in-depth analyses.
+A [growing collection of pre-built models](https://www.objectiv.io/docs/modeling/example-notebooks/) that you run, combine or customize to quickly build in-depth analyses.
 
 * All models work with any dataset that embraces the open analytics taxonomy
 * Currently covers common product analytics operations
@@ -58,7 +58,7 @@ A [growing collection of pre-built models](https://www.objectiv.io/docs/modeling
 
 ### Bach modeling library
 
-Python-based [modeling library](https://www.objectiv.io/docs/modeling/bach) that enables using pandas-like operations on the full SQL dataset.
+Python-based [modeling library](https://www.objectiv.io/docs/modeling/bach/) that enables using pandas-like operations on the full SQL dataset.
 
 * Includes specific operations to easily work with datasets that embrace the open analytics taxonomy
 * Pandas-compatible: use popular pandas ML libraries in your models

--- a/bach/docs/source/_ext/sphinx_docusaurus_builder/doctree2md.py
+++ b/bach/docs/source/_ext/sphinx_docusaurus_builder/doctree2md.py
@@ -443,12 +443,15 @@ class Translator(nodes.NodeVisitor):
         # None for no possible address
         this_doc = self.builder.current_docname
         url = node.get('refuri')
+        optional_anchor = ""
+
         if not node.get('internal'):
             return url
 
         if url not in (None, ''):
             # strip off the end starting with '/#', e.g. 'ModelHub/modelhub.ModelHub/#modelhub.ModelHub'
             hash_index = url.rfind('/#')
+            optional_anchor = url[hash_index+2:]
             url = url[0:hash_index]
             # strip off the first '../'
             url = url[3:]
@@ -471,6 +474,17 @@ class Translator(nodes.NodeVisitor):
         url = '{}/{}'.format(self.markdown_http_base, url)
         if 'refid' in node:
             url += '#' + node['refid']
+        elif not 'optional_anchor' == "":
+            # Sphinx references (by :ref: or :autosummary:) all generate anchors ('#myanchor') in the refuri.
+            # No distinction is made between a useful anchor that points to a section and a redundant one.
+            # One pattern exists: if the anchor is already part of the URL, it's nearly certainly redundant.
+            # example: 'bach-api-reference' for URL '/modeling/bach/api-reference/index.mdx'
+            # example: 'modelhub.Aggregate.frequency' for URL '/modeling/open-model-hub/models/Aggregate/modelhub.Aggregate.frequency.mdx'
+            # So here we only add the anchor if it seems useful (not yet part of the URL).
+            anchor_is_redundant = optional_anchor.replace("-", "/") in url
+            if not anchor_is_redundant:
+                url += '#' + optional_anchor
+
         return url
 
 

--- a/bach/docs/source/_ext/sphinx_docusaurus_builder/doctree2md.py
+++ b/bach/docs/source/_ext/sphinx_docusaurus_builder/doctree2md.py
@@ -481,7 +481,7 @@ class Translator(nodes.NodeVisitor):
             # example: 'bach-api-reference' for URL '/modeling/bach/api-reference/index.mdx'
             # example: 'modelhub.Aggregate.frequency' for URL '/modeling/open-model-hub/models/Aggregate/modelhub.Aggregate.frequency.mdx'
             # So here we only add the anchor if it seems useful (not yet part of the URL).
-            anchor_is_redundant = optional_anchor.replace("-", "/") in url
+            anchor_is_redundant = optional_anchor.replace("-", "/") in url or optional_anchor.startswith('./')
             if not anchor_is_redundant:
                 url += '#' + optional_anchor
 

--- a/bach/docs/source/_ext/sphinx_docusaurus_builder/docusaurus_writer.py
+++ b/bach/docs/source/_ext/sphinx_docusaurus_builder/docusaurus_writer.py
@@ -683,8 +683,6 @@ class DocusaurusTranslator(Translator):
         """The main signature (i.e. its name + parameters) of a class/method/property/attribute."""
         self.in_signature = False
         # only close the signature if it's not a property or attribute (which have no params)
-        if self.current_desc_type not in ['property', 'attribute']:
-            self.add(')')
         self.add('\n\n')
 
 
@@ -744,14 +742,14 @@ class DocusaurusTranslator(Translator):
 
     def visit_desc_parameterlist(self, node):
         """Method/class parameter list."""
-        self.add('<small className="parameter-list">')
-        if (self.current_desc_type != 'property'):
-            self.add('(')
+        if self.current_desc_type not in ['property', 'attribute']:
+            self.add('<small className="parameter-list">(')
 
 
     def depart_desc_parameterlist(self, node):
         """Method/class parameter list."""
-        self.add('</small>')
+        if self.current_desc_type not in ['property', 'attribute']:
+            self.add(')</small>')
 
 
     def visit_desc_parameter(self, node):

--- a/bach/docs/source/_ext/sphinx_docusaurus_builder/docusaurus_writer.py
+++ b/bach/docs/source/_ext/sphinx_docusaurus_builder/docusaurus_writer.py
@@ -122,6 +122,8 @@ class DocusaurusTranslator(Translator):
         """The root of the tree.
         https://docutils.sourceforge.io/docs/ref/doctree.html#document"""
         self.title = getattr(self.builder, 'current_docname')
+        if self.title == 'example-notebooks/index':
+            print("DOCUMENT:", node)
 
 
     def depart_document(self, node):
@@ -249,16 +251,14 @@ class DocusaurusTranslator(Translator):
             self.add('\n')
 
 
-    def visit_compact_paragraph(self, node):
-        """A paragraph that could be formatted more compactly; further formatting ignored here.
-        https://docutils.sourceforge.io/docs/ref/doctree.html#paragraph"""
-        pass
+    # A paragraph that could be formatted more compactly; further formatting ignored here.
+    # https://docutils.sourceforge.io/docs/ref/doctree.html#paragraph
+    visit_compact_paragraph = visit_paragraph
 
 
-    def depart_compact_paragraph(self, node):
-        """A paragraph that could be formatted more compactly; further formatting ignored here.
-        https://docutils.sourceforge.io/docs/ref/doctree.html#paragraph"""
-        pass
+    # A paragraph that could be formatted more compactly; further formatting ignored here.
+    # https://docutils.sourceforge.io/docs/ref/doctree.html#paragraph
+    depart_compact_paragraph = depart_paragraph
 
 
     def visit_reference(self, node):
@@ -433,9 +433,9 @@ class DocusaurusTranslator(Translator):
 
 
     def visit_field_body(self, node):
-      """Container for the body of a field: 
-      https://docutils.sourceforge.io/docs/ref/doctree.html#field-body"""
-      pass
+        """Container for the body of a field: 
+        https://docutils.sourceforge.io/docs/ref/doctree.html#field-body"""
+        pass
 
 
     def depart_field_body(self, node):

--- a/bach/docs/source/_ext/sphinx_docusaurus_builder/docusaurus_writer.py
+++ b/bach/docs/source/_ext/sphinx_docusaurus_builder/docusaurus_writer.py
@@ -478,7 +478,7 @@ class DocusaurusTranslator(Translator):
         """Analogous to a database field's name, e.g 'returns', 'parameters':
         https://docutils.sourceforge.io/docs/ref/doctree.html#field-name
         """
-        self.add('### ')
+        self.add('#### ')
 
 
     def depart_field_name(self, node):
@@ -673,7 +673,10 @@ class DocusaurusTranslator(Translator):
         self.in_signature = True
         # TBD: increase heading levels if description is nested in another one (e.g. in modelhub.ModelHub.aggregate)
         desc_depth = self.depth.get('desc')
-        self.add("\n## ")
+        if self.current_desc_type in ['method', 'property']:
+            self.add("\n### ")
+        else:
+            self.add("\n## ")
 
 
     def depart_desc_signature(self, node):
@@ -708,12 +711,20 @@ class DocusaurusTranslator(Translator):
 
     def visit_desc_addname(self, node):
         """Module preroll for class/method/property, e.g. 'classdomain' in 'classdomain.classname'."""
-        self.add('<span className="additional-name">')
+        if self.current_desc_type in ['method', 'property']:
+            # no need to repeat the classdomain
+            raise nodes.SkipNode
+        else:
+            self.add('<span className="additional-name">')
 
 
     def depart_desc_addname(self, node):
         """Module preroll for class/method/property, e.g. 'classdomain' in 'classdomain.classname'."""
-        self.add('</span>')
+        if self.current_desc_type in ['method', 'property']:
+            # no need to repeat the classdomain
+            raise nodes.SkipNode
+        else:
+            self.add('</span>')
 
 
     def visit_desc_name(self, node):

--- a/bach/docs/source/_ext/sphinx_docusaurus_builder/docusaurus_writer.py
+++ b/bach/docs/source/_ext/sphinx_docusaurus_builder/docusaurus_writer.py
@@ -147,8 +147,6 @@ class DocusaurusTranslator(Translator):
         """The root of the tree.
         https://docutils.sourceforge.io/docs/ref/doctree.html#document"""
         self.title = getattr(self.builder, 'current_docname')
-        if self.title == 'example-notebooks/machine-learning':
-            print("DOCUMENT:", node)
 
 
     def depart_document(self, node):
@@ -225,6 +223,17 @@ class DocusaurusTranslator(Translator):
         """Main unit of hierarchy: https://docutils.sourceforge.io/docs/ref/doctree.html#section"""
         self.section_depth -= 1
 
+    
+    def visit_target(self, node):
+        if self.visited_title:
+            if node.get('refid'):
+                target_id = str(node.get('refid'))
+                self.add('<div id="' + target_id + '" className="hidden-anchor"></div>\n\n')
+
+
+    def depart_target(self, node):
+        pass
+
 
     def visit_rubric(self, node):
         """An informal heading that doesn't correspond to the document's structure.
@@ -292,8 +301,6 @@ class DocusaurusTranslator(Translator):
         # Docusaurus doesn't support MDXv2 yet: https://github.com/facebook/docusaurus/issues/4029
         # so we cannot add an MD-formatted link in a <span> element, as it won't get parsed.
         # therefore, for now, we add these on a newline.
-        # if(self.in_signature):
-        #     self.add('\n\n ')
 
         # do the same for 'any view source' links
         if 'viewcode-link' in node.attributes['classes']:
@@ -303,13 +310,11 @@ class DocusaurusTranslator(Translator):
         url = self._refuri2http(node)
         if url is None:
             return
+
         self.add('[')
         for child in node.children:
             child.walkabout(self)
         self.add(']({})'.format(url))
-
-        # if(self.in_signature):
-        #     self.add('\n\n')
 
         if('viewcode-link' in node.attributes['classes']):
             self.add("</span>\n")

--- a/bach/docs/source/conf.py
+++ b/bach/docs/source/conf.py
@@ -51,6 +51,7 @@ extensions = [
     'numpydoc',  # use numpy style docs
     "IPython.sphinxext.ipython_directive",
     "IPython.sphinxext.ipython_console_highlighting",
+    'sphinx.ext.autosectionlabel',
     'sphinx_docusaurus_builder',
     'linkcode',  # generate [source] links to GH
 ]
@@ -77,6 +78,9 @@ autodoc_typehints_description_target = 'documented'
 autoclass_content = 'class'
 
 # TOTALLY breaks toctree generation autodoc_class_signature = 'separated'
+
+# automatically create explicit targets for sections
+autosectionlabel_prefix_document = True
 
 # numpydoc
 numpydoc_attributes_as_param_list = False

--- a/bach/docs/source/example-notebooks/feature-engineering.rst
+++ b/bach/docs/source/example-notebooks/feature-engineering.rst
@@ -21,7 +21,7 @@ to run on your own data or use our
 <https://objectiv.io/docs/home/quickstart-guide/>`_ to try it out with demo data in 5 minutes.
 
 At first we have to install the open model hub and instantiate the Objectiv DataFrame object. See
-:ref:`get_started_with_objectiv` for more info on this.
+:ref:`getting_started_with_objectiv` for more info on this.
 
 This object points to all data in the data set. Too large to run in pandas and therefore sklearn. For the
 data set that we need, we aggregate to user level, at which point it is small enough to fit in memory.

--- a/bach/docs/source/example-notebooks/feature-engineering.rst
+++ b/bach/docs/source/example-notebooks/feature-engineering.rst
@@ -12,7 +12,7 @@ This example shows how Bach can be used for feature engineering. We'll go throug
 outliers, transforming data and grouping and aggregating data so that a useful feature set is created that
 can be used for machine learning. We have a separate example available that goes into the details of how a
 data set prepared in Bach can be used for machine learning with sklearn 
-:ref:`here <example_machine_learning>`.
+:doc:`here <machine-learning>`.
 
 This example is also available in a `notebook
 <https://github.com/objectiv/objectiv-analytics/blob/main/notebooks/feature-engineering.ipynb>`_

--- a/bach/docs/source/example-notebooks/index.rst
+++ b/bach/docs/source/example-notebooks/index.rst
@@ -20,7 +20,7 @@ Bach :class:`DataFrames <bach.DataFrame>`, see the :ref:`Bach <bach>` docs or so
 started :ref:`here <bach_examples>`.
 
 
-.. _get_started_with_objectiv:
+.. _getting_started_with_objectiv:
 
 Getting started with Objectiv
 -----------------------------

--- a/bach/docs/source/example-notebooks/machine-learning.rst
+++ b/bach/docs/source/example-notebooks/machine-learning.rst
@@ -20,7 +20,7 @@ to run on your own data or use our
 <https://objectiv.io/docs/home/quickstart-guide/>`_ to try it out with demo data in 5 minutes.
 
 At first we have to install the open model hub and instantiate the Objectiv DataFrame object. See
-:ref:`get_started_with_objectiv` for more info on this.
+:ref:`getting_started_with_objectiv` for more info on this.
 
 This object points to all data in the data set. Without any aggregation, this dataset is too large to
 for pandas and sklearn. For the data set that we need, we aggregate to user level, at which point it is

--- a/bach/docs/source/example-notebooks/modelhub-basics.rst
+++ b/bach/docs/source/example-notebooks/modelhub-basics.rst
@@ -23,7 +23,7 @@ to run on your own data or use our
 <https://objectiv.io/docs/home/quickstart-guide/>`_ to try it out with demo data in 5 minutes.
 
 At first we have to install the open model hub and instantiate the Objectiv DataFrame object. See
-:ref:`get_started_with_objectiv` for more info on this.
+:ref:`getting_started_with_objectiv` for more info on this.
 
 Using the open model hub
 ------------------------

--- a/bach/docs/source/example-notebooks/open-taxonomy.rst
+++ b/bach/docs/source/example-notebooks/open-taxonomy.rst
@@ -75,7 +75,7 @@ The location stack and global contexts are stored as json type data. Within the 
 **Slicing the json data**
 With the `.json[]` syntax you can slice the array using integers. Instead of integers, dictionaries can also be passed to 'query' the json array. If the passed dictionary matches a context object in the stack, all objects of the stack starting (or ending, depending on the slice) at that object will be returned.
 
-In case a json array does not contain the object, `None` is returned. More info at the :ref:`API reference <json_accessor>`.
+In case a json array does not contain the object, `None` is returned. More info at the :doc:`API reference <../bach/api-reference/Series/Jsonb/index>`.
 
 .. _location_stack:
 
@@ -179,7 +179,7 @@ This concludes this demo.
 
 We’ve demonstrated a handful of the operations that Bach supports and hope you’ve gotten a taste of what Bach can do for your modeling workflow.
 
-The full Objectiv Bach API reference is available :ref:`here <bach_api_reference>`.
+The full Objectiv Bach API reference is available :doc:`here <../bach/api-reference/index>`.
 
 There is another example that focuses on using the :doc:`open model hub <modelhub-basics>`, 
 demonstrating how you can use the model hub and Bach to quickly answer common product analytics questions.

--- a/bach/docs/source/example-notebooks/open-taxonomy.rst
+++ b/bach/docs/source/example-notebooks/open-taxonomy.rst
@@ -181,5 +181,5 @@ We’ve demonstrated a handful of the operations that Bach supports and hope you
 
 The full Objectiv Bach API reference is available :ref:`here <bach_api_reference>`.
 
-There is another example that focuses on using the :ref:`open model hub <example_modelhub_basics>`, 
+There is another example that focuses on using the :doc:`open model hub <modelhub-basics>`, 
 demonstrating how you can use the model hub and Bach to quickly answer common product analytics questions.

--- a/bach/docs/source/example-notebooks/open-taxonomy.rst
+++ b/bach/docs/source/example-notebooks/open-taxonomy.rst
@@ -18,7 +18,7 @@ to run on your own data or use our
 <https://objectiv.io/docs/home/quickstart-guide/>`_ to try it out with demo data in 5 minutes.
 
 At first we have to install the open model hub and instantiate the Objectiv DataFrame object. See
-:ref:`get_started_with_objectiv` for more info on this.
+:ref:`getting_started_with_objectiv` for more info on this.
 
 The data
 --------

--- a/bach/docs/source/example-notebooks/open-taxonomy.rst
+++ b/bach/docs/source/example-notebooks/open-taxonomy.rst
@@ -119,7 +119,7 @@ global_contexts
 ~~~~~~~~~~~~~~~
 The `global_contexts` column in the DataFrame contain all information that is relevant to the logged event. As it is set as an `objectiv_global_context` type, specific methods can be used to access the data from the `global_contexts`. These methods can be used using the `.gc` accessor on the column. The methods are:
 
-* :ref:`.gc.get_from_context_with_type_series(type, key) <get_from_context_with_type_series>`.
+* :doc:`.gc.get_from_context_with_type_series(type, key) <../open-model-hub/api-reference/SeriesGlobalContexts/modelhub.SeriesGlobalContexts.objectiv>`.
 * The property accessors:
     * :ref:`.gc.cookie_id <gc_cookie_id>`
     * :ref:`.gc.user_agent <gc_user_agent>`

--- a/bach/docs/source/example-notebooks/product-analytics.rst
+++ b/bach/docs/source/example-notebooks/product-analytics.rst
@@ -11,13 +11,13 @@ Basic product analytics
 This example shows how the open model hub can be used for basic product analytics.
 
 This example is also available in a `notebook
-<https://github.com/objectiv/objectiv-analytics/blob/main/notebooks/basic-product-analytics.ipynb>`_
+<https://github.com/objectiv/objectiv-analytics/blob/main/notebooks/basic-analysis.ipynb>`_
 to run on your own data or use our
 `quickstart
 <https://objectiv.io/docs/home/quickstart-guide/>`_ to try it out with demo data in 5 minutes.
 
 At first we have to install the open model hub and instantiate the Objectiv DataFrame object. See
-:ref:`get_started_with_objectiv` for more info on this. The data used in this example is
+:ref:`getting_started_with_objectiv` for more info on this. The data used in this example is
 based on the data set that comes with our quickstart docker demo.
 
 First we look at the data.

--- a/bach/docs/source/example-notebooks/product-analytics.rst
+++ b/bach/docs/source/example-notebooks/product-analytics.rst
@@ -28,9 +28,8 @@ First we look at the data.
 
 The columns 'global_contexts' and the 'location_stack' contain most of the event specific data. These columns
 are json type columns and we can extract data from it based on the keys of the json objects using
-:ref:`get_from_context_with_type_series <get_from_context_with_type_series>`. Or use methods
-specific to the :ref:`location_stack` or :ref:`global_contexts` to
-extract the data.
+:doc:`get_from_context_with_type_series <../open-model-hub/api-reference/SeriesGlobalContexts/modelhub.SeriesGlobalContexts.objectiv>`. 
+Or use methods specific to the :ref:`location_stack` or :ref:`global_contexts` to extract the data.
 
 
 .. code-block:: python

--- a/bach/docs/source/example-notebooks/product-analytics.rst
+++ b/bach/docs/source/example-notebooks/product-analytics.rst
@@ -11,7 +11,7 @@ Basic product analytics
 This example shows how the open model hub can be used for basic product analytics.
 
 This example is also available in a `notebook
-<https://github.com/objectiv/objectiv-analytics/blob/main/notebooks/basic-analysis.ipynb>`_
+<https://github.com/objectiv/objectiv-analytics/blob/main/notebooks/basic-product-analytics.ipynb>`_
 to run on your own data or use our
 `quickstart
 <https://objectiv.io/docs/home/quickstart-guide/>`_ to try it out with demo data in 5 minutes.

--- a/bach/docs/source/example-notebooks/user-intent.rst
+++ b/bach/docs/source/example-notebooks/user-intent.rst
@@ -17,7 +17,7 @@ to run on your own data or use our
 <https://objectiv.io/docs/home/quickstart-guide/>`_ to try it out with demo data in 5 minutes.
 
 At first we have to install the open model hub and instantiate the Objectiv DataFrame object. See
-:ref:`get_started_with_objectiv` for more info on this. The data used in this example is
+:ref:`getting_started_with_objectiv` for more info on this. The data used in this example is
 based on the data set that comes with our quickstart docker demo.
 
 Besides the open model hub, we have to import the following packages for this example:

--- a/bach/docs/source/example-notebooks/user-intent.rst
+++ b/bach/docs/source/example-notebooks/user-intent.rst
@@ -31,9 +31,8 @@ Besides the open model hub, we have to import the following packages for this ex
 
 The columns 'global_contexts' and the 'location_stack' contain most of the event specific data. These columns
 are json type columns and we can extract data from it based on the keys of the json objects using
-:ref:`get_from_context_with_type_series <get_from_context_with_type_series>`. Or use methods
-specific to the :ref:`location_stack` or :ref:`global_contexts` to
-extract the data.
+:doc:`get_from_context_with_type_series <../open-model-hub/api-reference/SeriesGlobalContexts/modelhub.SeriesGlobalContexts.objectiv>`. 
+Or use methods specific to the :ref:`location_stack` or :ref:`global_contexts` to extract the data.
 
 .. code-block:: python
 

--- a/bach/docs/source/example-notebooks/user-intent.rst
+++ b/bach/docs/source/example-notebooks/user-intent.rst
@@ -50,7 +50,7 @@ The root_location context in the location_stack uniquely represents the top-leve
 
 Exploring session duration
 --------------------------
-The average `session_duration` model from the `open model hub </docs/modeling/>`_ is another good pointer to explore first for user intent.
+The average `session_duration` model from the `open model hub </docs/modeling/open-model-hub/>`_ is another good pointer to explore first for user intent.
 
 .. code-block:: python
 

--- a/bach/docs/source/example-notebooks/user-intent.rst
+++ b/bach/docs/source/example-notebooks/user-intent.rst
@@ -145,7 +145,7 @@ The are many next possible analysis steps, for example:
 - What kind of intent users come from different marketing campaigns?
 - How can we drive more users to the 'Implement' stage? Look at different product features that users with the 'Implement' intent use, compared to 'Explore'.
 
-A good starting point for these analyses on top of the user intent buckets is the basic product analytics example in the :ref:`example notebooks <example_notebooks>`.
+A good starting point for these analyses on top of the user intent buckets is the basic product analytics example in the :doc:`example notebooks <index>`.
 
 
 Get the SQL for this user intent analysis

--- a/bach/docs/source/index.rst
+++ b/bach/docs/source/index.rst
@@ -1,13 +1,14 @@
 .. _modeling:
 
 .. frontmatterposition:: 1
+.. frontmattersidebartitle:: Introduction
 
-============
-Introduction
-============
+======================
+Modeling with Objectiv
+======================
 
-Objectiv's modeling toolkit enables you to quickly build advanced data models and run in-depth analyses with 
-very little grunt work. This is the combined result of three components:
+Objectiv's modeling toolkit enables you to quickly build advanced data models and run in-depth analyses. 
+This is the combined result of three components:
 
 1. The open analytics taxonomy.
 1. The open model hub.

--- a/bach/docs/source/open-model-hub/models/Aggregate/index.rst
+++ b/bach/docs/source/open-model-hub/models/Aggregate/index.rst
@@ -1,9 +1,9 @@
 .. _models_reference_aggregation:
 
 
-===========
-Aggregation
-===========
+=========
+Aggregate
+=========
 
 .. currentmodule:: modelhub
 

--- a/bach/docs/source/open-model-hub/models/Map/index.rst
+++ b/bach/docs/source/open-model-hub/models/Map/index.rst
@@ -1,9 +1,9 @@
 .. _models_reference_mapping:
 
 
-=======
-Mapping
-=======
+===
+Map
+===
 
 .. currentmodule:: modelhub
 

--- a/bach/docs/source/open-model-hub/models/index.rst
+++ b/bach/docs/source/open-model-hub/models/index.rst
@@ -25,7 +25,7 @@ Map
 .. currentmodule:: modelhub.Map
 
 .. autosummary::
-    :toctree: Mapping
+    :toctree: Map
 
     is_first_session
     is_new_user
@@ -38,7 +38,7 @@ Map
 .. toctree::
     :hidden:
 
-    Mapping/index
+    Map/index
 
 
 .. currentmodule:: modelhub.Aggregate
@@ -47,7 +47,7 @@ Aggregate
 ---------
 
 .. autosummary::
-    :toctree: Aggregation
+    :toctree: Aggregate
 
     unique_users
     unique_sessions
@@ -58,4 +58,4 @@ Aggregate
 .. toctree::
     :hidden:
 
-    Aggregation/index
+    Aggregate/index

--- a/modelhub/README.md
+++ b/modelhub/README.md
@@ -16,7 +16,7 @@ made (see below). All other instructions live in the README.md in the link above
 
 ### Your own code
 To use the model hub in your own code, you can import the package and use it to get a Bach DataFrame 
-([What is Bach?](https://www.objectiv.io/docs/modeling/bach_whatisbach)) to 
+([What is Bach?](https://www.objectiv.io/docs/modeling/bach/what-is-bach/)) to 
 perform your operations on. The object can be instantiated as follows, where the `db_url` and `table_name`
 should be adjusted depending on where the data is stored and how to access it.
 ```python

--- a/notebooks/README.md
+++ b/notebooks/README.md
@@ -18,5 +18,5 @@ Metabase section in the modelhub [README.md](../modelhub/README.md).
 
 ## Notebooks 
 Please see the most complete list of examples at [the model hub example page on Objectiv.io](https://www.
-objectiv.io/docs/modeling/example_notebooks) 
+objectiv.io/docs/modeling/example-notebooks/) 
 or have a look at the files in this directory; most of them have a pretty decent introduction.

--- a/notebooks/basic-product-analytics.ipynb
+++ b/notebooks/basic-product-analytics.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "source": [
     "This is one of the Objectiv example notebooks. For more examples visit the \n",
-    "[example notebooks](https://objectiv.io/docs/modeling/example_notebooks/) section of our docs. The notebooks can run with the demo data set that comes with the our [quickstart](https://objectiv.io/docs/home/quickstart-guide/), but can be used to run on your own collected data as well.\n",
+    "[example notebooks](https://objectiv.io/docs/modeling/example-notebooks/) section of our docs. The notebooks can run with the demo data set that comes with the our [quickstart](https://objectiv.io/docs/home/quickstart-guide/), but can be used to run on your own collected data as well.\n",
     "\n",
     "All example notebooks are also available in our [quickstart](https://objectiv.io/docs/home/quickstart-guide/). With the quickstart you can spin up a fully functional Objectiv demo pipeline in five minutes. This also allows you to run these notebooks and experiment with them on a demo data set."
    ]

--- a/notebooks/basic-user-intent.ipynb
+++ b/notebooks/basic-user-intent.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "source": [
     "This is one of the Objectiv example notebooks. For more examples visit the \n",
-    "[example notebooks](https://objectiv.io/docs/modeling/example_notebooks/) section of our docs. The notebooks can run with the demo data set that comes with the our [quickstart](https://objectiv.io/docs/home/quickstart-guide/), but can be used to run on your own collected data as well.\n",
+    "[example notebooks](https://objectiv.io/docs/modeling/example-notebooks/) section of our docs. The notebooks can run with the demo data set that comes with the our [quickstart](https://objectiv.io/docs/home/quickstart-guide/), but can be used to run on your own collected data as well.\n",
     "\n",
     "All example notebooks are also available in our [quickstart](https://objectiv.io/docs/home/quickstart-guide/). With the quickstart you can spin up a fully functional Objectiv demo pipeline in five minutes. This also allows you to run these notebooks and experiment with them on a demo data set."
    ]
@@ -305,7 +305,7 @@
     "- What kind of intent users come from different marketing campaigns? \n",
     "- How can we drive more users to the 'Implement' stage? Look at different product features that users with the 'Implement' intent use, compared to 'Explore'.\n",
     "\n",
-    "A good starting point for these analyses on top of the user intent buckets is the basic product analytics example in the [example notebooks](https://objectiv.io/docs/modeling/example_notebooks/)."
+    "A good starting point for these analyses on top of the user intent buckets is the basic product analytics example in the [example notebooks](https://objectiv.io/docs/modeling/example-notebooks/)."
    ]
   },
   {

--- a/notebooks/basic-user-intent.ipynb
+++ b/notebooks/basic-user-intent.ipynb
@@ -129,7 +129,8 @@
    "metadata": {},
    "source": [
     "## Exploring session duration\n",
-    "The average `session_duration` model from the [open model hub](https://objectiv.io/docs/modeling/) is another good pointer to explore first for user intent. "
+    "The average `session_duration` model from the [open model hub](https://objectiv.io/docs/modeling/open-model-hub/) is\n",
+    "another good pointer to explore first for user intent."
    ]
   },
   {

--- a/notebooks/feature-engineering.ipynb
+++ b/notebooks/feature-engineering.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "source": [
     "This is one of the Objectiv example notebooks. For more examples visit the \n",
-    "[example notebooks](https://objectiv.io/docs/modeling/example_notebooks/) section of our docs. The notebooks can run with the demo data set that comes with the our [quickstart](https://objectiv.io/docs/home/quickstart-guide/), but can be used to run on your own collected data as well.\n",
+    "[example notebooks](https://objectiv.io/docs/modeling/example-notebooks/) section of our docs. The notebooks can run with the demo data set that comes with the our [quickstart](https://objectiv.io/docs/home/quickstart-guide/), but can be used to run on your own collected data as well.\n",
     "\n",
     "All example notebooks are also available in our [quickstart](https://objectiv.io/docs/home/quickstart-guide/). With the quickstart you can spin up a fully functional Objectiv demo pipeline in five minutes. This also allows you to run these notebooks and experiment with them on a demo data set."
    ]
@@ -19,7 +19,7 @@
     "This example shows how Bach can be used for feature engineering. We'll go through describing the data, finding\n",
     "outliers, transforming data and grouping and aggregating data so that a useful feature set is created that\n",
     "can be used for machine learning. We have a separate example available that goes into the details of how a\n",
-    "data set prepared in Bach can be used for machine learning with sklearn [here](https://objectiv.io/docs/modeling/machine_learning/)."
+    "data set prepared in Bach can be used for machine learning with sklearn [here](https://objectiv.io/docs/modeling/example-notebooks/machine-learning/)."
    ]
   },
   {
@@ -385,7 +385,7 @@
     "Now that we have our data set, we can use it for machine learning, using for example sklearn. To do so\n",
     "we call `to_pandas()` to get a pandas DataFrame that can be used in sklearn.\n",
     "\n",
-    "Here is our example on how to use Objectiv data and [sklearn](https://objectiv.io/docs/modeling/machine_learning/)."
+    "Here is our example on how to use Objectiv data and [sklearn](https://objectiv.io/docs/modeling/example-notebooks/machine-learning/)."
    ]
   },
   {

--- a/notebooks/model-hub-demo-notebook.ipynb
+++ b/notebooks/model-hub-demo-notebook.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "source": [
     "This is one of the Objectiv example notebooks. For more examples visit the \n",
-    "[example notebooks](https://objectiv.io/docs/modeling/example_notebooks/) section of our docs. The notebooks can run with the demo data set that comes with the our [quickstart](https://objectiv.io/docs/home/quickstart-guide/), but can be used to run on your own collected data as well.\n",
+    "[example notebooks](https://objectiv.io/docs/modeling/example-notebooks/) section of our docs. The notebooks can run with the demo data set that comes with the our [quickstart](https://objectiv.io/docs/home/quickstart-guide/), but can be used to run on your own collected data as well.\n",
     "\n",
     "All example notebooks are also available in our [quickstart](https://objectiv.io/docs/home/quickstart-guide/). With the quickstart you can spin up a fully functional Objectiv demo pipeline in five minutes. This also allows you to run these notebooks and experiment with them on a demo data set."
    ]
@@ -21,7 +21,7 @@
     "\n",
     "This example uses real, unaltered data that was collected from https://objectiv.io/ with Objectiv’s Tracker. All models in the open model hub are compatible with datasets that have been validated against the [open analytics taxonomy](https://objectiv.io/docs/taxonomy/).\n",
     "\n",
-    "For an overview of all available models, check out the [open model hub docs](https://objectiv.io/docs/modeling/models/)."
+    "For an overview of all available models, check out the [open model hub docs](https://objectiv.io/docs/modeling/open-model-hub/models/)."
    ]
   },
   {
@@ -146,7 +146,7 @@
    "id": "d46cba1e",
    "metadata": {},
    "source": [
-    "Or we can label conversion events. To do this we first have to define what a conversion is by setting the type of event and the location on the product at which this event was triggered with `add_conversion_event` (this is called the location stack, see [here](https://objectiv.io/docs/modeling/open_taxonomy/#location-stack) for info)."
+    "Or we can label conversion events. To do this we first have to define what a conversion is by setting the type of event and the location on the product at which this event was triggered with `add_conversion_event` (this is called the location stack, see [here](https://objectiv.io/docs/modeling/example-notebooks/open-taxonomy/#location_stack) for info)."
    ]
   },
   {
@@ -359,8 +359,8 @@
    "id": "670dde5e",
    "metadata": {},
    "source": [
-    "There is another [example](https://objectiv.io/docs/modeling/bach_examples/) that demonstrates what you can do with the Bach modeling\n",
-    "library, or head over to the [api reference](https://objectiv.io/docs/modeling/bach_reference/) for a complete overview of the possibilities."
+    "There is another [example](https://objectiv.io/docs/modeling/bach/examples/) that demonstrates what you can do with the Bach modeling\n",
+    "library, or head over to the [api reference](https://objectiv.io/docs/modeling/bach/api-reference/) for a complete overview of the possibilities."
    ]
   },
   {
@@ -396,7 +396,7 @@
     "\n",
     "We hope you’ve gotten a taste of the power and flexibility of the open model hub to quickly answer common product analytics questions. You can take it a lot further and build highly specific model stacks for in-depth analysis and exploration.\n",
     "\n",
-    "For a complete overview of all available and upcoming models, check out the [model hub docs](https://objectiv.io/docs/modeling/models/)."
+    "For a complete overview of all available and upcoming models, check out the [model hub docs](https://objectiv.io/docs/modeling/open-model-hub/models/)."
    ]
   }
  ],

--- a/notebooks/open-taxonomy-how-to.ipynb
+++ b/notebooks/open-taxonomy-how-to.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "source": [
     "This is one of the Objectiv example notebooks. For more examples visit the \n",
-    "[example notebooks](https://objectiv.io/docs/modeling/example_notebooks/) section of our docs. The notebooks can run with the demo data set that comes with the our [quickstart](https://objectiv.io/docs/home/quickstart-guide/), but can be used to run on your own collected data as well.\n",
+    "[example notebooks](https://objectiv.io/docs/modeling/example-notebooks/) section of our docs. The notebooks can run with the demo data set that comes with the our [quickstart](https://objectiv.io/docs/home/quickstart-guide/), but can be used to run on your own collected data as well.\n",
     "\n",
     "All example notebooks are also available in our [quickstart](https://objectiv.io/docs/home/quickstart-guide/). With the quickstart you can spin up a fully functional Objectiv demo pipeline in five minutes. This also allows you to run these notebooks and experiment with them on a demo data set."
    ]
@@ -24,7 +24,7 @@
     "The Objectiv Bach API is heavily inspired by the pandas API. We believe this provides a great, generic interface to handle large amounts of data in a python environment while supporting multiple data stores.\n",
     "\n",
     "For an intro into the pandas api see: https://pandas.pydata.org/pandas-docs/stable/user_guide/10min.html  \n",
-    "The full Objectiv Bach api reference is available here: https://objectiv.io/docs/modeling/bach_reference/"
+    "The full Objectiv Bach api reference is available here: https://objectiv.io/modeling/bach/api-reference/"
    ]
   },
   {
@@ -90,11 +90,11 @@
    "metadata": {},
    "source": [
     "The data for the DataFrame is still in the database and the database is not queried before any of the data is loaded to the python environment. The methods that query the database are: \n",
-    "* [`head()`](https://objectiv.io/docs/modeling/DataFrame/bach.DataFrame.head/)\n",
-    "* [`to_pandas()`](https://objectiv.io/docs/modeling/DataFrame/bach.DataFrame.to_pandas/)\n",
-    "* [`get_sample()`](https://objectiv.io/docs/modeling/DataFrame/bach.DataFrame.get_sample/)\n",
-    "* [`to_numpy()`](https://objectiv.io/docs/modeling/DataFrame/bach.DataFrame.to_numpy/)\n",
-    "* The property accessors [`Series.array`](https://objectiv.io/docs/modeling/Series/bach.Series.array/), [`Series.value`](https://objectiv.io/docs/modeling/Series/bach.Series.value/)\n",
+    "* [`head()`](https://objectiv.io/docs/modeling/bach/api-reference/DataFrame/head/)\n",
+    "* [`to_pandas()`](https://objectiv.io/docs/modeling/bach/api-reference/DataFrame/to_pandas/)\n",
+    "* [`get_sample()`](https://objectiv.io/docs/modeling/bach/api-reference/DataFrame/get_sample/)\n",
+    "* [`to_numpy()`](https://objectiv.io/docs/modeling/bach/api-reference/DataFrame/to_numpy/)\n",
+    "* The property accessors [`Series.array`](https://objectiv.io/docs/modeling/bach/api-reference/Series/array/), [`Series.value`](https://objectiv.io/docs/modeling/bach/api-reference/Series/value/)\n",
     "\n",
     "For demo puposes of this notebook, these methods are called often to show the results of our operations. To limit the number of executed queries on the full data set it is recommended to use these methods less often or [to sample the data first](#Sampling)."
    ]
@@ -262,7 +262,7 @@
     " {'id': 'DataFrame', '_type': 'ExpandableContext'},\n",
     " {'id': 'Overview', '_type': 'LinkContext'}]\n",
     "```\n",
-    "In case a json array does not contain the object, `None` is returned. More info at the api reference: https://objectiv.io/docs/modeling/Series/bach.SeriesJsonb.json/#bach.SeriesJsonb.json"
+    "In case a json array does not contain the object, `None` is returned. More info at the api reference: https://objectiv.io/docs/modeling/bach/api-reference/Series/Jsonb/json/"
    ]
   },
   {
@@ -274,8 +274,8 @@
     "The `location_stack` column in the DataFrame stores the information on the exact location where the event is triggered in the product. The example used above is the location stack of the link to the DataFrame api reference in the menu on our docs page.\n",
     "\n",
     "Because of the specific way the location information is labeled, validated, and stored using the Open Taxonomy, it can be used to slice and group your products' features in an efficient and easy way. The column is set as an `objectiv_location_stack` type, and therefore location stack specific methods can be used to access the data from the `location_stack`. These methods can be used using the `.ls` accessor on the column. The methods are:\n",
-    "* The property accessors [`.ls.navigation_features`](https://objectiv.io/docs/modeling/modelhub_api_reference/modelhub.SeriesLocationStack.ls/), [`.ls.feature_stack`](https://objectiv.io/docs/modeling/modelhub_api_reference/modelhub.SeriesLocationStack.ls/), [`.ls.nice_name`](https://objectiv.io/docs/modeling/modelhub_api_reference/modelhub.SeriesLocationStack.ls/)\n",
-    "* all [methods](https://objectiv.io/docs/modeling/Series/bach.SeriesJsonb.json/) for the json(b) type can also be accessed using `.ls`\n",
+    "* The property accessors [`.ls.navigation_features`](https://objectiv.io/docs/modeling/open-model-hub/api-reference/SeriesLocationStack/ls/), [`.ls.feature_stack`](https://objectiv.io/docs/modeling/open-model-hub/api-reference/SeriesLocationStack/ls/), [`.ls.nice_name`](https://objectiv.io/docs/modeling/open-model-hub/api-reference/SeriesLocationStack/ls/)\n",
+    "* all [methods](https://objectiv.io/docs/modeling/bach/api-reference/Series/Jsonb/json/) for the json(b) type can also be accessed using `.ls`\n",
     "\n",
     "For example,\n",
     "```python\n",
@@ -303,9 +303,9 @@
    "source": [
     "### global_contexts\n",
     "The `global_contexts` column in the DataFrame contain all information that is relevant to the logged event. As it is set as an `objectiv_global_context` type, specific methods can be used to access the data from the `global_contexts`. These methods can be used using the `.gc` accessor on the column. The methods are:\n",
-    "* [`.gc.get_from_context_with_type_series(type, key)`](https://objectiv.io/docs/modeling/modelhub_api_reference/modelhub.SeriesGlobalContexts.obj/)\n",
-    "* The property accessors [`.gc.cookie_id`](https://objectiv.io/docs/modeling/modelhub_api_reference/modelhub.SeriesGlobalContexts.gc/), [`.gc.user_agent`](https://objectiv.io/docs/modeling/modelhub_api_reference/modelhub.SeriesGlobalContexts.gc/), [`.gc.application`](https://objectiv.io/docs/modeling/modelhub_api_reference/modelhub.SeriesGlobalContexts.gc/)\n",
-    "* all [methods](https://objectiv.io/docs/modeling/Series/bach.SeriesJsonb.json/) for the json(b) type can also be accessed using `.gc`\n",
+    "* [`.gc.get_from_context_with_type_series(type, key)`](https://objectiv.io/docs/modeling/open-model-hub/api-reference/SeriesGlobalContexts/obj/)\n",
+    "* The property accessors [`.gc.cookie_id`](https://objectiv.io/docs/modeling/open-model-hub/api-reference/SeriesGlobalContexts/gc/), [`.gc.user_agent`](https://objectiv.io/docs/modeling/open-model-hub/api-reference/SeriesGlobalContexts/gc/), [`.gc.application`](https://objectiv.io/docs/modeling/open-model-hub/api-reference/SeriesGlobalContexts/gc/)\n",
+    "* all [methods](https://objectiv.io/docs/modeling/bach/api-reference/Series/Jsonb/json/) for the json(b) type can also be accessed using `.gc`\n",
     "\n",
     "The full reference of global contexts is [here](https://objectiv.io/docs/taxonomy/global-contexts/). An example is queried below:"
    ]
@@ -431,9 +431,9 @@
     "\n",
     "We’ve demonstrated a handful of the operations that Bach supports and hope you’ve gotten a taste of what Bach can do for your modeling workflow. \n",
     "\n",
-    "The full Objectiv Bach API reference is available here: https://objectiv.io/docs/modeling/bach_reference/\n",
+    "The full Objectiv Bach API reference is available here: https://objectiv.io/docs/modeling/bach/api-reference/\n",
     "\n",
-    "There is another example that focuses on using the [open model hub](https://objectiv.io/docs/modeling/modelhub_basics/), demonstrating\n",
+    "There is another example that focuses on using the [open model hub](https://objectiv.io/docs/modeling/example-notebooks/modelhub-basics/), demonstrating\n",
     "how you can use the model hub and Bach to quickly answer common product analytics questions."
    ]
   }

--- a/notebooks/sklearn-example.ipynb
+++ b/notebooks/sklearn-example.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "source": [
     "This is one of the Objectiv example notebooks. For more examples visit the \n",
-    "[example notebooks](https://objectiv.io/docs/modeling/example_notebooks/) section of our docs. The notebooks can run with the demo data set that comes with the our [quickstart](https://objectiv.io/docs/home/quickstart-guide/), but can be used to run on your own collected data as well.\n",
+    "[example notebooks](https://objectiv.io/docs/modeling/example-notebooks/) section of our docs. The notebooks can run with the demo data set that comes with the our [quickstart](https://objectiv.io/docs/home/quickstart-guide/), but can be used to run on your own collected data as well.\n",
     "\n",
     "All example notebooks are also available in our [quickstart](https://objectiv.io/docs/home/quickstart-guide/). With the quickstart you can spin up a fully functional Objectiv demo pipeline in five minutes. This also allows you to run these notebooks and experiment with them on a demo data set."
    ]
@@ -19,7 +19,7 @@
     "With Objectiv you can do all your analysis and Machine Learning directly on the raw data in your SQL database.\n",
     "This example shows in the simplest way possible how you can use Objectiv to create a basic feature set and use\n",
     "sklearn to do machine learning on this data set. We also have an example that goes deeper into\n",
-    "feature engineering [here](https://objectiv.io/docs/modeling/feature_engineering/)."
+    "feature engineering [here](https://objectiv.io/docs/modeling/example-notebooks/feature-engineering/)."
    ]
   },
   {
@@ -69,7 +69,7 @@
    "id": "20c780fa",
    "metadata": {},
    "source": [
-    "We create a data set of per user all the root locations that the user clicked on. For the ins and outs on feature engineering see our feature [engineering example](https://objectiv.io/docs/modeling/feature_engineering/)."
+    "We create a data set of per user all the root locations that the user clicked on. For the ins and outs on feature engineering see our feature [engineering example](https://objectiv.io/docs/modeling/example-notebooks/feature-engineering/)."
    ]
   },
   {


### PR DESCRIPTION
Several improvements found during testing.

Links to sections:
- Added support for targets (=HTML anchors).
- Added document references to example notebooks where possible, so there's no unnecessary jumping to anchors.
- Switched to direct doc reference to SeriesGlobalContexts for `get_from_context_with_type_series` method in example notebooks.

Content:
- Updates title of Modeling docs intro to 'Modeling with Objectiv'. Added a new frontmatter directive to support this.
- Fixed compact bullet list all showing up in one line in the open model hub intro.

API reference:
- Added full support for attributes like Bach's `Series.dtype`.
- No longer repeating classnames for methods & properties, e.g. no more `DateTimeOperation` in method 'DateTimeOperation.sql_format()' for Bach's `Series.AbstractDateTime.dt`.
  - Increased max depth level for the TOC, so headings like 'parameters' and 'return' are still shown. Affects other docs like in Tracking as well.
- Fixed small styling glitch in parameter list of methods.
- Smaller headings for all API References.