### PR TITLE
Remove obsolete copright notices from READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,4 @@ For more information, visit [objectiv.io](https://www.objectiv.io) or [Objectiv 
 
 ---
 
-This repository is part of the source code for Objectiv, which is released under the Apache 2.0 License. Please refer to [LICENSE.md](LICENSE.md) for details. Unless otherwise noted, all files © 2021 Objectiv B.V.
-
-
-
+This repository is part of the source code for Objectiv, which is released under the Apache 2.0 License. Please refer to [LICENSE.md](LICENSE.md) for details.

--- a/bach/README.md
+++ b/bach/README.md
@@ -113,5 +113,3 @@ If you want to contribute to Objectiv or use it as a base for custom development
 
 ## License
 This repository is part of the source code for Objectiv, which is released under the Apache 2.0 License. Please refer to [LICENSE.md](../LICENSE.md) for details.
-
-Unless otherwise noted, all files © 2021 Objectiv B.V.

--- a/backend/README.md
+++ b/backend/README.md
@@ -31,5 +31,3 @@ If you want to contribute to Objectiv or use it as a base for custom development
 
 ## License
 This repository is part of the source code for Objectiv, which is released under the Apache 2.0 License. Please refer to [LICENSE.md](../LICENSE.md) for details.
-
-Unless otherwise noted, all files © 2021 Objectiv B.V.

--- a/schema/README.md
+++ b/schema/README.md
@@ -33,5 +33,3 @@ If you want to contribute to the Open Taxonomy or use it as a base for custom de
 
 ## License
 This repository is part of the source code for Objectiv, which is released under the Apache 2.0 License. Please refer to [LICENSE.md](../LICENSE.md) for details.
-
-Unless otherwise noted, all files © 2021 Objectiv B.V.

--- a/tracker/README.md
+++ b/tracker/README.md
@@ -33,5 +33,3 @@ If you want to contribute to Objectiv or use it as a base for custom development
 
 ## License
 This repository is part of the source code for Objectiv, which is released under the Apache 2.0 License. Please refer to [LICENSE.md](../LICENSE.md) for details.
-
-Unless otherwise noted, all files © 2021-2022 Objectiv B.V.


### PR DESCRIPTION
The READMEs currently contain copyright messages. As every file has a copyright message now, as well as our License files, this is redundant. This PR removes them from the READMEs.