### PR TITLE
Do not aggregate the index in a DataFrame

### DIFF
--- a/bach/bach/dataframe.py
+++ b/bach/bach/dataframe.py
@@ -1583,7 +1583,7 @@ class DataFrame:
         It will not materialize, just prepared for more operations
         """
         new_series = {s.name: s.copy_override(group_by=group_by, index=group_by.index, index_sorting=[])
-                      for n, s in df.all_series.items() if n not in group_by.index.keys()}
+                      for n, s in df.data.items() if n not in group_by.index.keys()}
         return df.copy_override(
             index=group_by.index,
             series=new_series,

--- a/bach/bach/plotting.py
+++ b/bach/bach/plotting.py
@@ -92,7 +92,7 @@ class PlotHandler(object):
 
         # create frequency distribution dataframe per label (numeric column)
         # labels are contained in __stacked_index series (result from DataFrame.stack)
-        frequencies = bins_per_col_df.groupby(by=['__stacked_index', 'range']).count()
+        frequencies = bins_per_col_df.reset_index().groupby(by=['__stacked_index', 'range']).count()
         frequencies = frequencies.reset_index(drop=False)
 
         # rename columns to meaningful names

--- a/bach/docs/source/bach/api-reference/Series/index.rst
+++ b/bach/docs/source/bach/api-reference/Series/index.rst
@@ -57,6 +57,7 @@ Sql Model
     :toctree:
 
     Series.base_node
+    Series.materialize
     Series.view_sql
 
 Comparison and set operations
@@ -76,6 +77,7 @@ Conversion, reshaping, sorting
 .. autosummary::
     :toctree:
 
+    Series.reset_index
     Series.sort_index
     Series.sort_values
     Series.fillna

--- a/bach/tests/functional/bach/test_df.py
+++ b/bach/tests/functional/bach/test_df.py
@@ -149,7 +149,7 @@ def test_quantile(pg_engine) -> None:
 
         # pandas returns a series when calculating just 1 quantile
         result_values = result.to_numpy() if isinstance(q, list) else result.to_numpy()[0]
-        expected = pdf.reset_index(drop=False).quantile(q)
+        expected = pdf.reset_index(drop=True).quantile(q)
         np.testing.assert_almost_equal(expected, result_values, decimal=4)
 
 

--- a/bach/tests/functional/bach/test_df_getitem.py
+++ b/bach/tests/functional/bach/test_df_getitem.py
@@ -131,10 +131,10 @@ def test_get_item_mixed_groupby(engine):
     assert_equals_data(
         grouped_all_sum[grouped_sum > 50000],
         order_by='inhabitants_sum',
-        expected_columns=['municipality', '_index_skating_order_sum', 'inhabitants_sum', 'founding_sum'],
+        expected_columns=['municipality', 'inhabitants_sum', 'founding_sum'],
         expected_data=[
-            ['Súdwest-Fryslân', 31, 52965, 7864],
-            ['Leeuwarden', 1, 93485, 1285]
+            ['Súdwest-Fryslân', 52965, 7864],
+            ['Leeuwarden', 93485, 1285]
         ]
     )
 
@@ -142,10 +142,10 @@ def test_get_item_mixed_groupby(engine):
     assert_equals_data(
         grouped_all_sum[bt.founding < 1300],
         order_by='inhabitants_sum',
-        expected_columns=['municipality', '_index_skating_order_sum', 'inhabitants_sum', 'founding_sum'],
+        expected_columns=['municipality', 'inhabitants_sum', 'founding_sum'],
         expected_data=[
-            ['Súdwest-Fryslân', 14, 4885, 3554], ['Noardeast-Fryslân', 11, 12675, 1298],
-            ['Harlingen', 9, 14740, 1234], ['Leeuwarden', 1, 93485, 1285]
+            ['Súdwest-Fryslân', 4885, 3554], ['Noardeast-Fryslân', 12675, 1298],
+            ['Harlingen', 14740, 1234], ['Leeuwarden', 93485, 1285]
         ]
     )
 
@@ -153,9 +153,9 @@ def test_get_item_mixed_groupby(engine):
     assert_equals_data(
         grouped_all_sum[grouped_all_sum.index['municipality'] == 'Harlingen'],
         order_by='inhabitants_sum',
-        expected_columns=['municipality', '_index_skating_order_sum', 'inhabitants_sum', 'founding_sum'],
+        expected_columns=['municipality', 'inhabitants_sum', 'founding_sum'],
         expected_data=[
-            ['Harlingen', 9, 14740, 1234]
+            ['Harlingen', 14740, 1234]
         ]
     )
 

--- a/bach/tests/functional/bach/test_df_groupby.py
+++ b/bach/tests/functional/bach/test_df_groupby.py
@@ -29,14 +29,13 @@ def test_group_by_all(engine):
 
     assert_equals_data(
         result_bt,
-        expected_columns=['_index_skating_order_nunique', 'skating_order_nunique', 'city_nunique', 'municipality_nunique', 'inhabitants_nunique', 'founding_nunique'],
+        expected_columns=['skating_order_nunique', 'city_nunique', 'municipality_nunique', 'inhabitants_nunique', 'founding_nunique'],
         order_by='skating_order_nunique',
         expected_data=[
-            [11, 11, 11, 6, 11, 11],
+            [11, 11, 6, 11, 11],
         ]
     )
     assert result_bt.dtypes == {
-        '_index_skating_order_nunique': 'int64',
         'city_nunique': 'int64',
         'founding_nunique': 'int64',
         'inhabitants_nunique': 'int64',
@@ -59,22 +58,21 @@ def test_group_by_single_syntax(engine):
 
         assert_equals_data(
             r,
-            expected_columns=['municipality', '_index_skating_order_count', 'skating_order_count', 'city_count', 'inhabitants_count', 'founding_count'],
+            expected_columns=['municipality', 'skating_order_count', 'city_count', 'inhabitants_count', 'founding_count'],
             order_by=['skating_order_count', 'municipality'],
             expected_data=[
-                ['De Friese Meren', 1, 1, 1, 1, 1],
-                ['Harlingen', 1, 1, 1, 1, 1],
-                ['Leeuwarden', 1, 1, 1, 1, 1],
-                ['Noardeast-Fryslân', 1, 1, 1, 1, 1],
-                ['Waadhoeke', 1, 1, 1, 1, 1],
-                ['Súdwest-Fryslân', 6, 6, 6, 6, 6],
+                ['De Friese Meren', 1, 1, 1, 1],
+                ['Harlingen', 1, 1, 1, 1],
+                ['Leeuwarden', 1, 1, 1, 1],
+                ['Noardeast-Fryslân', 1, 1, 1, 1],
+                ['Waadhoeke', 1, 1, 1, 1],
+                ['Súdwest-Fryslân', 6, 6, 6, 6],
             ]
         )
         assert r.index_dtypes == {
             'municipality': 'string'
         }
         assert r.dtypes == {
-            '_index_skating_order_count': 'int64',
             'city_count': 'int64',
             'founding_count': 'int64',
             'inhabitants_count': 'int64',
@@ -99,20 +97,20 @@ def test_group_by_multiple_syntax(engine):
 
         assert_equals_data(
             r,
-            expected_columns=['municipality', 'city', '_index_skating_order_count', 'skating_order_count', 'inhabitants_count', 'founding_count'],
+            expected_columns=['municipality', 'city', 'skating_order_count', 'inhabitants_count', 'founding_count'],
             order_by=['skating_order_count', 'municipality', 'city'],
             expected_data=[
-                ['De Friese Meren', 'Sleat', 1, 1, 1, 1],
-                ['Harlingen', 'Harns', 1, 1, 1, 1],
-                ['Leeuwarden', 'Ljouwert', 1, 1, 1, 1],
-                ['Noardeast-Fryslân', 'Dokkum', 1, 1, 1, 1],
-                ['Súdwest-Fryslân', 'Boalsert', 1, 1, 1, 1],
-                ['Súdwest-Fryslân', 'Drylts', 1, 1, 1, 1],
-                ['Súdwest-Fryslân', 'Hylpen', 1, 1, 1, 1],
-                ['Súdwest-Fryslân', 'Snits', 1, 1, 1, 1],
-                ['Súdwest-Fryslân', 'Starum', 1, 1, 1, 1],
-                ['Súdwest-Fryslân', 'Warkum', 1, 1, 1, 1],
-                ['Waadhoeke', 'Frjentsjer', 1, 1, 1, 1]
+                ['De Friese Meren', 'Sleat', 1, 1, 1],
+                ['Harlingen', 'Harns', 1, 1, 1],
+                ['Leeuwarden', 'Ljouwert', 1, 1, 1],
+                ['Noardeast-Fryslân', 'Dokkum', 1, 1, 1],
+                ['Súdwest-Fryslân', 'Boalsert', 1, 1, 1],
+                ['Súdwest-Fryslân', 'Drylts', 1, 1, 1],
+                ['Súdwest-Fryslân', 'Hylpen', 1, 1, 1],
+                ['Súdwest-Fryslân', 'Snits', 1, 1, 1],
+                ['Súdwest-Fryslân', 'Starum', 1, 1, 1],
+                ['Súdwest-Fryslân', 'Warkum', 1, 1, 1],
+                ['Waadhoeke', 'Frjentsjer', 1, 1, 1]
             ]
         )
         assert r.index_dtypes == {
@@ -120,7 +118,6 @@ def test_group_by_multiple_syntax(engine):
             'city': 'string'
         }
         assert r.dtypes == {
-            '_index_skating_order_count': 'int64',
             'founding_count': 'int64',
             'inhabitants_count': 'int64',
             'skating_order_count': 'int64'
@@ -141,19 +138,18 @@ def test_group_by_expression(engine):
 
     assert_equals_data(
         result_bt,
-        expected_columns=['city', '_index_skating_order_nunique', 'skating_order_nunique',
+        expected_columns=['city', 'skating_order_nunique',
                           'municipality_nunique', 'inhabitants_nunique', 'founding_nunique'],
         order_by='city',
         expected_data=[
-            ['B', 1, 1, 1, 1, 1], ['D', 2, 2, 2, 2, 2], ['F', 1, 1, 1, 1, 1], ['H', 2, 2, 2, 2, 2],
-            ['L', 1, 1, 1, 1, 1], ['S', 3, 3, 2, 3, 3], ['W', 1, 1, 1, 1, 1]
+            ['B', 1, 1, 1, 1], ['D', 2, 2, 2, 2], ['F', 1, 1, 1, 1], ['H', 2, 2, 2, 2],
+            ['L', 1, 1, 1, 1], ['S', 3, 2, 3, 3], ['W', 1, 1, 1, 1]
         ]
     )
     assert result_bt.index_dtypes == {
         'city': 'string'
     }
     assert result_bt.dtypes == {
-        '_index_skating_order_nunique': 'int64',
         'municipality_nunique': 'int64',
         'founding_nunique': 'int64',
         'inhabitants_nunique': 'int64',
@@ -230,20 +226,18 @@ def test_dataframe_agg_all(engine):
         # no materialization has taken place yet.
         assert result_bt.base_node == bt.base_node
 
-        assert result_bt._index_skating_order_nunique.expression.is_single_value
         assert result_bt.municipality_nunique.expression.is_single_value
         assert result_bt.inhabitants_nunique.expression.is_single_value
 
         assert_equals_data(
             result_bt,
-            expected_columns=['_index_skating_order_nunique', 'municipality_nunique', 'inhabitants_nunique'],
+            expected_columns=['municipality_nunique', 'inhabitants_nunique'],
             expected_data=[
-                [11, 6, 11]
+                [6, 11]
             ]
         )
         assert result_bt.index == {}
         assert result_bt.dtypes == {
-            '_index_skating_order_nunique': 'int64',
             'municipality_nunique': 'int64',
             'inhabitants_nunique': 'int64'
         }
@@ -267,17 +261,16 @@ def test_groupby_dataframe_agg(engine):
         assert_equals_data(
             result_bt,
             order_by=['municipality'],
-            expected_columns=['municipality', '_index_skating_order_nunique', 'inhabitants_nunique'],
+            expected_columns=['municipality', 'inhabitants_nunique'],
             expected_data=[
-                ['De Friese Meren', 1, 1], ['Harlingen', 1, 1], ['Leeuwarden', 1, 1],
-                ['Noardeast-Fryslân', 1, 1], ['Súdwest-Fryslân', 6, 6], ['Waadhoeke', 1, 1]
+                ['De Friese Meren', 1], ['Harlingen', 1], ['Leeuwarden', 1],
+                ['Noardeast-Fryslân', 1], ['Súdwest-Fryslân', 6], ['Waadhoeke', 1]
             ]
         )
         assert result_bt.index_dtypes == {
             'municipality': 'string'
         }
         assert result_bt.dtypes == {
-            '_index_skating_order_nunique': 'int64',
             'inhabitants_nunique': 'int64'
         }
 
@@ -384,7 +377,6 @@ def test_dataframe_agg_numeric_only(engine):
         assert result_bt.inhabitants_sum.value == 187325
         assert result_bt.dtypes == {
             # infers that municipality was dropped because not numeric
-            '_index_skating_order_sum': 'int64',
             'inhabitants_sum': 'int64'
         }
 

--- a/bach/tests/functional/bach/test_df_materialize.py
+++ b/bach/tests/functional/bach/test_df_materialize.py
@@ -67,7 +67,7 @@ def test_materialize_with_non_aggregation_series(inplace: bool, engine):
     btg = bt.groupby('municipality')
     assert btg.group_by is not None
     with pytest.raises(ValueError, match="groupby set, but contains Series that have no aggregation func.*"
-                                         "\\['_index_skating_order', 'founding', 'inhabitants'\\]"):
+                                         "\\['founding', 'inhabitants'\\]"):
         btg.materialize(inplace=inplace)
 
     assert btg.base_node == bt.base_node
@@ -75,7 +75,7 @@ def test_materialize_with_non_aggregation_series(inplace: bool, engine):
     # Add one that's aggregated, should still fail
     btg['founding'] = btg.founding.sum()
     with pytest.raises(ValueError, match="groupby set, but contains Series that have no aggregation func.*"
-                                         "\\['_index_skating_order', 'inhabitants'\\]"):
+                                         "\\['inhabitants'\\]"):
         btg.materialize(inplace=inplace)
     assert btg.base_node == bt.base_node
 
@@ -91,7 +91,6 @@ def test_materialize_with_non_aggregation_series(inplace: bool, engine):
 
     # Fix the last one,
     btg['inhabitants'] = btg.inhabitants.sum()
-    btg['_index_skating_order'] = btg._index_skating_order.sum()
     bt_materialized = btg.copy().materialize(inplace=inplace)
     assert bt_materialized.base_node != btg.base_node
 

--- a/bach/tests/functional/bach/test_df_reset_index.py
+++ b/bach/tests/functional/bach/test_df_reset_index.py
@@ -161,11 +161,11 @@ def test_reset_index_materialize(engine):
         assert_equals_data(
             r,
             expected_columns=[
-                'municipality', '_index_skating_order_sum', 'inhabitants_sum'
+                'municipality', 'inhabitants_sum'
             ],
             expected_data=[
-                ['Leeuwarden', 1, 93485],
-                ['Súdwest-Fryslân', 5, 36575],
+                ['Leeuwarden', 93485],
+                ['Súdwest-Fryslân', 36575],
             ],
-            order_by=['_index_skating_order_sum'],
+            order_by=['municipality'],
         )

--- a/bach/tests/functional/bach/test_df_sample.py
+++ b/bach/tests/functional/bach/test_df_sample.py
@@ -139,12 +139,12 @@ def test_get_unsampled_multiple_nodes():
     assert_equals_data(
         bt2,
         expected_columns=[
-            'municipality', '_index_skating_order_sum', 'founding_sum', 'inhabitants_plus_3000_sum',
+            'municipality', 'founding_sum', 'inhabitants_plus_3000_sum',
             'extra_ppl'
         ],
         expected_data=[
-            ['Leeuwarden', 1, 1285, 93485, 93490],
-            ['Súdwest-Fryslân', 5, 2724, 39575, 39580]
+            ['Leeuwarden', 1285, 93485, 93490],
+            ['Súdwest-Fryslân', 2724, 39575, 39580]
         ]
     )
 

--- a/bach/tests/functional/bach/test_series.py
+++ b/bach/tests/functional/bach/test_series.py
@@ -39,13 +39,6 @@ def test_series__getitem__(engine):
     with pytest.raises(IndexError):
         non_existing_value_ref.value
 
-    # selection on index of non-materialized groupby
-    l2 = l1.groupby('_index_skating_order_min').city_min.nunique()
-    assert l2[9].value == 1
-    non_existing_value_ref = l2[5]
-    with pytest.raises(IndexError):
-        non_existing_value_ref.value
-
 
 def test_positional_slicing():
     bt = get_bt_with_test_data(full_data_set=True)['inhabitants'].sort_values()

--- a/bach/tests/functional/bach/test_series_boolean.py
+++ b/bach/tests/functional/bach/test_series_boolean.py
@@ -89,11 +89,11 @@ def test_min_max(pg_engine):
     )
     assert_equals_data(
         df.min(),
-        expected_columns=['_index_skating_order_min', 'founding_min', 'mixed_min', 'yes_min', 'no_min'],
-        expected_data=[[1, 1268, False, True, False]]
+        expected_columns=['founding_min', 'mixed_min', 'yes_min', 'no_min'],
+        expected_data=[[1268, False, True, False]]
     )
     assert_equals_data(
         df.max(),
-        expected_columns=['_index_skating_order_max', 'founding_max', 'mixed_max', 'yes_max', 'no_max'],
-        expected_data=[[3, 1456, True, True, False]]
+        expected_columns=['founding_max', 'mixed_max', 'yes_max', 'no_max'],
+        expected_data=[[1456, True, True, False]]
     )

--- a/modelhub/modelhub/aggregate.py
+++ b/modelhub/modelhub/aggregate.py
@@ -164,8 +164,7 @@ class Aggregate:
         """
 
         self._mh._check_data_is_objectiv_data(data)
-
-        total_sessions_user = data.groupby(['user_id']).aggregate({'session_id': 'nunique'})
+        total_sessions_user = data.groupby(['user_id']).aggregate({'session_id': 'nunique'}).reset_index()
         frequency = total_sessions_user.groupby(['session_id_nunique']).aggregate({'user_id': 'nunique'})
 
         return frequency.user_id_nunique

--- a/modelhub/tests_modelhub/functional/modelhub/test_model_hub.py
+++ b/modelhub/tests_modelhub/functional/modelhub/test_model_hub.py
@@ -2,7 +2,7 @@
 Copyright 2021 Objectiv B.V.
 """
 
-# Any import from from modelhub initializes all the types, do not remove
+# Any import from modelhub initializes all the types, do not remove
 from modelhub import __version__
 from tests_modelhub.functional.modelhub.data_and_utils import get_objectiv_dataframe_test
 from tests.functional.bach.test_data_and_utils import assert_equals_data

--- a/modelhub/tests_modelhub/functional/modelhub/test_model_hub_frequency.py
+++ b/modelhub/tests_modelhub/functional/modelhub/test_model_hub_frequency.py
@@ -2,7 +2,7 @@
 Copyright 2021 Objectiv B.V.
 """
 
-# Any import from from modelhub initializes all the types, do not remove
+# Any import from modelhub initializes all the types, do not remove
 from modelhub import __version__
 from tests_modelhub.functional.modelhub.data_and_utils import get_objectiv_dataframe_test
 from tests.functional.bach.test_data_and_utils import assert_equals_data

--- a/modelhub/tests_modelhub/functional/modelhub/test_model_hub_session_duration.py
+++ b/modelhub/tests_modelhub/functional/modelhub/test_model_hub_session_duration.py
@@ -2,7 +2,7 @@
 Copyright 2021 Objectiv B.V.
 """
 
-# Any import from from modelhub initializes all the types, do not remove
+# Any import from modelhub initializes all the types, do not remove
 from modelhub import __version__
 import pytest
 from tests_modelhub.functional.modelhub.data_and_utils import get_objectiv_dataframe_test

--- a/modelhub/tests_modelhub/functional/modelhub/test_model_hub_unique_sessions.py
+++ b/modelhub/tests_modelhub/functional/modelhub/test_model_hub_unique_sessions.py
@@ -3,7 +3,7 @@ Copyright 2021 Objectiv B.V.
 """
 
 import pytest
-# Any import from from modelhub initializes all the types, do not remove
+# Any import from modelhub initializes all the types, do not remove
 from modelhub import __version__
 from tests_modelhub.functional.modelhub.data_and_utils import get_objectiv_dataframe_test
 from tests.functional.bach.test_data_and_utils import assert_equals_data

--- a/modelhub/tests_modelhub/functional/modelhub/test_model_hub_unique_users.py
+++ b/modelhub/tests_modelhub/functional/modelhub/test_model_hub_unique_users.py
@@ -3,7 +3,7 @@ Copyright 2021 Objectiv B.V.
 """
 
 import pytest
-# Any import from from modelhub initializes all the types, do not remove
+# Any import from modelhub initializes all the types, do not remove
 from modelhub import __version__
 from tests_modelhub.functional.modelhub.data_and_utils import get_objectiv_dataframe_test
 from tests.functional.bach.test_data_and_utils import assert_equals_data

--- a/modelhub/tests_modelhub/functional/modelhub/test_series_objectiv.py
+++ b/modelhub/tests_modelhub/functional/modelhub/test_series_objectiv.py
@@ -2,7 +2,7 @@
 Copyright 2021 Objectiv B.V.
 """
 
-# Any import from from modelhub initializes all the types, do not remove
+# Any import from modelhub initializes all the types, do not remove
 from modelhub import __version__
 from tests_modelhub.functional.modelhub.data_and_utils import get_bt_with_json_data_real
 from tests.functional.bach.test_data_and_utils import assert_equals_data

--- a/notebooks/basic-user-intent.ipynb
+++ b/notebooks/basic-user-intent.ipynb
@@ -285,7 +285,7 @@
    "outputs": [],
    "source": [
     "# total number of users per intent bucket\n",
-    "user_intent_buckets.groupby('bucket').agg({'user_id': 'nunique'}).head()"
+    "user_intent_buckets.reset_index().groupby('bucket').agg({'user_id': 'nunique'}).head()"
    ]
   },
   {


### PR DESCRIPTION
The change was done in `DataFrame._groupby_to_frame` method.
`DataFrame._groupby_to_frame` was converting indexes (those which were not included in `groupby`) into data series. In pandas when you do groupby it doesn't insert index into dataframe columns.
So with this change, `groupby` in Bach also doesn't insert indexes into the dataframe columns -> hence it is eliminating the problem of aggregation of indexes in the dataframe.