### PR TITLE
[ModelHub]: Ignore DeprecationWarnings from SeriesDateTime

### DIFF
--- a/.github/workflows/modelhub_tests.yml
+++ b/.github/workflows/modelhub_tests.yml
@@ -70,4 +70,4 @@ jobs:
       - name: Functional tests
         run: |
           cd modelhub
-          pytest tests_modelhub/functional/  -W error::DeprecationWarning
+          pytest tests_modelhub/functional/  -W error::DeprecationWarning -W ignore::DeprecationWarning:bach.series.series_datetime

--- a/modelhub/pytest.ini
+++ b/modelhub/pytest.ini
@@ -1,11 +1,13 @@
 [pytest]
-
 # See https://docs.pytest.org/en/6.2.x/reference.html#ini-options-ref
 
 # Pytest commandline parameters that we always set
 # --strict-markers: Fail if a test function has an unknown marker (e.g. is decorated with @pytest.mark.not_existing)
 # -W error::DeprecationWarning: Raise an error if we encounter a DeprecationWarning
-addopts = --strict-markers -W error::DeprecationWarning -W ignore::DeprecationWarning:bach.series.series_datetime
+addopts =
+    --strict-markers
+    -W error::DeprecationWarning
+    -W ignore::DeprecationWarning:bach.series.series_datetime
 
 # markers defines our custom markers
 markers =

--- a/modelhub/pytest.ini
+++ b/modelhub/pytest.ini
@@ -1,10 +1,11 @@
 [pytest]
+
 # See https://docs.pytest.org/en/6.2.x/reference.html#ini-options-ref
 
 # Pytest commandline parameters that we always set
 # --strict-markers: Fail if a test function has an unknown marker (e.g. is decorated with @pytest.mark.not_existing)
 # -W error::DeprecationWarning: Raise an error if we encounter a DeprecationWarning
-addopts = --strict-markers -W error::DeprecationWarning
+addopts = --strict-markers -W error::DeprecationWarning -W ignore::DeprecationWarning:bach.series.series_datetime
 
 # markers defines our custom markers
 markers =
@@ -14,4 +15,3 @@ markers =
 # disable version check in tests
 env = 
     OBJECTIV_VERSION_CHECK_DISABLE='true'
-


### PR DESCRIPTION
We are planning to deprecate `bach.series.series_datetime.DateTimeOperation.sql_format`, for now let's ignore those warnings in checks. Anyways, after using `strftime`. We should remove these changes https://github.com/objectiv/objectiv-analytics/issues/821