### PR TITLE
Explicit column names in SQL used in `from_table`

### DIFF
--- a/bach/bach/dataframe.py
+++ b/bach/bach/dataframe.py
@@ -588,13 +588,14 @@ class DataFrame:
 
         # use placeholders for columns in order to avoid conflicts when extracting spec references
         column_stmt = ','.join(f'{{col_{col_index}}}' for col_index in range(len(dtypes)))
-        column_place_holders = {
+        column_placeholders = {
             f'col_{col_index}': quote_identifier(engine.dialect, col_name)
             for col_index, col_name in enumerate(dtypes.keys())
         }
+        sql_params.update(column_placeholders)
 
         sql = f'SELECT {column_stmt} FROM {sql_table_name_template}'
-        model_builder = CustomSqlModelBuilder(sql=sql, name='from_table', **column_place_holders)
+        model_builder = CustomSqlModelBuilder(sql=sql, name='from_table')
         sql_model = model_builder(**sql_params)
 
         return cls._from_node(

--- a/bach/bach/dataframe.py
+++ b/bach/bach/dataframe.py
@@ -586,9 +586,15 @@ class DataFrame:
             sql_table_name_template = f'{{bq_project_id}}.{sql_table_name_template}'
             sql_params['bq_project_id'] = quote_identifier(engine.dialect, bq_project_id)
 
-        column_stmt = ','.join([quote_identifier(engine.dialect, col_name) for col_name in dtypes.keys()])
+        # use placeholders for columns in order to avoid conflicts when extracting spec references
+        column_stmt = ','.join(f'{{col_{col_index}}}' for col_index in range(len(dtypes)))
+        column_place_holders = {
+            f'col_{col_index}': quote_identifier(engine.dialect, col_name)
+            for col_index, col_name in enumerate(dtypes.keys())
+        }
+
         sql = f'SELECT {column_stmt} FROM {sql_table_name_template}'
-        model_builder = CustomSqlModelBuilder(sql=sql, name='from_table')
+        model_builder = CustomSqlModelBuilder(sql=sql, name='from_table', **column_place_holders)
         sql_model = model_builder(**sql_params)
 
         return cls._from_node(

--- a/bach/bach/dataframe.py
+++ b/bach/bach/dataframe.py
@@ -584,7 +584,8 @@ class DataFrame:
             sql_table_name_template = f'{{bq_project_id}}.{sql_table_name_template}'
             sql_params['bq_project_id'] = quote_identifier(engine.dialect, bq_project_id)
 
-        sql = f'SELECT * FROM {sql_table_name_template}'
+        column_stmt = ','.join([quote_identifier(engine.dialect, col_name) for col_name in dtypes.keys()])
+        sql = f'SELECT {column_stmt} FROM {sql_table_name_template}'
         model_builder = CustomSqlModelBuilder(sql=sql, name='from_table')
         sql_model = model_builder(**sql_params)
 

--- a/bach/bach/dataframe.py
+++ b/bach/bach/dataframe.py
@@ -572,9 +572,11 @@ class DataFrame:
                 bq_project_id=bq_project_id
             )
 
-        # For postgres we just generate:    'SELECT * FROM "table_name"'
-        # For BQ we might need to generate: 'SELECT * FROM `project_id`.`data_set`.`table_name`'
-
+        # For postgres we just generate:
+        # 'SELECT "column_1", ... , "column_N" FROM "table_name"'
+        # For BQ we might need to generate:
+        # 'SELECT `column_1`, ... , `column_N`  FROM `project_id`.`data_set`.`table_name`'
+        #  columns in select statement are based on keys from dtypes
         sql_table_name_template = '{table_name}'
         sql_params = {'table_name': quote_identifier(engine.dialect, table_name)}
         if bq_dataset:

--- a/bach/sql_models/model.py
+++ b/bach/sql_models/model.py
@@ -673,7 +673,7 @@ class CustomSqlModelBuilder(SqlModelBuilder):
     Builder that instantiates a SqlModel that can run custom sql and refer custom tables.
     """
 
-    def __init__(self, sql: str, name: str = None):
+    def __init__(self, sql: str, name: str = None, **values):
         """
         :param sql: sql of the model
         :param name: optional override of the generic name (default: 'CustomSqlModel')
@@ -683,7 +683,7 @@ class CustomSqlModelBuilder(SqlModelBuilder):
             self._generic_name = name
         else:
             self._generic_name = 'CustomSqlModel'
-        super().__init__()
+        super().__init__(**values)
 
     @property
     def sql(self):

--- a/bach/sql_models/model.py
+++ b/bach/sql_models/model.py
@@ -673,7 +673,7 @@ class CustomSqlModelBuilder(SqlModelBuilder):
     Builder that instantiates a SqlModel that can run custom sql and refer custom tables.
     """
 
-    def __init__(self, sql: str, name: str = None, **values):
+    def __init__(self, sql: str, name: str = None):
         """
         :param sql: sql of the model
         :param name: optional override of the generic name (default: 'CustomSqlModel')
@@ -683,7 +683,7 @@ class CustomSqlModelBuilder(SqlModelBuilder):
             self._generic_name = name
         else:
             self._generic_name = 'CustomSqlModel'
-        super().__init__(**values)
+        super().__init__()
 
     @property
     def sql(self):

--- a/bach/tests/functional/bach/test_df_from_pandas.py
+++ b/bach/tests/functional/bach/test_df_from_pandas.py
@@ -65,15 +65,16 @@ def test_from_pandas_table(pg_engine):
 @pytest.mark.xdist_group(name="from_pd_table")
 def test_from_pandas_table_injection(pg_engine):
     pdf = get_pandas_df(TEST_DATA_INJECTION, COLUMNS_INJECTION)
-    bt = DataFrame.from_pandas(
-        engine=pg_engine,
-        df=pdf,
-        convert_objects=True,
-        name='test_from_pd_{table}_"injection"',
-        materialization='table',
-        if_exists='replace'
-    )
-    assert_equals_data(bt, expected_columns=EXPECTED_COLUMNS_INJECTION, expected_data=EXPECTED_DATA_INJECTION)
+
+    with pytest.raises(ValueError, match="unexpected '{' in field name"):
+        DataFrame.from_pandas(
+            engine=pg_engine,
+            df=pdf,
+            convert_objects=True,
+            name='test_from_pd_{table}_"injection"',
+            materialization='table',
+            if_exists='replace',
+        )
 
 
 def test_from_pandas_ephemeral_basic(engine):

--- a/bach/tests/functional/bach/test_df_from_pandas.py
+++ b/bach/tests/functional/bach/test_df_from_pandas.py
@@ -63,12 +63,13 @@ def test_from_pandas_table(pg_engine):
 
 
 @pytest.mark.xdist_group(name="from_pd_table")
-def test_from_pandas_table_injection(pg_engine):
+def test_from_pandas_table_injection(engine):
     pdf = get_pandas_df(TEST_DATA_INJECTION, COLUMNS_INJECTION)
 
-    with pytest.raises(ValueError, match="unexpected '{' in field name"):
+    # TODO: generate same value error for all engines
+    with pytest.raises(ValueError):
         DataFrame.from_pandas(
-            engine=pg_engine,
+            engine=engine,
             df=pdf,
             convert_objects=True,
             name='test_from_pd_{table}_"injection"',


### PR DESCRIPTION
We should just select needed columns from SQL, selecting all columns for BigQuery might be expensive.