### PR TITLE
Update to new Bach API reference URL in notebook

### DIFF
--- a/notebooks/open-taxonomy-how-to.ipynb
+++ b/notebooks/open-taxonomy-how-to.ipynb
@@ -24,7 +24,7 @@
     "The Objectiv Bach API is heavily inspired by the pandas API. We believe this provides a great, generic interface to handle large amounts of data in a python environment while supporting multiple data stores.\n",
     "\n",
     "For an intro into the pandas api see: https://pandas.pydata.org/pandas-docs/stable/user_guide/10min.html  \n",
-    "The full Objectiv Bach api reference is available here: https://objectiv.io/modeling/bach/api-reference/"
+    "The full Objectiv Bach api reference is available here: https://objectiv.io/docs/modeling/bach/api-reference/"
    ]
   },
   {


### PR DESCRIPTION
Updates to the new Bach API reference URL in the open taxonomy notebook.