### PR TITLE
Small modeling docs improvements

### DIFF
--- a/bach/docs/source/example-notebooks/index.rst
+++ b/bach/docs/source/example-notebooks/index.rst
@@ -72,5 +72,5 @@ introduction examples are :ref:`here <bach_examples>`.
     feature-engineering
     modelhub-basics
     open-taxonomy
-    feature_importance
+    feature-importance
 

--- a/bach/docs/source/index.rst
+++ b/bach/docs/source/index.rst
@@ -26,7 +26,7 @@ model on without any cleaning or transformation.
 The open model hub consists of pre-built models and operations that you can combine to build advanced 
 compound models with little effort. The open model hub is powered by Bach, our python-based modeling library.
 
-:ref:`Learn more about the open model hub <open_model_hub>`
+:doc:`Learn more about the open model hub <open-model-hub/index>`
 
 ### The Bach modeling library
 
@@ -34,14 +34,14 @@ Bach is a python-based modeling library that enables you to use Pandas-like oper
 dataset in the SQL database. Any dataframe or model built with Bach can be converted to an SQL statement with 
 a single command.
 
-:ref:`Learn more about the Objectiv Bach modeling libary <bach>`
+:doc:`Learn more about the Objectiv Bach modeling libary <bach/index>`
 
 ### Example notebooks
 
 To see how all components work together, there are several example notebooks that show how you can analyze 
 and model data using the open analytics taxonomy, the open model hub, and the Bach modeling library.
 
-:ref:`See the example notebooks <example_notebooks>`
+:doc:`See the example notebooks <example-notebooks/index>`
 
 
 .. toctree::


### PR DESCRIPTION
- Direct links to the modeling docs sections instead of references with an anchor, so the page doesn't 'jump' .
- Rename the 'feature_importance' notebook link to the new 'feature-importance' convention (corresponding redirect in https://github.com/objectiv/objectiv.io/pull/432).