### PR TITLE
Trackers Developer Tools: Event recorder

### DIFF
--- a/tracker/core/developer-tools/package.json
+++ b/tracker/core/developer-tools/package.json
@@ -43,7 +43,7 @@
   },
   "scripts": {
     "generate": "ts-node -r tsconfig-paths/register src/scripts/generateErrorMessages.ts",
-    "build": "tsup src/index.ts --format cjs,esm --legacy-output --minify --dts --sourcemap --clean",
+    "build": "tsup src/index.ts --format cjs,esm --legacy-output --minify --sourcemap --clean",
     "prettify": "prettier --write .",
     "prettify:generated": "yarn prettier --write ./src/ContextErrorMessages.ts",
     "tsc": "tsc --noEmit",

--- a/tracker/core/developer-tools/src/EventRecorder.ts
+++ b/tracker/core/developer-tools/src/EventRecorder.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2022 Objectiv B.V.
+ */
+
+import {
+  cleanObjectFromInternalProperties,
+  EventRecorderConfig,
+  EventRecorderInterface,
+  NonEmptyArray,
+  RecordedEvent,
+  TrackerEvent,
+  TransportableEvent,
+} from '@objectiv/tracker-core';
+
+/**
+ * Some default values for the global instance of EventRecorder. Can be changed by calling EventRecorder.configure.
+ */
+const DEFAULT_ENABLED = true;
+const DEFAULT_MAX_EVENTS = 1000;
+const DEFAULT_AUTO_START = true;
+
+/**
+ * EventRecorder factory. A TrackerTransport to store TrackerEvents in the `recordedEvents` state for later analysis.
+ * Recorded TrackerEvents are automatically assigned predictable identifiers: `event.type` + `#` + number of times
+ * Event Type occurred, starting at 1. Also, their `time` is removed. This ensures comparability.
+ */
+export const EventRecorder = new (class implements EventRecorderInterface {
+  readonly transportName = 'EventRecorder';
+  enabled: boolean = DEFAULT_ENABLED;
+  maxEvents: number = DEFAULT_MAX_EVENTS;
+  autoStart: boolean = DEFAULT_AUTO_START;
+  recording: boolean = this.enabled && this.autoStart;
+  events: RecordedEvent[] = [];
+  eventsCountByType: { [type: string]: number } = {};
+
+  /**
+   * Reconfigures EventRecorder `maxEvents` and/or `autoStart`.
+   */
+  configure(eventRecorderConfig?: EventRecorderConfig) {
+    this.enabled = eventRecorderConfig?.enabled ?? DEFAULT_ENABLED;
+    this.maxEvents = eventRecorderConfig?.maxEvents ?? DEFAULT_MAX_EVENTS;
+    this.autoStart = eventRecorderConfig?.autoStart ?? DEFAULT_AUTO_START;
+    this.recording = this.enabled && this.autoStart;
+  }
+
+  /**
+   * Completely resets EventRecorder state.
+   */
+  clear() {
+    this.events.length = 0;
+    this.eventsCountByType = {};
+  }
+
+  /**
+   * Starts recording events.
+   */
+  start() {
+    if (!this.recording && this.enabled) {
+      this.recording = true;
+    }
+  }
+
+  /**
+   * Stops recording events.
+   */
+  stop() {
+    if (this.recording && this.enabled) {
+      this.recording = false;
+    }
+  }
+
+  /**
+   * Stores incoming TrackerEvents to globalThis.objectiv.recordedEvents
+   */
+  async handle(...args: NonEmptyArray<TransportableEvent>): Promise<any> {
+    if (!this.recording) {
+      return;
+    }
+
+    (await Promise.all(args)).forEach((trackerEvent) => {
+      const eventType = trackerEvent._type;
+
+      // Clone the event
+      const recordedEvent = new TrackerEvent(trackerEvent);
+
+      // Increment how many times have we seen this event type so far
+      this.eventsCountByType[eventType] = (this.eventsCountByType[eventType] ?? 0) + 1;
+
+      // Make event predictable, set the new identifier and remove time information
+      recordedEvent.id = `${eventType}#${this.eventsCountByType[eventType]}`;
+      delete recordedEvent.time;
+
+      this.events.push({
+        ...cleanObjectFromInternalProperties(recordedEvent),
+        location_stack: recordedEvent.location_stack.map(cleanObjectFromInternalProperties),
+        global_contexts: recordedEvent.global_contexts.map(cleanObjectFromInternalProperties),
+      });
+    });
+
+    if (this.events.length >= this.maxEvents) {
+      this.events.splice(0, this.events.length - this.maxEvents);
+    }
+  }
+
+  /**
+   * EventRecorder is usable as a Transport if it's enabled.
+   */
+  isUsable(): boolean {
+    return this.enabled;
+  }
+})();

--- a/tracker/core/developer-tools/src/index.ts
+++ b/tracker/core/developer-tools/src/index.ts
@@ -3,6 +3,7 @@
  */
 
 import { TrackerDeveloperToolsInterface } from '@objectiv/tracker-core';
+import { EventRecorder } from './EventRecorder';
 import { getLocationPath } from './getLocationPath';
 import { LocationTree } from './LocationTree';
 import { TrackerConsole } from './TrackerConsole';
@@ -13,11 +14,12 @@ import { makeLocationContextValidationRule } from './validationRules/makeLocatio
  * A global object containing all DeveloperTools
  */
 const developerTools: TrackerDeveloperToolsInterface = {
-  getLocationPath: getLocationPath,
-  LocationTree: LocationTree,
+  EventRecorder,
+  getLocationPath,
+  LocationTree,
   makeGlobalContextValidationRule,
   makeLocationContextValidationRule,
-  TrackerConsole: TrackerConsole,
+  TrackerConsole,
 };
 
 /**

--- a/tracker/core/developer-tools/tests/EventRecorder.test.ts
+++ b/tracker/core/developer-tools/tests/EventRecorder.test.ts
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2022 Objectiv B.V.
+ */
+
+import { TrackerEvent } from '@objectiv/tracker-core';
+import { EventRecorder } from '../src/EventRecorder';
+
+describe('EventRecorder', () => {
+  beforeEach(() => {
+    EventRecorder.clear();
+    EventRecorder.configure();
+  });
+
+  it('should be usable and auto-recording', async () => {
+    expect(EventRecorder.isUsable()).toBe(true);
+    expect(EventRecorder.autoStart).toBe(true);
+    expect(EventRecorder.recording).toBe(true);
+  });
+
+  it('should not be usable and not auto-recording', async () => {
+    EventRecorder.configure({ enabled: false });
+    expect(EventRecorder.isUsable()).toBe(false);
+    expect(EventRecorder.autoStart).toBe(true);
+    expect(EventRecorder.recording).toBe(false);
+  });
+
+  it('should become usable and start recording', async () => {
+    EventRecorder.configure({ enabled: false });
+    expect(EventRecorder.isUsable()).toBe(false);
+    expect(EventRecorder.autoStart).toBe(true);
+    expect(EventRecorder.recording).toBe(false);
+    EventRecorder.configure({ enabled: true });
+    expect(EventRecorder.isUsable()).toBe(true);
+    expect(EventRecorder.autoStart).toBe(true);
+    expect(EventRecorder.recording).toBe(true);
+  });
+
+  it('should allow configuring maxEvents', async () => {
+    EventRecorder.configure({ maxEvents: 10 });
+
+    expect(EventRecorder.maxEvents).toBe(10);
+  });
+
+  it('should store the events in recordedEvents', async () => {
+    const testPressEvent = new TrackerEvent({ _type: 'PressEvent', id: 'test-press-event' });
+    const testVisibleEvent = new TrackerEvent({ _type: 'VisibleEvent', id: 'test-visible-event' });
+    const testSuccessEvent = new TrackerEvent({ _type: 'SuccessEvent', id: 'test-success-event' });
+
+    expect(EventRecorder.events).toStrictEqual([]);
+
+    await EventRecorder.handle(testPressEvent, testVisibleEvent, testSuccessEvent);
+
+    expect(EventRecorder.events).toStrictEqual([
+      expect.objectContaining({ _type: 'PressEvent', id: 'PressEvent#1' }),
+      expect.objectContaining({ _type: 'VisibleEvent', id: 'VisibleEvent#1' }),
+      expect.objectContaining({ _type: 'SuccessEvent', id: 'SuccessEvent#1' }),
+    ]);
+  });
+
+  it('should automatically assign a predictable identifier to Events of the same type', async () => {
+    const testPressEvent1 = new TrackerEvent({ _type: 'PressEvent' });
+    const testPressEvent2 = new TrackerEvent({ _type: 'PressEvent' });
+    const testPressEvent3 = new TrackerEvent({ _type: 'PressEvent' });
+
+    expect(EventRecorder.events).toStrictEqual([]);
+
+    await EventRecorder.handle(testPressEvent1, testPressEvent2, testPressEvent3);
+
+    expect(EventRecorder.events).toStrictEqual([
+      expect.objectContaining({ _type: 'PressEvent', id: 'PressEvent#1' }),
+      expect.objectContaining({ _type: 'PressEvent', id: 'PressEvent#2' }),
+      expect.objectContaining({ _type: 'PressEvent', id: 'PressEvent#3' }),
+    ]);
+  });
+
+  it('should remove time information from recorded Events', async () => {
+    const testPressEvent1 = new TrackerEvent({ _type: 'PressEvent' });
+    const testPressEvent2 = new TrackerEvent({ _type: 'PressEvent' });
+    const testPressEvent3 = new TrackerEvent({ _type: 'PressEvent' });
+
+    testPressEvent1.setTime();
+    testPressEvent2.setTime();
+    testPressEvent3.setTime();
+
+    expect(testPressEvent1.time).not.toBeUndefined();
+    expect(testPressEvent2.time).not.toBeUndefined();
+    expect(testPressEvent3.time).not.toBeUndefined();
+
+    expect(EventRecorder.events).toStrictEqual([]);
+
+    await EventRecorder.handle(testPressEvent1, testPressEvent2, testPressEvent3);
+
+    // @ts-ignore
+    expect(EventRecorder.events[0].time).toBeUndefined();
+    // @ts-ignore
+    expect(EventRecorder.events[1].time).toBeUndefined();
+    // @ts-ignore
+    expect(EventRecorder.events[2].time).toBeUndefined();
+  });
+
+  it('should clear the recorded events', async () => {
+    const testPressEvent = new TrackerEvent({ _type: 'PressEvent', id: 'test-press-event' });
+    const testVisibleEvent = new TrackerEvent({ _type: 'VisibleEvent', id: 'test-visible-event' });
+    const testSuccessEvent = new TrackerEvent({ _type: 'SuccessEvent', id: 'test-success-event' });
+
+    await EventRecorder.handle(testPressEvent, testVisibleEvent, testSuccessEvent);
+    expect(EventRecorder.events.length).toBe(3);
+
+    EventRecorder.clear();
+
+    expect(EventRecorder.events.length).toBe(0);
+  });
+
+  it('should start recording', async () => {
+    EventRecorder.configure({ autoStart: false });
+    expect(EventRecorder.recording).toBe(false);
+
+    const testPressEvent = new TrackerEvent({ _type: 'PressEvent', id: 'test-press-event' });
+    const testVisibleEvent = new TrackerEvent({ _type: 'VisibleEvent', id: 'test-visible-event' });
+    const testSuccessEvent = new TrackerEvent({ _type: 'SuccessEvent', id: 'test-success-event' });
+
+    await EventRecorder.handle(testPressEvent, testVisibleEvent, testSuccessEvent);
+
+    expect(EventRecorder.events.length).toBe(0);
+
+    EventRecorder.start();
+
+    expect(EventRecorder.recording).toBe(true);
+
+    await EventRecorder.handle(testPressEvent, testVisibleEvent, testSuccessEvent);
+
+    expect(EventRecorder.events.length).toBe(3);
+  });
+
+  it('should stop recording', async () => {
+    const testPressEvent = new TrackerEvent({ _type: 'PressEvent', id: 'test-press-event' });
+    const testVisibleEvent = new TrackerEvent({ _type: 'VisibleEvent', id: 'test-visible-event' });
+    const testSuccessEvent = new TrackerEvent({ _type: 'SuccessEvent', id: 'test-success-event' });
+
+    expect(EventRecorder.recording).toBe(true);
+
+    EventRecorder.stop();
+
+    expect(EventRecorder.recording).toBe(false);
+
+    await EventRecorder.handle(testPressEvent, testVisibleEvent, testSuccessEvent);
+
+    expect(EventRecorder.events.length).toBe(0);
+  });
+
+  it('should throw away the oldest recorder events when reaching maxEvents', async () => {
+    EventRecorder.configure({ maxEvents: 3 });
+
+    const event1 = new TrackerEvent({ _type: 'PressEvent' });
+    const event2 = new TrackerEvent({ _type: 'PressEvent' });
+    const event3 = new TrackerEvent({ _type: 'PressEvent' });
+    const event4 = new TrackerEvent({ _type: 'PressEvent' });
+    const event5 = new TrackerEvent({ _type: 'PressEvent' });
+    const event6 = new TrackerEvent({ _type: 'PressEvent' });
+    const event7 = new TrackerEvent({ _type: 'PressEvent' });
+    const event8 = new TrackerEvent({ _type: 'PressEvent' });
+    const event9 = new TrackerEvent({ _type: 'PressEvent' });
+
+    await EventRecorder.handle(event1, event2, event3, event4);
+
+    expect(EventRecorder.events.length).toBe(3);
+    expect(EventRecorder.events[0].id).toBe('PressEvent#2');
+    expect(EventRecorder.events[1].id).toBe('PressEvent#3');
+    expect(EventRecorder.events[2].id).toBe('PressEvent#4');
+
+    await EventRecorder.handle(event5);
+
+    expect(EventRecorder.events.length).toBe(3);
+    expect(EventRecorder.events[0].id).toBe('PressEvent#3');
+    expect(EventRecorder.events[1].id).toBe('PressEvent#4');
+    expect(EventRecorder.events[2].id).toBe('PressEvent#5');
+
+    await EventRecorder.handle(event6, event7, event8);
+
+    expect(EventRecorder.events.length).toBe(3);
+    expect(EventRecorder.events[0].id).toBe('PressEvent#6');
+    expect(EventRecorder.events[1].id).toBe('PressEvent#7');
+    expect(EventRecorder.events[2].id).toBe('PressEvent#8');
+
+    await EventRecorder.handle(event9);
+
+    expect(EventRecorder.events.length).toBe(3);
+    expect(EventRecorder.events[0].id).toBe('PressEvent#7');
+    expect(EventRecorder.events[1].id).toBe('PressEvent#8');
+    expect(EventRecorder.events[2].id).toBe('PressEvent#9');
+  });
+});

--- a/tracker/core/developer-tools/tests/TrackerConsole.jsdom.test.ts
+++ b/tracker/core/developer-tools/tests/TrackerConsole.jsdom.test.ts
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2022 Objectiv B.V.
+ * @jest-environment jsdom
+ */
+
+import { NoopConsoleImplementation } from '../src/NoopConsoleImplementation';
+import { TrackerConsole } from '../src/TrackerConsole';
+
+describe('TrackerConsole', () => {
+  it('should default to console', () => {
+    jest.spyOn(NoopConsoleImplementation, 'log');
+    jest.spyOn(console, 'log');
+    TrackerConsole.log('should log to console');
+
+    expect(console.log).toHaveBeenCalledTimes(1);
+    expect(console.log).toHaveBeenCalledWith('should log to console');
+    expect(NoopConsoleImplementation.log).not.toHaveBeenCalled();
+  });
+});

--- a/tracker/core/react/tests/ObjectivProvider.test.tsx
+++ b/tracker/core/react/tests/ObjectivProvider.test.tsx
@@ -17,6 +17,7 @@ import { ObjectivProvider, useTrackingContext } from '../src';
 
 require('@objectiv/developer-tools');
 globalThis.objectiv?.TrackerConsole.setImplementation(MockConsoleImplementation);
+globalThis.objectiv?.EventRecorder.configure({ enabled: false });
 
 describe('ObjectivProvider', () => {
   beforeEach(() => {

--- a/tracker/core/react/tests/TrackerProvider.test.tsx
+++ b/tracker/core/react/tests/TrackerProvider.test.tsx
@@ -10,6 +10,7 @@ import { TrackerProvider, useTracker } from '../src';
 
 require('@objectiv/developer-tools');
 globalThis.objectiv?.TrackerConsole.setImplementation(MockConsoleImplementation);
+globalThis.objectiv?.EventRecorder.configure({ enabled: false });
 
 describe('TrackerProvider', () => {
   beforeEach(() => {

--- a/tracker/core/react/tests/TrackingContextProvider.test.tsx
+++ b/tracker/core/react/tests/TrackingContextProvider.test.tsx
@@ -16,6 +16,7 @@ import { LocationProvider, TrackingContextProvider, useLocationStack, useTracker
 
 require('@objectiv/developer-tools');
 globalThis.objectiv?.TrackerConsole.setImplementation(MockConsoleImplementation);
+globalThis.objectiv?.EventRecorder.configure({ enabled: false });
 
 describe('TrackingContextProvider', () => {
   beforeEach(() => {

--- a/tracker/core/tracker/src/EventRecorderInterface.ts
+++ b/tracker/core/tracker/src/EventRecorderInterface.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2022 Objectiv B.V.
+ */
+
+import { AbstractEvent } from '@objectiv/schema';
+import { TrackerTransportInterface } from './TrackerTransportInterface';
+
+/**
+ * A predictable AbstractEvent. It has no `time` and a predictable identifier.
+ */
+export type RecordedEvent = Omit<AbstractEvent, 'time'>;
+
+/**
+ * EventRecording instances can store lists of TrackerEvents for snapshot-testing or other debugging purposes.
+ */
+export type EventRecorderConfig = {
+  /**
+   * When set to false it will cause EventRecorder to become unusable. Trackers will not automatically record events.
+   */
+  enabled?: boolean;
+
+  /**
+   * Determines how many TrackerEvents will be recorded before rotating the oldest ones. Default to 1000.
+   */
+  maxEvents?: number;
+
+  /**
+   * Whether EventRecorder will start recording automatically. Default to true.
+   */
+  autoStart?: boolean;
+};
+
+/**
+ * EventRecording instances can store lists of TrackerEvents for snapshot-testing or other debugging purposes.
+ */
+export type EventRecorderInterface = TrackerTransportInterface &
+  Required<EventRecorderConfig> & {
+    /**
+     * When set to false it will cause EventRecorder to become unusable. Trackers will not automatically record events.
+     */
+    enabled: boolean;
+
+    /**
+     * Whether EventRecorder is recording or not.
+     */
+    recording: boolean;
+
+    /**
+     * Holds the list of recorded events.
+     */
+    events: RecordedEvent[];
+
+    /**
+     * Allows reconfiguring EventRecorder
+     */
+    configure: (eventRecorderConfig?: EventRecorderConfig) => void;
+
+    /**
+     * Completely resets EventRecorder state.
+     */
+    clear: () => void;
+
+    /**
+     * Starts recording events.
+     */
+    start: () => void;
+
+    /**
+     * Stops recording events.
+     */
+    stop: () => void;
+  };

--- a/tracker/core/tracker/src/TrackerDeveloperToolsInterface.ts
+++ b/tracker/core/tracker/src/TrackerDeveloperToolsInterface.ts
@@ -4,6 +4,7 @@
 
 import { LocationStack } from './Context';
 import { GlobalContextValidationRuleFactory, LocationContextValidationRuleFactory } from './ContextValidationRules';
+import { EventRecorderInterface } from './EventRecorderInterface';
 import { LocationTreeInterface } from './LocationTreeInterface';
 import { TrackerConsoleInterface } from './TrackerConsoleInterface';
 
@@ -11,6 +12,7 @@ import { TrackerConsoleInterface } from './TrackerConsoleInterface';
  * DeveloperTools interface definition.
  */
 export interface TrackerDeveloperToolsInterface {
+  EventRecorder: EventRecorderInterface;
   getLocationPath: (locationStack: LocationStack) => string;
   LocationTree: LocationTreeInterface;
   makeGlobalContextValidationRule: GlobalContextValidationRuleFactory;

--- a/tracker/core/tracker/src/TrackerTransportGroup.ts
+++ b/tracker/core/tracker/src/TrackerTransportGroup.ts
@@ -36,6 +36,7 @@ export class TrackerTransportGroup implements TrackerTransportInterface {
       globalThis.objectiv.TrackerConsole.log(
         `Usable Transports: ${this.usableTransports.map((transport) => transport.transportName).join(', ')}`
       );
+      globalThis.objectiv.TrackerConsole.groupEnd();
     }
   }
 

--- a/tracker/core/tracker/src/index.ts
+++ b/tracker/core/tracker/src/index.ts
@@ -17,6 +17,7 @@ export * from './ContextFactories';
 export * from './ContextNames';
 export * from './ContextValidationRules';
 export * from './EventFactories';
+export * from './EventRecorderInterface';
 export * from './helpers';
 export * from './LocationTreeInterface';
 export * from './Tracker';

--- a/tracker/core/tracker/tests/Tracker.test.ts
+++ b/tracker/core/tracker/tests/Tracker.test.ts
@@ -18,6 +18,7 @@ import {
 
 require('@objectiv/developer-tools');
 globalThis.objectiv?.TrackerConsole.setImplementation(MockConsoleImplementation);
+globalThis.objectiv?.EventRecorder.configure({ enabled: false });
 
 describe('Tracker', () => {
   beforeEach(() => {

--- a/tracker/trackers/browser/tests/BrowserTracker.test.ts
+++ b/tracker/trackers/browser/tests/BrowserTracker.test.ts
@@ -18,6 +18,7 @@ import { BrowserTracker } from '../src/';
 
 require('@objectiv/developer-tools');
 globalThis.objectiv?.TrackerConsole.setImplementation(MockConsoleImplementation);
+globalThis.objectiv?.EventRecorder.configure({ enabled: false });
 
 describe('BrowserTracker', () => {
   beforeEach(() => {

--- a/tracker/trackers/browser/tests/globals.test.ts
+++ b/tracker/trackers/browser/tests/globals.test.ts
@@ -139,4 +139,27 @@ describe('globals', () => {
       "Tracker `app-id` exists but its configuration doesn't match the given one. This means getOrMakeTracker has been called twice with different configs."
     );
   });
+
+  describe('Without developer tools', () => {
+    let objectivGlobal = globalThis.objectiv;
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+      globalThis.objectiv = undefined;
+    });
+
+    afterEach(() => {
+      globalThis.objectiv = objectivGlobal;
+    });
+
+    it('should not TrackerConsole.error because a Browser Tracker exists with the same Tracker Id but has a different configuration', () => {
+      const trackerConfig1 = { applicationId: 'app-id', endpoint: 'localhost' };
+      const trackerConfig2 = { applicationId: 'app-id', endpoint: 'http://collector' };
+      expect(TrackerRepository.trackersMap.size).toBe(0);
+      makeTracker(trackerConfig1);
+      expect(TrackerRepository.trackersMap.size).toBe(1);
+      getOrMakeTracker(trackerConfig2);
+      expect(MockConsoleImplementation.error).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/tracker/trackers/react-native/tests/ReactNativeTracker.test.ts
+++ b/tracker/trackers/react-native/tests/ReactNativeTracker.test.ts
@@ -11,6 +11,7 @@ import { ReactNativeTracker } from '../src/';
 
 require('@objectiv/developer-tools');
 globalThis.objectiv?.TrackerConsole.setImplementation(MockConsoleImplementation);
+globalThis.objectiv?.EventRecorder.configure({ enabled: false });
 
 describe('ReactNativeTracker', () => {
   beforeEach(() => {

--- a/tracker/trackers/react/tests/ReactTracker.test.ts
+++ b/tracker/trackers/react/tests/ReactTracker.test.ts
@@ -18,6 +18,7 @@ import { ReactTracker } from '../src/';
 
 require('@objectiv/developer-tools');
 globalThis.objectiv?.TrackerConsole.setImplementation(MockConsoleImplementation);
+globalThis.objectiv?.EventRecorder.configure({ enabled: false });
 
 describe('ReactTracker', () => {
   beforeEach(() => {

--- a/tracker/trackers/react/tests/withoutDOM.test.ts
+++ b/tracker/trackers/react/tests/withoutDOM.test.ts
@@ -8,6 +8,7 @@ import { ReactTracker } from '../src';
 
 require('@objectiv/developer-tools');
 globalThis.objectiv?.TrackerConsole.setImplementation(MockConsoleImplementation);
+globalThis.objectiv?.EventRecorder.configure({ enabled: false });
 
 describe('Without DOM', () => {
   it('ReactTracker: should not instantiate LocalStorage but MemoryQueue instead', () => {


### PR DESCRIPTION
EventRecorder is a Transport that doubles down as Event recording interface, available in DeveloperTools. 

It's able to record events in a snapshot compatible format, suitable for both unit or e2e testing.

Basic features:
- It starts recording automatically, unless differently configured.
- Methods: `stop`, `play` and `clear`.
- Configuration options: `enabled`, `autoStart` and `maxEvents`.
- EventRecorder.events have predictable identifiers and no time information. This allows comparing different sessions.
- Trackers will automatically record events when Developer Tools are present, unless EventRecorder has been disabled.