### PR TITLE
disable version check through env

### DIFF
--- a/modelhub/pytest.ini
+++ b/modelhub/pytest.ini
@@ -10,3 +10,8 @@ addopts = --strict-markers -W error::DeprecationWarning
 markers =
     skip_postgres: Mark a test as testing code that does not need to work with Postgres.
     skip_bigquery: Mark a test as testing code that does not need to work with BigQuery.
+
+# disable version check in tests
+env = 
+    OBJECTIV_VERSION_CHECK_DISABLE='true'
+

--- a/modelhub/requirements-dev.txt
+++ b/modelhub/requirements-dev.txt
@@ -1,4 +1,5 @@
 pytest==6.2.5
+pytest-env
 mypy==0.910
 pycodestyle==2.7.0
 types-requests


### PR DESCRIPTION
- adds `pytest-env` to requirements-dev
- disables the automated version check in pytest