### PR TITLE
Added columns attribute for DataFrame

### DIFF
--- a/bach/bach/dataframe.py
+++ b/bach/bach/dataframe.py
@@ -299,6 +299,9 @@ class DataFrame:
         """
         return list(self.data.keys())
 
+    # alias for getting data names
+    columns = data_columns
+
     @property
     def index_dtypes(self) -> Dict[str, str]:
         """

--- a/bach/docs/source/bach/api-reference/DataFrame/index.rst
+++ b/bach/docs/source/bach/api-reference/DataFrame/index.rst
@@ -44,6 +44,7 @@ Axes
     DataFrame.all_series
     DataFrame.index_columns
     DataFrame.data_columns
+    DataFrame.columns
     DataFrame.group_by
     DataFrame.order_by
 


### PR DESCRIPTION
In Pandas, we have the DataFrame.columns attribute, which returns the column labels of the DataFrame, so I added it as well for Bach DataFrame, it is an alias to the existing Bach DataFrame.data_columns.