### PR TITLE
Workflow to add opened issues/PRs to Development board

### DIFF
--- a/.github/workflows/add_issues_to_project.yml
+++ b/.github/workflows/add_issues_to_project.yml
@@ -1,0 +1,20 @@
+name: Add opened Issues & PRs to the Development board project
+
+on:
+  issues:
+    types:
+      - opened
+      - transferred
+  pull_request:
+    types:
+      - opened
+      
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@main
+        with:
+          project-url: https://github.com/orgs/objectiv/projects/4/
+          github-token: ${{ secrets.ADD_TO_PROJECT_PAT }}


### PR DESCRIPTION
This [Action](https://github.com/marketplace/actions/add-to-github-projects-beta#creating-a-pat-and-adding-it-to-your-repository) automatically transfers any newly opened Issues and PRs to the Development board project.