### PR TITLE
React Tracker: Success and Failure event tracking hooks improvements

### DIFF
--- a/tracker/core/react/src/hooks/eventTrackers/useFailureEventTracker.ts
+++ b/tracker/core/react/src/hooks/eventTrackers/useFailureEventTracker.ts
@@ -3,25 +3,17 @@
  */
 
 import { trackFailureEvent } from '../../eventTrackers/trackFailureEvent';
+import { SuccessEventTrackerParameters } from '../../eventTrackers/trackSuccessEvent';
 import { EventTrackerHookParameters } from '../../types';
 import { useLocationStack } from '../consumers/useLocationStack';
 import { useTracker } from '../consumers/useTracker';
 
 /**
- * The parameters of `useFailureEventTracker`. Has one extra attribute, `message`, as mandatory parameter.
- */
-export type FailureEventTrackerHookParameters = EventTrackerHookParameters & {
-  /**
-   * The failure message or error code.
-   */
-  message: string;
-};
-
-/**
  * Returns an FailureEvent Tracker callback function, ready to be triggered.
  */
-export const useFailureEventTracker = (parameters: FailureEventTrackerHookParameters) => {
-  const { message, tracker = useTracker(), locationStack = useLocationStack(), globalContexts } = parameters;
+export const useFailureEventTracker = (parameters: EventTrackerHookParameters = {}) => {
+  const { tracker = useTracker(), locationStack = useLocationStack(), globalContexts } = parameters;
 
-  return () => trackFailureEvent({ message, tracker, locationStack, globalContexts });
+  return ({ message }: Pick<SuccessEventTrackerParameters, 'message'>) =>
+    trackFailureEvent({ message, tracker, locationStack, globalContexts });
 };

--- a/tracker/core/react/src/hooks/eventTrackers/useSuccessEventTracker.ts
+++ b/tracker/core/react/src/hooks/eventTrackers/useSuccessEventTracker.ts
@@ -2,26 +2,17 @@
  * Copyright 2021-2022 Objectiv B.V.
  */
 
-import { trackSuccessEvent } from '../../eventTrackers/trackSuccessEvent';
+import { SuccessEventTrackerParameters, trackSuccessEvent } from '../../eventTrackers/trackSuccessEvent';
 import { EventTrackerHookParameters } from '../../types';
 import { useLocationStack } from '../consumers/useLocationStack';
 import { useTracker } from '../consumers/useTracker';
 
 /**
- * The parameters of `useSuccessEventTracker`. Has one extra attribute, `message`, as mandatory parameter.
- */
-export type SuccessEventTrackerHookParameters = EventTrackerHookParameters & {
-  /**
-   * The success message or status code.
-   */
-  message: string;
-};
-
-/**
  * Returns a SuccessEvent Tracker callback function, ready to be triggered.
  */
-export const useSuccessEventTracker = (parameters: SuccessEventTrackerHookParameters) => {
-  const { message, tracker = useTracker(), locationStack = useLocationStack(), globalContexts } = parameters;
+export const useSuccessEventTracker = (parameters: EventTrackerHookParameters = {}) => {
+  const { tracker = useTracker(), locationStack = useLocationStack(), globalContexts } = parameters;
 
-  return () => trackSuccessEvent({ message, tracker, locationStack, globalContexts });
+  return ({ message }: Pick<SuccessEventTrackerParameters, 'message'>) =>
+    trackSuccessEvent({ message, tracker, locationStack, globalContexts });
 };

--- a/tracker/core/react/tests/FailureEvent.test.tsx
+++ b/tracker/core/react/tests/FailureEvent.test.tsx
@@ -35,8 +35,8 @@ describe('FailureEvent', () => {
     const tracker = new Tracker({ applicationId: 'app-id', transport: spyTransport });
 
     const Component = () => {
-      const trackFailureEvent = useFailureEventTracker({ message: 'ko' });
-      trackFailureEvent();
+      const trackFailureEvent = useFailureEventTracker();
+      trackFailureEvent({ message: 'ko' });
 
       return <>Component triggering FailureEvent</>;
     };
@@ -60,11 +60,10 @@ describe('FailureEvent', () => {
 
     const Component = () => {
       const trackFailureEvent = useFailureEventTracker({
-        message: 'ko',
         tracker: customTracker,
         locationStack: [makeContentContext({ id: 'override' })],
       });
-      trackFailureEvent();
+      trackFailureEvent({ message: 'ko' });
 
       return <>Component triggering FailureEvent</>;
     };

--- a/tracker/core/react/tests/SuccessEvent.test.tsx
+++ b/tracker/core/react/tests/SuccessEvent.test.tsx
@@ -35,8 +35,8 @@ describe('SuccessEvent', () => {
     const tracker = new Tracker({ applicationId: 'app-id', transport: spyTransport });
 
     const Component = () => {
-      const trackSuccessEvent = useSuccessEventTracker({ message: 'ok' });
-      trackSuccessEvent();
+      const trackSuccessEvent = useSuccessEventTracker();
+      trackSuccessEvent({ message: 'ok' });
 
       return <>Component triggering SuccessEvent</>;
     };
@@ -60,11 +60,10 @@ describe('SuccessEvent', () => {
 
     const Component = () => {
       const trackSuccessEvent = useSuccessEventTracker({
-        message: 'ok',
         tracker: customTracker,
         locationStack: [makeContentContext({ id: 'override' })],
       });
-      trackSuccessEvent();
+      trackSuccessEvent({ message: 'ok' });
 
       return <>Component triggering SuccessEvent</>;
     };


### PR DESCRIPTION
In the previous version of `useFailureEventTracker` and `useSuccessEventTracker` the 'message' parameter would be required when invoking the hook.

The problem with that approach is that it makes it impossible to specify error or success messages at runtime. 

I've changed the signature of the hooks and the signature of their callbacks by moving the message parameter from the hook to the callbacks.

---
# Before

Example of the code before:

```tsx
const trackSuccessEvent = useSuccessEventTracker({ message: 'ok' });
const trackFailureEvent = useFailureEventTracker({ message: 'ko' });

submit(payload)
  .then((response) => {
    if (response.ok) {
      trackSuccessEvent();
    } else {
      trackFailureEvent();
    }
  }).catch(() => {
     trackFailureEvent();
  });
```

In the example above we cannot differentiate between a network failure or a remote failure, as both would produce the same `trackFailureEvent`.

We could improve the code like this:
```tsx
const trackSuccessEvent = useSuccessEventTracker({ message: 'ok' });
const trackNetworkFailureEvent = useFailureEventTracker({ message: 'network-ko' });
const trackRemoteFailureEvent = useFailureEventTracker({ message: 'remote-ko' });

submit(payload)
  .then((response) => {
    if (response.ok) {
      trackSuccessEvent();
    } else {
      trackRemoteFailureEvent();
    }
  }).catch(() => {
     trackNetworkFailureEvent();
  });
```

But what if our remote can return multiple errors? This becomes really difficult to maintain. On top of that it should not be required for the FE to know about all possible remote errors.

---
# New implementation


With the new implementation, message can be specified when triggering the callbacks. This allows us to map response messages and remote error messages directly to the events' message property.

```tsx
const trackSuccessEvent = useSuccessEventTracker();
const trackFailureEvent = useFailureEventTracker();

submit(payload)
  .then((response) => {
    if (response.ok) {
      trackSuccessEvent({ message: 'ok' });
    } else {
      trackFailureEvent({ message: response.statusText });
    }
  }).catch((error) => {
     trackFailureEvent({ message: error.message });
  });
```
