### PR TITLE
ModelHub: Package for data and utils for pytest.

### DIFF
--- a/modelhub/tests_modelhub/conftest.py
+++ b/modelhub/tests_modelhub/conftest.py
@@ -1,0 +1,25 @@
+import bach
+import pytest
+from sql_models.constants import DBDialect
+from sqlalchemy import create_engine
+
+from tests_modelhub.data_and_utils.utils import PG_DB_URL, setup_db, PG_TABLE_NAME
+
+
+@pytest.fixture(autouse=True, scope='session')
+def setup_postgres_db() -> None:
+    """
+    Helper for creating postgres database used by all functional tests.
+    """
+    engine = create_engine(url=PG_DB_URL)
+    setup_db(
+        engine,
+        table_name=PG_TABLE_NAME,
+        columns={
+            'event_id': bach.SeriesUuid.supported_db_dtype[DBDialect.POSTGRES],
+            'day': bach.SeriesDate.supported_db_dtype[DBDialect.POSTGRES],
+            'moment': bach.SeriesTimestamp.supported_db_dtype[DBDialect.POSTGRES],
+            'cookie_id': bach.SeriesUuid.supported_db_dtype[DBDialect.POSTGRES],
+            'value': bach.SeriesJsonPostgres.supported_db_dtype[DBDialect.POSTGRES],
+        },
+    )

--- a/modelhub/tests_modelhub/data_and_utils/data_json_real.py
+++ b/modelhub/tests_modelhub/data_and_utils/data_json_real.py
@@ -1,0 +1,19 @@
+# all data below is generated dummy data
+TEST_DATA_JSON_REAL = [
+    [1,
+     '[{"_type": "ApplicationContext", "id": "rod-web-demo"}, {"id": "http_context", "referrer": "https://rick.objectiv.io/", "user_agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:94.0) Gecko/20100101 Firefox/94.0", "remote_address": "144.144.144.144", "_type": "HttpContext"}, {"id": "f84446c6-eb76-4458-8ef4-93ade596fd5b", "cookie_id": "f84446c6-eb76-4458-8ef4-93ade596fd5b", "_type": "CookieIdContext"}]',
+     '[{"_type": "WebDocumentContext", "id": "#document", "url": "https://rick.objectiv.io/"}, {"_type": "SectionContext", "id": "home"}, {"_type": "SectionContext", "id": "yep"}, {"_type": "SectionContext", "id": "cc91EfoBh8A"}]'],
+    [2,
+     '[{"_type": "ApplicationContext", "id": "rod-web-demo"}, {"id": "http_context", "referrer": "https://rick.objectiv.io/", "user_agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:94.0) Gecko/20100101 Firefox/94.0", "remote_address": "144.144.144.144", "_type": "HttpContext"}, {"id": "f84446c6-eb76-4458-8ef4-93ade596fd5b", "cookie_id": "f84446c6-eb76-4458-8ef4-93ade596fd5b", "_type": "CookieIdContext"}]',
+     '[{"_type": "WebDocumentContext", "id": "#document", "url": "https://rick.objectiv.io/", "_types": ["AbstractContext", "AbstractLocationContext", "SectionContext", "WebDocumentContext"]}, {"_type": "NavigationContext", "id": "navigation", "_types": ["AbstractContext", "AbstractLocationContext", "NavigationContext", "SectionContext"]}]'],
+    [3,
+     '[{"_type": "ApplicationContext", "id": "rod-web-demo"}, {"id": "http_context", "referrer": "https://rick.objectiv.io/", "user_agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:94.0) Gecko/20100101 Firefox/94.0", "remote_address": "144.144.144.144", "_type": "HttpContext"}, {"id": "f84446c6-eb76-4458-8ef4-93ade596fd5b", "cookie_id": "f84446c6-eb76-4458-8ef4-93ade596fd5b", "_type": "CookieIdContext"}]',
+     '[{"_type": "WebDocumentContext", "id": "#document", "url": "https://rick.objectiv.io/"}, {"_type": "SectionContext", "id": "home"}, {"_type": "SectionContext", "id": "new"}, {"_type": "SectionContext", "id": "BeyEGebJ1l4"}]'],
+    [4,
+     '[{"_type": "ApplicationContext", "id": "rod-web-demo"}, {"id": "http_context", "referrer": "https://rick.objectiv.io/", "user_agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:94.0) Gecko/20100101 Firefox/94.0", "remote_address": "144.144.144.144", "_type": "HttpContext"}, {"id": "f84446c6-eb76-4458-8ef4-93ade596fd5b", "cookie_id": "f84446c6-eb76-4458-8ef4-93ade596fd5b", "_type": "CookieIdContext"}]',
+     '[{"_type": "WebDocumentContext", "id": "#document", "url": "https://rick.objectiv.io/"}, {"_type": "SectionContext", "id": "home"}, {"_type": "SectionContext", "id": "new"}, {"_type": "SectionContext", "id": "yBwD4iYcWC4"}]'],
+    [5,
+     '[{"_type": "ApplicationContext", "id": "rod-web-demo"}, {"id": "http_context", "referrer": "https://rick.objectiv.io/", "user_agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:94.0) Gecko/20100101 Firefox/94.0", "remote_address": "144.144.144.144", "_type": "HttpContext"}, {"id": "f84446c6-eb76-4458-8ef4-93ade596fd5b", "cookie_id": "f84446c6-eb76-4458-8ef4-93ade596fd5b", "_type": "CookieIdContext"}]',
+     '[{"_type": "WebDocumentContext", "id": "#document", "url": "https://rick.objectiv.io/"}, {"_type": "SectionContext", "id": "home"}, {"_type": "SectionContext", "id": "new"}, {"_type": "SectionContext", "id": "eYuUAGXN0KM"}]']
+]
+JSON_COLUMNS_REAL = ['event_id', 'global_contexts', 'location_stack']

--- a/modelhub/tests_modelhub/data_and_utils/data_objectiv.py
+++ b/modelhub/tests_modelhub/data_and_utils/data_objectiv.py
@@ -1,40 +1,4 @@
-"""
-Copyright 2021 Objectiv B.V.
-
-Utilities and a dataset for testing Bach Open Taxonomy.
-"""
-
-from tests.functional.bach.test_data_and_utils import get_bt, run_query
-from modelhub import ModelHub
-from bach import DataFrame
-import sqlalchemy
-import os
-
-DB_TEST_URL = os.environ.get('OBJ_DB_PG_TEST_URL', 'postgresql://objectiv:@localhost:5432/objectiv')
-
-# all data below is generated dummy data
-TEST_DATA_JSON_REAL = [
-    [1,
-     '[{"_type": "ApplicationContext", "id": "rod-web-demo"}, {"id": "http_context", "referrer": "https://rick.objectiv.io/", "user_agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:94.0) Gecko/20100101 Firefox/94.0", "remote_address": "144.144.144.144", "_type": "HttpContext"}, {"id": "f84446c6-eb76-4458-8ef4-93ade596fd5b", "cookie_id": "f84446c6-eb76-4458-8ef4-93ade596fd5b", "_type": "CookieIdContext"}]',
-     '[{"_type": "WebDocumentContext", "id": "#document", "url": "https://rick.objectiv.io/"}, {"_type": "SectionContext", "id": "home"}, {"_type": "SectionContext", "id": "yep"}, {"_type": "SectionContext", "id": "cc91EfoBh8A"}]'],
-    [2,
-     '[{"_type": "ApplicationContext", "id": "rod-web-demo"}, {"id": "http_context", "referrer": "https://rick.objectiv.io/", "user_agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:94.0) Gecko/20100101 Firefox/94.0", "remote_address": "144.144.144.144", "_type": "HttpContext"}, {"id": "f84446c6-eb76-4458-8ef4-93ade596fd5b", "cookie_id": "f84446c6-eb76-4458-8ef4-93ade596fd5b", "_type": "CookieIdContext"}]',
-     '[{"_type": "WebDocumentContext", "id": "#document", "url": "https://rick.objectiv.io/", "_types": ["AbstractContext", "AbstractLocationContext", "SectionContext", "WebDocumentContext"]}, {"_type": "NavigationContext", "id": "navigation", "_types": ["AbstractContext", "AbstractLocationContext", "NavigationContext", "SectionContext"]}]'],
-    [3,
-     '[{"_type": "ApplicationContext", "id": "rod-web-demo"}, {"id": "http_context", "referrer": "https://rick.objectiv.io/", "user_agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:94.0) Gecko/20100101 Firefox/94.0", "remote_address": "144.144.144.144", "_type": "HttpContext"}, {"id": "f84446c6-eb76-4458-8ef4-93ade596fd5b", "cookie_id": "f84446c6-eb76-4458-8ef4-93ade596fd5b", "_type": "CookieIdContext"}]',
-     '[{"_type": "WebDocumentContext", "id": "#document", "url": "https://rick.objectiv.io/"}, {"_type": "SectionContext", "id": "home"}, {"_type": "SectionContext", "id": "new"}, {"_type": "SectionContext", "id": "BeyEGebJ1l4"}]'],
-    [4,
-     '[{"_type": "ApplicationContext", "id": "rod-web-demo"}, {"id": "http_context", "referrer": "https://rick.objectiv.io/", "user_agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:94.0) Gecko/20100101 Firefox/94.0", "remote_address": "144.144.144.144", "_type": "HttpContext"}, {"id": "f84446c6-eb76-4458-8ef4-93ade596fd5b", "cookie_id": "f84446c6-eb76-4458-8ef4-93ade596fd5b", "_type": "CookieIdContext"}]',
-     '[{"_type": "WebDocumentContext", "id": "#document", "url": "https://rick.objectiv.io/"}, {"_type": "SectionContext", "id": "home"}, {"_type": "SectionContext", "id": "new"}, {"_type": "SectionContext", "id": "yBwD4iYcWC4"}]'],
-    [5,
-     '[{"_type": "ApplicationContext", "id": "rod-web-demo"}, {"id": "http_context", "referrer": "https://rick.objectiv.io/", "user_agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:94.0) Gecko/20100101 Firefox/94.0", "remote_address": "144.144.144.144", "_type": "HttpContext"}, {"id": "f84446c6-eb76-4458-8ef4-93ade596fd5b", "cookie_id": "f84446c6-eb76-4458-8ef4-93ade596fd5b", "_type": "CookieIdContext"}]',
-     '[{"_type": "WebDocumentContext", "id": "#document", "url": "https://rick.objectiv.io/"}, {"_type": "SectionContext", "id": "home"}, {"_type": "SectionContext", "id": "new"}, {"_type": "SectionContext", "id": "eYuUAGXN0KM"}]']
-]
-JSON_COLUMNS_REAL = ['event_id', 'global_contexts', 'location_stack']
-
-TEST_DATA_OBJECTIV = '''
-    INSERT INTO objectiv_data (event_id,day,moment,cookie_id,value)
-    VALUES 
+TEST_DATA_OBJECTIV = [
     ('12b55ed5-4295-4fc1-bf1f-88d64d1ac301','2021-11-30','2021-11-30 10:23:36.287','b2df75d2-d7ca-48ac-9747-af47d7a4a2b2','{"_type": "ClickEvent", "location_stack": [{"_type": "WebDocumentContext", "id": "#document", "url": "https://objectiv.io/", "_types": ["AbstractContext", "AbstractLocationContext", "SectionContext", "WebDocumentContext"]}, {"_type": "SectionContext", "id": "navbar-top", "_types": ["AbstractContext", "AbstractLocationContext", "SectionContext"]}, {"_type": "OverlayContext", "id": "hamburger-menu", "_types": ["AbstractContext", "AbstractLocationContext", "OverlayContext", "SectionContext"]}, {"_type": "LinkContext", "id": "GitHub", "text": "GitHub", "href": "https://github.com/objectiv", "_types": ["AbstractContext", "AbstractLocationContext", "ActionContext", "ItemContext", "LinkContext"]}], "global_contexts": [{"_type": "ApplicationContext", "id": "objectiv-website", "_types": ["AbstractContext", "AbstractGlobalContext", "ApplicationContext"]}, {"id": "http_context", "referrer": "https://objectiv.io/", "user_agent": "Mozilla/5.0 (Linux; Android 12; Pixel 4a) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.74 Mobile Safari/537.36", "_type": "HttpContext", "_types": ["AbstractContext", "AbstractGlobalContext", "HttpContext"]}, {"id": "1cc3cb08-010b-465a-8241-88c9b4d233ea", "cookie_id": "1cc3cb08-010b-465a-8241-88c9b4d233ea", "_type": "CookieIdContext", "_types": ["AbstractContext", "AbstractGlobalContext", "CookieIdContext"]}], "id": "729c84f9-91d0-4f9f-be58-5cfb2d8130e4", "time": 1636476263115, "_types": ["AbstractEvent", "ClickEvent", "InteractiveEvent"]}'),
     ('12b55ed5-4295-4fc1-bf1f-88d64d1ac302','2021-11-30','2021-11-30 10:23:36.290','b2df75d2-d7ca-48ac-9747-af47d7a4a2b2','{"_type": "ClickEvent", "location_stack": [{"_type": "WebDocumentContext", "id": "#document", "url": "https://objectiv.io/", "_types": ["AbstractContext", "AbstractLocationContext", "SectionContext", "WebDocumentContext"]}, {"_type": "SectionContext", "id": "main", "_types": ["AbstractContext", "AbstractLocationContext", "SectionContext"]}, {"_type": "SectionContext", "id": "location-stack", "_types": ["AbstractContext", "AbstractLocationContext", "SectionContext"]}, {"_type": "LinkContext", "id": "cta-docs-location-stack", "text": "Docs - Location Stack", "href": "/docs/taxonomy", "_types": ["AbstractContext", "AbstractLocationContext", "ActionContext", "ItemContext", "LinkContext"]}], "global_contexts": [{"_type": "ApplicationContext", "id": "objectiv-website", "_types": ["AbstractContext", "AbstractGlobalContext", "ApplicationContext"]}, {"id": "http_context", "referrer": "https://objectiv.io/", "user_agent": "Mozilla/5.0 (Linux; Android 12; Pixel 4a) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.74 Mobile Safari/537.36", "_type": "HttpContext", "_types": ["AbstractContext", "AbstractGlobalContext", "HttpContext"]}, {"id": "a30c5ca2-6f0c-4e56-997c-2148bd71ee8d", "cookie_id": "a30c5ca2-6f0c-4e56-997c-2148bd71ee8d", "_type": "CookieIdContext", "_types": ["AbstractContext", "AbstractGlobalContext", "CookieIdContext"]}], "id": "1049e11c-bb9c-4b84-9dac-b4125998999d", "time": 1636475896879, "_types": ["AbstractEvent", "ClickEvent", "InteractiveEvent"]}'),
     ('12b55ed5-4295-4fc1-bf1f-88d64d1ac303','2021-11-30','2021-11-30 10:23:36.291','b2df75d2-d7ca-48ac-9747-af47d7a4a2b2','{"_type": "ClickEvent", "location_stack": [{"_type": "WebDocumentContext", "id": "#document", "url": "https://objectiv.io/", "_types": ["AbstractContext", "AbstractLocationContext", "SectionContext", "WebDocumentContext"]}, {"_type": "SectionContext", "id": "header", "_types": ["AbstractContext", "AbstractLocationContext", "SectionContext"]}, {"_type": "LinkContext", "id": "cta-repo-button", "text": "Objectiv on GitHub", "href": "https://github.com/objectiv/objectiv-analytics", "_types": ["AbstractContext", "AbstractLocationContext", "ActionContext", "ItemContext", "LinkContext"]}], "global_contexts": [{"_type": "ApplicationContext", "id": "objectiv-website", "_types": ["AbstractContext", "AbstractGlobalContext", "ApplicationContext"]}, {"id": "http_context", "referrer": "https://objectiv.io/", "user_agent": "Mozilla/5.0 (Linux; Android 12; Pixel 4a) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.74 Mobile Safari/537.36", "_type": "HttpContext", "_types": ["AbstractContext", "AbstractGlobalContext", "HttpContext"]}, {"id": "a30c5ca2-6f0c-4e56-997c-2148bd71ee8d", "cookie_id": "a30c5ca2-6f0c-4e56-997c-2148bd71ee8d", "_type": "CookieIdContext", "_types": ["AbstractContext", "AbstractGlobalContext", "CookieIdContext"]}], "id": "fd8239de-032f-499a-9849-8e97214ecdf1", "time": 1636475880112, "_types": ["AbstractEvent", "ClickEvent", "InteractiveEvent"]}'),
@@ -47,39 +11,6 @@ TEST_DATA_OBJECTIV = '''
     ('12b55ed5-4295-4fc1-bf1f-88d64d1ac310','2021-12-03','2021-12-03 10:23:36.283','b2df75d2-d7ca-48ac-9747-af47d7a4a2b4','{"_type": "ClickEvent", "location_stack": [{"_type": "WebDocumentContext", "id": "#document", "url": "https://objectiv.io/about", "_types": ["AbstractContext", "AbstractLocationContext", "SectionContext", "WebDocumentContext"]}, {"_type": "SectionContext", "id": "navbar-top", "_types": ["AbstractContext", "AbstractLocationContext", "SectionContext"]}, {"_type": "OverlayContext", "id": "hamburger-menu", "_types": ["AbstractContext", "AbstractLocationContext", "OverlayContext", "SectionContext"]}, {"_type": "LinkContext", "id": "Docs", "text": "Docs", "href": "https://objectiv.io/docs/", "_types": ["AbstractContext", "AbstractLocationContext", "ActionContext", "ItemContext", "LinkContext"]}], "global_contexts": [{"_type": "ApplicationContext", "id": "objectiv-website", "_types": ["AbstractContext", "AbstractGlobalContext", "ApplicationContext"]}, {"id": "http_context", "referrer": "https://objectiv.io/", "user_agent": "Mozilla/5.0 (Linux; Android 10; POCOPHONE F1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.74 Mobile Safari/537.36", "_type": "HttpContext", "_types": ["AbstractContext", "AbstractGlobalContext", "HttpContext"]}, {"id": "5b1e395f-ef4c-438c-aab2-ae0aa19131ee", "cookie_id": "5b1e395f-ef4c-438c-aab2-ae0aa19131ee", "_type": "CookieIdContext", "_types": ["AbstractContext", "AbstractGlobalContext", "CookieIdContext"]}], "id": "089ff754-35d6-49da-bb32-dc9031b10289", "time": 1636476142139, "_types": ["AbstractEvent", "ClickEvent", "InteractiveEvent"]}'),
     ('12b55ed5-4295-4fc1-bf1f-88d64d1ac311','2021-11-29','2021-11-29 10:23:36.286','b2df75d2-d7ca-48ac-9747-af47d7a4a2b2','{"_type": "ClickEvent", "location_stack": [{"_type": "WebDocumentContext", "id": "#document", "url": "https://objectiv.io/", "_types": ["AbstractContext", "AbstractLocationContext", "SectionContext", "WebDocumentContext"]}, {"_type": "SectionContext", "id": "main", "_types": ["AbstractContext", "AbstractLocationContext", "SectionContext"]}, {"_type": "SectionContext", "id": "taxonomy", "_types": ["AbstractContext", "AbstractLocationContext", "SectionContext"]}, {"_type": "LinkContext", "id": "cta-docs-taxonomy", "text": "Docs - Taxonomy", "href": "/docs/taxonomy/", "_types": ["AbstractContext", "AbstractLocationContext", "ActionContext", "ItemContext", "LinkContext"]}], "global_contexts": [{"_type": "ApplicationContext", "id": "objectiv-website", "_types": ["AbstractContext", "AbstractGlobalContext", "ApplicationContext"]}, {"id": "http_context", "referrer": "https://objectiv.io/", "user_agent": "Mozilla/5.0 (Linux; Android 11; SM-G986B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.74 Mobile Safari/537.36", "_type": "HttpContext", "_types": ["AbstractContext", "AbstractGlobalContext", "HttpContext"]}, {"id": "81a8ace2-273b-4b95-b6a6-0fba33858a22", "cookie_id": "81a8ace2-273b-4b95-b6a6-0fba33858a22", "_type": "CookieIdContext", "_types": ["AbstractContext", "AbstractGlobalContext", "CookieIdContext"]}], "id": "fd54aa9a-b8b8-4feb-968d-8fa9f736c596", "time": 1636476191693, "_types": ["AbstractEvent", "ClickEvent", "InteractiveEvent"]}'),
     ('12b55ed5-4295-4fc1-bf1f-88d64d1ac312','2021-11-29','2021-11-29 10:23:36.287','b2df75d2-d7ca-48ac-9747-af47d7a4a2b2','{"_type": "ClickEvent", "location_stack": [{"_type": "WebDocumentContext", "id": "#document", "url": "https://objectiv.io/docs/taxonomy/", "_types": ["AbstractContext", "AbstractLocationContext", "SectionContext", "WebDocumentContext"]}, {"_type": "SectionContext", "id": "navbar-top", "_types": ["AbstractContext", "AbstractLocationContext", "SectionContext"]}, {"_type": "LinkContext", "id": "logo", "text": "Objectiv Documentation Logo", "href": "/docs/", "_types": ["AbstractContext", "AbstractLocationContext", "ActionContext", "ItemContext", "LinkContext"]}], "global_contexts": [{"_type": "ApplicationContext", "id": "objectiv-docs", "_types": ["AbstractContext", "AbstractGlobalContext", "ApplicationContext"]}, {"id": "http_context", "referrer": "https://objectiv.io/", "user_agent": "Mozilla/5.0 (Linux; Android 11; SM-G986B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.74 Mobile Safari/537.36", "_type": "HttpContext", "_types": ["AbstractContext", "AbstractGlobalContext", "HttpContext"]}, {"id": "81a8ace2-273b-4b95-b6a6-0fba33858a22", "cookie_id": "81a8ace2-273b-4b95-b6a6-0fba33858a22", "_type": "CookieIdContext", "_types": ["AbstractContext", "AbstractGlobalContext", "CookieIdContext"]}], "id": "e2445152-327a-466f-a2bf-116f0146ab7a", "time": 1636476196460, "_types": ["AbstractEvent", "ClickEvent", "InteractiveEvent"]}')
-'''
+]
 
-
-def get_bt_with_json_data_real() -> DataFrame:
-    bt = get_bt(TEST_DATA_JSON_REAL, JSON_COLUMNS_REAL, True)
-    bt['global_contexts'] = bt.global_contexts.astype('json')
-    bt['location_stack'] = bt.location_stack.astype('json')
-    return bt
-
-
-def get_objectiv_dataframe_test(time_aggregation=None):
-    sql = """
-    drop table if exists objectiv_data;
-
-    create table objectiv_data
-    (
-        event_id  uuid      ,
-        day       date      ,
-        moment    timestamp ,
-        cookie_id uuid      ,
-        value     json
-    );
-
-    alter table objectiv_data
-        owner to objectiv
-    """
-
-    run_query(sqlalchemy.create_engine(DB_TEST_URL), sql)
-    run_query(sqlalchemy.create_engine(DB_TEST_URL), TEST_DATA_OBJECTIV)
-
-    kwargs = {}
-    if time_aggregation:
-        kwargs = {'time_aggregation': time_aggregation}
-    modelhub = ModelHub(**kwargs)
-
-    return modelhub.get_objectiv_dataframe(DB_TEST_URL, table_name='objectiv_data'), modelhub
+_TEST_DATA_OBJECTIV_COLUMN_NAMES = ['event_id', 'day', 'moment', 'cookie_id', 'value']

--- a/modelhub/tests_modelhub/data_and_utils/utils.py
+++ b/modelhub/tests_modelhub/data_and_utils/utils.py
@@ -1,0 +1,68 @@
+import os
+from typing import Dict, Any
+
+from bach import DataFrame
+from sql_models.util import is_postgres
+from sqlalchemy.engine import Engine
+from tests.functional.bach.test_data_and_utils import get_bt, run_query
+
+from modelhub import ModelHub
+from tests_modelhub.data_and_utils.data_json_real import TEST_DATA_JSON_REAL, JSON_COLUMNS_REAL
+
+PG_DB_URL = os.environ.get('OBJ_DB_PG_TEST_URL', 'postgresql://objectiv:@localhost:5432/objectiv')
+PG_TABLE_NAME = 'objectiv_data'
+
+
+def get_bt_with_json_data_real() -> DataFrame:
+    bt = get_bt(TEST_DATA_JSON_REAL, JSON_COLUMNS_REAL, True)
+    bt['global_contexts'] = bt.global_contexts.astype('json')
+    bt['location_stack'] = bt.location_stack.astype('json')
+    return bt
+
+
+def get_objectiv_dataframe_test(time_aggregation=None):
+    kwargs = {}
+    if time_aggregation:
+        kwargs = {'time_aggregation': time_aggregation}
+    modelhub = ModelHub(**kwargs)
+
+    return modelhub.get_objectiv_dataframe(
+        db_url=PG_DB_URL,
+        table_name=PG_TABLE_NAME,
+    ), modelhub
+
+
+def setup_db(engine: Engine, table_name: str, columns: Dict[str, Any]):
+    _prep_db_table(engine, table_name=table_name, columns=columns)
+    _insert_records_in_db(engine, table_name=table_name, columns=columns)
+
+
+def _prep_db_table(engine, table_name: str, columns: Dict[str, Any]):
+    if is_postgres(engine):
+        column_stmt = ','.join(f'{col_name} {db_type}' for col_name, db_type in columns.items())
+        sql = f"""
+            drop table if exists {table_name};
+            create table {table_name} ({column_stmt});
+            alter table {table_name}
+                owner to objectiv
+        """
+    else:
+        raise Exception()
+    run_query(engine, sql)
+
+
+def _insert_records_in_db(engine, table_name: str, columns: Dict[str, Any]):
+    from tests_modelhub.data_and_utils.data_objectiv import TEST_DATA_OBJECTIV
+
+    column_stmt = ','.join(columns.keys())
+    records = []
+    if is_postgres(engine):
+        for record in TEST_DATA_OBJECTIV:
+            formatted_values = [f"'{record[col_index]}'" for col_index, _ in enumerate(columns)]
+            records.append(f"({','.join(formatted_values)})")
+    else:
+        raise Exception()
+
+    values_stmt = ','.join(records)
+    sql = f'insert into {table_name} ({column_stmt}) values {values_stmt}'
+    run_query(engine, sql)

--- a/modelhub/tests_modelhub/functional/modelhub/test_model_hub.py
+++ b/modelhub/tests_modelhub/functional/modelhub/test_model_hub.py
@@ -5,7 +5,7 @@ Copyright 2021 Objectiv B.V.
 # Any import from modelhub initializes all the types, do not remove
 from modelhub import __version__
 import pytest
-from tests_modelhub.functional.modelhub.data_and_utils import get_objectiv_dataframe_test
+from tests_modelhub.data_and_utils.utils import get_objectiv_dataframe_test
 from tests.functional.bach.test_data_and_utils import assert_equals_data
 from uuid import UUID
 

--- a/modelhub/tests_modelhub/functional/modelhub/test_model_hub_frequency.py
+++ b/modelhub/tests_modelhub/functional/modelhub/test_model_hub_frequency.py
@@ -4,7 +4,7 @@ Copyright 2021 Objectiv B.V.
 
 # Any import from modelhub initializes all the types, do not remove
 from modelhub import __version__
-from tests_modelhub.functional.modelhub.data_and_utils import get_objectiv_dataframe_test
+from tests_modelhub.data_and_utils.utils import get_objectiv_dataframe_test
 from tests.functional.bach.test_data_and_utils import assert_equals_data
 
 def test_frequency():

--- a/modelhub/tests_modelhub/functional/modelhub/test_model_hub_session_duration.py
+++ b/modelhub/tests_modelhub/functional/modelhub/test_model_hub_session_duration.py
@@ -5,7 +5,7 @@ Copyright 2021 Objectiv B.V.
 # Any import from modelhub initializes all the types, do not remove
 from modelhub import __version__
 import pytest
-from tests_modelhub.functional.modelhub.data_and_utils import get_objectiv_dataframe_test
+from tests_modelhub.data_and_utils.utils import get_objectiv_dataframe_test
 from tests.functional.bach.test_data_and_utils import assert_equals_data
 import datetime
 

--- a/modelhub/tests_modelhub/functional/modelhub/test_model_hub_unique_sessions.py
+++ b/modelhub/tests_modelhub/functional/modelhub/test_model_hub_unique_sessions.py
@@ -5,7 +5,7 @@ Copyright 2021 Objectiv B.V.
 import pytest
 # Any import from modelhub initializes all the types, do not remove
 from modelhub import __version__
-from tests_modelhub.functional.modelhub.data_and_utils import get_objectiv_dataframe_test
+from tests_modelhub.data_and_utils.utils import get_objectiv_dataframe_test
 from tests.functional.bach.test_data_and_utils import assert_equals_data
 from uuid import UUID
 

--- a/modelhub/tests_modelhub/functional/modelhub/test_model_hub_unique_users.py
+++ b/modelhub/tests_modelhub/functional/modelhub/test_model_hub_unique_users.py
@@ -5,7 +5,7 @@ Copyright 2021 Objectiv B.V.
 import pytest
 # Any import from modelhub initializes all the types, do not remove
 from modelhub import __version__
-from tests_modelhub.functional.modelhub.data_and_utils import get_objectiv_dataframe_test
+from tests_modelhub.data_and_utils.utils import get_objectiv_dataframe_test
 from tests.functional.bach.test_data_and_utils import assert_equals_data
 
 

--- a/modelhub/tests_modelhub/functional/modelhub/test_series_objectiv.py
+++ b/modelhub/tests_modelhub/functional/modelhub/test_series_objectiv.py
@@ -4,7 +4,7 @@ Copyright 2021 Objectiv B.V.
 
 # Any import from modelhub initializes all the types, do not remove
 from modelhub import __version__
-from tests_modelhub.functional.modelhub.data_and_utils import get_bt_with_json_data_real
+from tests_modelhub.data_and_utils.utils import get_bt_with_json_data_real
 from tests.functional.bach.test_data_and_utils import assert_equals_data
 
 


### PR DESCRIPTION
Splitted https://github.com/objectiv/objectiv-analytics/blob/main/modelhub/tests_modelhub/functional/modelhub/data_and_utils.py into a package, mainly because I found myself using a lot of this functions in `conftest.py` and makes easier to create tests for other engines (BigQuery). 

This PR includes also a fixture for creating and inserting **once** to PG db.