### PR TITLE
ModelHub BQ: Support `Map.is_new_user`

### DIFF
--- a/modelhub/tests_modelhub/functional/modelhub/test_model_hub.py
+++ b/modelhub/tests_modelhub/functional/modelhub/test_model_hub.py
@@ -55,7 +55,6 @@ def test_is_first_session(db_params):
     )
 
 
-@pytest.mark.skip_bigquery
 def test_is_new_user(db_params):
     df, modelhub = get_objectiv_dataframe_test(db_params, time_aggregation='YYYY-MM-DD')
 

--- a/modelhub/tests_modelhub/functional/modelhub/test_model_hub.py
+++ b/modelhub/tests_modelhub/functional/modelhub/test_model_hub.py
@@ -56,7 +56,7 @@ def test_is_first_session(db_params):
 
 
 def test_is_new_user(db_params):
-    df, modelhub = get_objectiv_dataframe_test(db_params, time_aggregation='YYYY-MM-DD')
+    df, modelhub = get_objectiv_dataframe_test(db_params, time_aggregation='%Y-%m-%d')
 
     s = modelhub.map.is_new_user(df)
 
@@ -100,7 +100,7 @@ def test_is_new_user(db_params):
         convert_uuid=True,
     )
 
-    s = modelhub.map.is_new_user(df, time_aggregation='YYYY-MM')
+    s = modelhub.map.is_new_user(df, time_aggregation='%Y-%m')
 
     assert_equals_data(
         s,


### PR DESCRIPTION
**Description**
`Map.is_new_user` was raising some errors for BigQuery, this is mainly because we materialize in `bach.DataFrame.groupby`.

Dependencies:
- https://github.com/objectiv/objectiv-analytics/pull/788
- https://github.com/objectiv/objectiv-analytics/pull/797
- https://github.com/objectiv/objectiv-analytics/pull/842