### PR TITLE
Bugfix: Consistent and configurable id normalization in React Tracker components

### DIFF
--- a/tracker/plugins/react-router-tracked-components/src/TrackedLink.tsx
+++ b/tracker/plugins/react-router-tracked-components/src/TrackedLink.tsx
@@ -27,7 +27,7 @@ export const TrackedLink = React.forwardRef<HTMLAnchorElement, TrackedLinkProps>
   const linkContextHref = useHref(props.to);
 
   // Attempt to generate an id for LinkContext by looking at `id`, `title`, `children` and `objectiv.contextId` props.
-  const linkContextId = makeIdFromTrackedAnchorProps(props);
+  const linkContextId = makeIdFromTrackedAnchorProps({ ...props, ...objectiv });
 
   // If we couldn't generate an `id`, log the issue and return a regular Link component.
   const locationStack = useLocationStack();

--- a/tracker/plugins/react-router-tracked-components/src/TrackedNavLink.tsx
+++ b/tracker/plugins/react-router-tracked-components/src/TrackedNavLink.tsx
@@ -27,7 +27,7 @@ export const TrackedNavLink = React.forwardRef<HTMLAnchorElement, TrackedNavLink
   const linkContextHref = useHref(props.to);
 
   // Attempt to generate an id for LinkContext by looking at `id`, `title`, `children` and `objectiv.contextId` props.
-  const linkContextId = makeIdFromTrackedAnchorProps(props);
+  const linkContextId = makeIdFromTrackedAnchorProps({ ...props, ...objectiv });
 
   // If we couldn't generate an `id`, log the issue and return a regular Link component.
   const locationStack = useLocationStack();

--- a/tracker/trackers/react/src/common/factories/makeIdFromTrackedAnchorProps.tsx
+++ b/tracker/trackers/react/src/common/factories/makeIdFromTrackedAnchorProps.tsx
@@ -12,4 +12,4 @@ import { TrackingOptionsProp } from '../../types';
  */
 export const makeIdFromTrackedAnchorProps = (
   props: { id?: string; title?: string; children?: React.ReactNode } & TrackingOptionsProp
-) => makeIdFromString(props.id ?? props.objectiv?.contextId ?? props.title ?? makeTitleFromChildren(props.children));
+) => props.id ?? props.objectiv?.contextId ?? makeIdFromString(props.title ?? makeTitleFromChildren(props.children));

--- a/tracker/trackers/react/src/common/factories/makeIdFromTrackedAnchorProps.tsx
+++ b/tracker/trackers/react/src/common/factories/makeIdFromTrackedAnchorProps.tsx
@@ -5,11 +5,32 @@
 import { makeIdFromString } from '@objectiv/tracker-core';
 import { makeTitleFromChildren } from '@objectiv/tracker-react-core';
 import React from 'react';
-import { TrackingOptionsProp } from '../../types';
+import { ObjectivTrackingOptions } from '../../types';
+
+/**
+ * The parameters of makeIdFromTrackedAnchorProps
+ */
+export type makeIdFromTrackedAnchorPropsParameters = ObjectivTrackingOptions & {
+  id?: string;
+  title?: string;
+  children?: React.ReactNode;
+};
 
 /**
  * Attempts to generate an id by looking at `id`, `title`, `children` and `objectiv.contextId` props.
  */
-export const makeIdFromTrackedAnchorProps = (
-  props: { id?: string; title?: string; children?: React.ReactNode } & TrackingOptionsProp
-) => props.id ?? props.objectiv?.contextId ?? makeIdFromString(props.title ?? makeTitleFromChildren(props.children));
+export const makeIdFromTrackedAnchorProps = ({
+  id,
+  title,
+  children,
+  contextId,
+  normalizeId = true,
+}: makeIdFromTrackedAnchorPropsParameters) => {
+  const resultId = id ?? contextId ?? title ?? makeTitleFromChildren(children);
+
+  if (normalizeId) {
+    return makeIdFromString(resultId);
+  }
+
+  return resultId;
+};

--- a/tracker/trackers/react/src/trackedContexts/TrackedContentContext.tsx
+++ b/tracker/trackers/react/src/trackedContexts/TrackedContentContext.tsx
@@ -2,7 +2,7 @@
  * Copyright 2021-2022 Objectiv B.V.
  */
 
-import { makeIdFromString } from "@objectiv/tracker-core";
+import { makeIdFromString } from '@objectiv/tracker-core';
 import { ContentContextWrapper, useLocationStack } from '@objectiv/tracker-react-core';
 import React from 'react';
 import { TrackedContextProps } from '../types';
@@ -15,7 +15,7 @@ export const TrackedContentContext = React.forwardRef<HTMLElement, TrackedContex
   const locationStack = useLocationStack();
 
   let contentId: string | null = id;
-  if(normalizeId) {
+  if (normalizeId) {
     contentId = makeIdFromString(contentId);
   }
 

--- a/tracker/trackers/react/src/trackedContexts/TrackedExpandableContext.tsx
+++ b/tracker/trackers/react/src/trackedContexts/TrackedExpandableContext.tsx
@@ -2,7 +2,7 @@
  * Copyright 2021-2022 Objectiv B.V.
  */
 
-import { makeIdFromString } from "@objectiv/tracker-core";
+import { makeIdFromString } from '@objectiv/tracker-core';
 import { ExpandableContextWrapper, trackVisibility, useLocationStack, useOnChange } from '@objectiv/tracker-react-core';
 import React, { useState } from 'react';
 import { TrackedShowableContextProps } from '../types';
@@ -17,7 +17,7 @@ export const TrackedExpandableContext = React.forwardRef<HTMLElement, TrackedSho
   const locationStack = useLocationStack();
 
   let expandableId: string | null = id;
-  if(normalizeId) {
+  if (normalizeId) {
     expandableId = makeIdFromString(expandableId);
   }
 

--- a/tracker/trackers/react/src/trackedContexts/TrackedExpandableContext.tsx
+++ b/tracker/trackers/react/src/trackedContexts/TrackedExpandableContext.tsx
@@ -2,7 +2,8 @@
  * Copyright 2021-2022 Objectiv B.V.
  */
 
-import { ExpandableContextWrapper, trackVisibility, useOnChange } from '@objectiv/tracker-react-core';
+import { makeIdFromString } from "@objectiv/tracker-core";
+import { ExpandableContextWrapper, trackVisibility, useLocationStack, useOnChange } from '@objectiv/tracker-react-core';
 import React, { useState } from 'react';
 import { TrackedShowableContextProps } from '../types';
 
@@ -12,7 +13,13 @@ import { TrackedShowableContextProps } from '../types';
  */
 export const TrackedExpandableContext = React.forwardRef<HTMLElement, TrackedShowableContextProps>((props, ref) => {
   const [wasVisible, setWasVisible] = useState<boolean>(false);
-  const { id, Component, forwardId = false, isVisible = false, ...otherProps } = props;
+  const { id, Component, forwardId = false, isVisible = false, normalizeId = true, ...otherProps } = props;
+  const locationStack = useLocationStack();
+
+  let expandableId: string | null = id;
+  if(normalizeId) {
+    expandableId = makeIdFromString(expandableId);
+  }
 
   useOnChange(isVisible, () => setWasVisible(isVisible));
 
@@ -22,8 +29,18 @@ export const TrackedExpandableContext = React.forwardRef<HTMLElement, TrackedSho
     ...(forwardId ? { id } : {}),
   };
 
+  if (!expandableId) {
+    if (globalThis.objectiv) {
+      const locationPath = globalThis.objectiv.getLocationPath(locationStack);
+      globalThis.objectiv.TrackerConsole.error(
+        `｢objectiv｣ Could not generate a valid id for ContentContext @ ${locationPath}. Please provide the \`id\` property.`
+      );
+    }
+    return React.createElement(Component, componentProps);
+  }
+
   return (
-    <ExpandableContextWrapper id={id}>
+    <ExpandableContextWrapper id={expandableId}>
       {(trackingContext) => {
         if ((wasVisible && !isVisible) || (!wasVisible && isVisible)) {
           trackVisibility({ isVisible, ...trackingContext });

--- a/tracker/trackers/react/src/trackedContexts/TrackedExpandableContext.tsx
+++ b/tracker/trackers/react/src/trackedContexts/TrackedExpandableContext.tsx
@@ -33,7 +33,7 @@ export const TrackedExpandableContext = React.forwardRef<HTMLElement, TrackedSho
     if (globalThis.objectiv) {
       const locationPath = globalThis.objectiv.getLocationPath(locationStack);
       globalThis.objectiv.TrackerConsole.error(
-        `｢objectiv｣ Could not generate a valid id for ContentContext @ ${locationPath}. Please provide the \`id\` property.`
+        `｢objectiv｣ Could not generate a valid id for ExpandableContext @ ${locationPath}. Please provide the \`id\` property.`
       );
     }
     return React.createElement(Component, componentProps);

--- a/tracker/trackers/react/src/trackedContexts/TrackedMediaPlayerContext.tsx
+++ b/tracker/trackers/react/src/trackedContexts/TrackedMediaPlayerContext.tsx
@@ -2,7 +2,8 @@
  * Copyright 2021-2022 Objectiv B.V.
  */
 
-import { MediaPlayerContextWrapper } from '@objectiv/tracker-react-core';
+import { makeIdFromString } from '@objectiv/tracker-core';
+import { MediaPlayerContextWrapper, useLocationStack } from '@objectiv/tracker-react-core';
 import React from 'react';
 import { TrackedContextProps } from '../types';
 
@@ -10,7 +11,13 @@ import { TrackedContextProps } from '../types';
  * Generates a new React Element already wrapped in a MediaPlayerContext.
  */
 export const TrackedMediaPlayerContext = React.forwardRef<HTMLElement, TrackedContextProps>((props, ref) => {
-  const { id, Component, forwardId = false, ...otherProps } = props;
+  const { id, Component, forwardId = false, normalizeId = true, ...otherProps } = props;
+  const locationStack = useLocationStack();
+
+  let mediaPlayerId: string | null = id;
+  if (normalizeId) {
+    mediaPlayerId = makeIdFromString(mediaPlayerId);
+  }
 
   const componentProps = {
     ...otherProps,
@@ -18,7 +25,19 @@ export const TrackedMediaPlayerContext = React.forwardRef<HTMLElement, TrackedCo
     ...(forwardId ? { id } : {}),
   };
 
+  if (!mediaPlayerId) {
+    if (globalThis.objectiv) {
+      const locationPath = globalThis.objectiv.getLocationPath(locationStack);
+      globalThis.objectiv.TrackerConsole.error(
+        `｢objectiv｣ Could not generate a valid id for MediaPlayerContext @ ${locationPath}. Please provide the \`id\` property.`
+      );
+    }
+    return React.createElement(Component, componentProps);
+  }
+
   return (
-    <MediaPlayerContextWrapper id={id}>{React.createElement(Component, componentProps)}</MediaPlayerContextWrapper>
+    <MediaPlayerContextWrapper id={mediaPlayerId}>
+      {React.createElement(Component, componentProps)}
+    </MediaPlayerContextWrapper>
   );
 });

--- a/tracker/trackers/react/src/trackedContexts/TrackedNavigationContext.tsx
+++ b/tracker/trackers/react/src/trackedContexts/TrackedNavigationContext.tsx
@@ -2,7 +2,7 @@
  * Copyright 2021-2022 Objectiv B.V.
  */
 
-import { makeIdFromString } from "@objectiv/tracker-core";
+import { makeIdFromString } from '@objectiv/tracker-core';
 import { NavigationContextWrapper, useLocationStack } from '@objectiv/tracker-react-core';
 import React from 'react';
 import { TrackedContextProps } from '../types';
@@ -15,7 +15,7 @@ export const TrackedNavigationContext = React.forwardRef<HTMLElement, TrackedCon
   const locationStack = useLocationStack();
 
   let navigationId: string | null = id;
-  if(normalizeId) {
+  if (normalizeId) {
     navigationId = makeIdFromString(navigationId);
   }
 
@@ -35,5 +35,9 @@ export const TrackedNavigationContext = React.forwardRef<HTMLElement, TrackedCon
     return React.createElement(Component, componentProps);
   }
 
-  return <NavigationContextWrapper id={navigationId}>{React.createElement(Component, componentProps)}</NavigationContextWrapper>;
+  return (
+    <NavigationContextWrapper id={navigationId}>
+      {React.createElement(Component, componentProps)}
+    </NavigationContextWrapper>
+  );
 });

--- a/tracker/trackers/react/src/trackedContexts/TrackedNavigationContext.tsx
+++ b/tracker/trackers/react/src/trackedContexts/TrackedNavigationContext.tsx
@@ -29,7 +29,7 @@ export const TrackedNavigationContext = React.forwardRef<HTMLElement, TrackedCon
     if (globalThis.objectiv) {
       const locationPath = globalThis.objectiv.getLocationPath(locationStack);
       globalThis.objectiv.TrackerConsole.error(
-        `｢objectiv｣ Could not generate a valid id for ContentContext @ ${locationPath}. Please provide the \`id\` property.`
+        `｢objectiv｣ Could not generate a valid id for NavigationContext @ ${locationPath}. Please provide the \`id\` property.`
       );
     }
     return React.createElement(Component, componentProps);

--- a/tracker/trackers/react/src/trackedContexts/TrackedNavigationContext.tsx
+++ b/tracker/trackers/react/src/trackedContexts/TrackedNavigationContext.tsx
@@ -2,7 +2,8 @@
  * Copyright 2021-2022 Objectiv B.V.
  */
 
-import { NavigationContextWrapper } from '@objectiv/tracker-react-core';
+import { makeIdFromString } from "@objectiv/tracker-core";
+import { NavigationContextWrapper, useLocationStack } from '@objectiv/tracker-react-core';
 import React from 'react';
 import { TrackedContextProps } from '../types';
 
@@ -10,7 +11,13 @@ import { TrackedContextProps } from '../types';
  * Generates a new React Element already wrapped in a NavigationContext.
  */
 export const TrackedNavigationContext = React.forwardRef<HTMLElement, TrackedContextProps>((props, ref) => {
-  const { id, Component, forwardId = false, ...otherProps } = props;
+  const { id, Component, forwardId = false, normalizeId = true, ...otherProps } = props;
+  const locationStack = useLocationStack();
+
+  let navigationId: string | null = id;
+  if(normalizeId) {
+    navigationId = makeIdFromString(navigationId);
+  }
 
   const componentProps = {
     ...otherProps,
@@ -18,5 +25,15 @@ export const TrackedNavigationContext = React.forwardRef<HTMLElement, TrackedCon
     ...(forwardId ? { id } : {}),
   };
 
-  return <NavigationContextWrapper id={id}>{React.createElement(Component, componentProps)}</NavigationContextWrapper>;
+  if (!navigationId) {
+    if (globalThis.objectiv) {
+      const locationPath = globalThis.objectiv.getLocationPath(locationStack);
+      globalThis.objectiv.TrackerConsole.error(
+        `｢objectiv｣ Could not generate a valid id for ContentContext @ ${locationPath}. Please provide the \`id\` property.`
+      );
+    }
+    return React.createElement(Component, componentProps);
+  }
+
+  return <NavigationContextWrapper id={navigationId}>{React.createElement(Component, componentProps)}</NavigationContextWrapper>;
 });

--- a/tracker/trackers/react/src/trackedContexts/TrackedOverlayContext.tsx
+++ b/tracker/trackers/react/src/trackedContexts/TrackedOverlayContext.tsx
@@ -2,7 +2,7 @@
  * Copyright 2021-2022 Objectiv B.V.
  */
 
-import { makeIdFromString } from "@objectiv/tracker-core";
+import { makeIdFromString } from '@objectiv/tracker-core';
 import { OverlayContextWrapper, trackVisibility, useLocationStack, useOnChange } from '@objectiv/tracker-react-core';
 import React, { useState } from 'react';
 import { TrackedShowableContextProps } from '../types';

--- a/tracker/trackers/react/src/trackedContexts/TrackedPressableContext.tsx
+++ b/tracker/trackers/react/src/trackedContexts/TrackedPressableContext.tsx
@@ -17,11 +17,14 @@ import { TrackedPressableContextProps } from '../types';
  * Automatically tracks PressEvent when the given Component receives an `onClick` SyntheticEvent.
  */
 export const TrackedPressableContext = React.forwardRef<HTMLElement, TrackedPressableContextProps>((props, ref) => {
-  const { Component, id, title, forwardId = false, forwardTitle = false, ...otherProps } = props;
+  const { Component, id, title, forwardId = false, forwardTitle = false, normalizeId = true, ...otherProps } = props;
 
   // Attempt to auto-detect `id` for LinkContext by looking at either the `title` or `children` props.
   const pressableTitle = title ?? makeTitleFromChildren(props.children);
-  const pressableId = id ?? makeIdFromString(pressableTitle);
+  let pressableId: string | null = id ?? pressableTitle;
+  if(normalizeId) {
+    pressableId = makeIdFromString(pressableId);
+  }
 
   // Prepare new Component props
   const componentProps = {

--- a/tracker/trackers/react/src/trackedContexts/TrackedPressableContext.tsx
+++ b/tracker/trackers/react/src/trackedContexts/TrackedPressableContext.tsx
@@ -22,7 +22,7 @@ export const TrackedPressableContext = React.forwardRef<HTMLElement, TrackedPres
   // Attempt to auto-detect `id` for LinkContext by looking at either the `title` or `children` props.
   const pressableTitle = title ?? makeTitleFromChildren(props.children);
   let pressableId: string | null = id ?? pressableTitle;
-  if(normalizeId) {
+  if (normalizeId) {
     pressableId = makeIdFromString(pressableId);
   }
 

--- a/tracker/trackers/react/src/trackedContexts/TrackedRootLocationContext.tsx
+++ b/tracker/trackers/react/src/trackedContexts/TrackedRootLocationContext.tsx
@@ -2,7 +2,7 @@
  * Copyright 2021-2022 Objectiv B.V.
  */
 
-import { makeIdFromString } from "@objectiv/tracker-core";
+import { makeIdFromString } from '@objectiv/tracker-core';
 import { RootLocationContextWrapper } from '@objectiv/tracker-react-core';
 import React from 'react';
 import { TrackedContextProps } from '../types';
@@ -34,6 +34,8 @@ export const TrackedRootLocationContext = React.forwardRef<HTMLElement, TrackedC
   }
 
   return (
-    <RootLocationContextWrapper id={rootId}>{React.createElement(Component, componentProps)}</RootLocationContextWrapper>
+    <RootLocationContextWrapper id={rootId}>
+      {React.createElement(Component, componentProps)}
+    </RootLocationContextWrapper>
   );
 });

--- a/tracker/trackers/react/src/trackedContexts/TrackedRootLocationContext.tsx
+++ b/tracker/trackers/react/src/trackedContexts/TrackedRootLocationContext.tsx
@@ -2,6 +2,7 @@
  * Copyright 2021-2022 Objectiv B.V.
  */
 
+import { makeIdFromString } from "@objectiv/tracker-core";
 import { RootLocationContextWrapper } from '@objectiv/tracker-react-core';
 import React from 'react';
 import { TrackedContextProps } from '../types';
@@ -10,7 +11,12 @@ import { TrackedContextProps } from '../types';
  * Generates a new React Element already wrapped in a RootLocationContext.
  */
 export const TrackedRootLocationContext = React.forwardRef<HTMLElement, TrackedContextProps>((props, ref) => {
-  const { id, Component, forwardId = false, ...otherProps } = props;
+  const { id, Component, forwardId = false, normalizeId = true, ...otherProps } = props;
+
+  let rootId: string | null = id;
+  if (normalizeId) {
+    rootId = makeIdFromString(rootId);
+  }
 
   const componentProps = {
     ...otherProps,
@@ -18,7 +24,16 @@ export const TrackedRootLocationContext = React.forwardRef<HTMLElement, TrackedC
     ...(forwardId ? { id } : {}),
   };
 
+  if (!rootId) {
+    if (globalThis.objectiv) {
+      globalThis.objectiv.TrackerConsole.error(
+        `｢objectiv｣ Could not generate a valid id for RootLocationContext. Please provide the \`id\` property.`
+      );
+    }
+    return React.createElement(Component, componentProps);
+  }
+
   return (
-    <RootLocationContextWrapper id={id}>{React.createElement(Component, componentProps)}</RootLocationContextWrapper>
+    <RootLocationContextWrapper id={rootId}>{React.createElement(Component, componentProps)}</RootLocationContextWrapper>
   );
 });

--- a/tracker/trackers/react/src/types.ts
+++ b/tracker/trackers/react/src/types.ts
@@ -22,6 +22,11 @@ export type TrackedContextProps<T = HTMLElement> = WithComponentProp<AllHTMLAttr
    * Whether to forward the given id to the given Component
    */
   forwardId?: boolean;
+
+  /**
+   * Whether to normalize the given id, default to true
+   */
+  normalizeId?: boolean;
 };
 
 /**
@@ -80,6 +85,11 @@ export type ObjectivTrackingOptions = {
    * The unique id of the LinkContext. Required for links without any title nor text.
    */
   contextId?: string;
+
+  /**
+   * Whether to normalize the given id, default to true.
+   */
+  normalizeId?: boolean;
 };
 
 /**

--- a/tracker/trackers/react/tests/TrackedAnchor.test.tsx
+++ b/tracker/trackers/react/tests/TrackedAnchor.test.tsx
@@ -58,7 +58,9 @@ describe('TrackedAnchor', () => {
     const { container } = render(
       <ObjectivProvider tracker={tracker}>
         <TrackedAnchor href={'/some-url'}>Trigger Event 1</TrackedAnchor>
-        <TrackedAnchor href={'/some-url'} normalizeId={false}>Trigger Event 2</TrackedAnchor>
+        <TrackedAnchor href={'/some-url'} normalizeId={false}>
+          Trigger Event 2
+        </TrackedAnchor>
       </ObjectivProvider>
     );
 
@@ -68,7 +70,8 @@ describe('TrackedAnchor', () => {
     fireEvent.click(getByText(container, /trigger event 2/i));
 
     expect(spyTransport.handle).toHaveBeenCalledTimes(2);
-    expect(spyTransport.handle).toHaveBeenNthCalledWith(1,
+    expect(spyTransport.handle).toHaveBeenNthCalledWith(
+      1,
       expect.objectContaining({
         _type: 'PressEvent',
         location_stack: expect.arrayContaining([
@@ -80,7 +83,8 @@ describe('TrackedAnchor', () => {
         ]),
       })
     );
-    expect(spyTransport.handle).toHaveBeenNthCalledWith(2,
+    expect(spyTransport.handle).toHaveBeenNthCalledWith(
+      2,
       expect.objectContaining({
         _type: 'PressEvent',
         location_stack: expect.arrayContaining([
@@ -93,7 +97,6 @@ describe('TrackedAnchor', () => {
       })
     );
   });
-
 
   it('should forwardHref to the given Component', () => {
     const tracker = new ReactTracker({ applicationId: 'app-id', transport: new SpyTransport() });

--- a/tracker/trackers/react/tests/TrackedButton.test.tsx
+++ b/tracker/trackers/react/tests/TrackedButton.test.tsx
@@ -67,7 +67,8 @@ describe('TrackedButton', () => {
     fireEvent.click(getByText(container, /trigger event 2/i));
 
     expect(spyTransport.handle).toHaveBeenCalledTimes(2);
-    expect(spyTransport.handle).toHaveBeenNthCalledWith(1,
+    expect(spyTransport.handle).toHaveBeenNthCalledWith(
+      1,
       expect.objectContaining({
         _type: 'PressEvent',
         location_stack: expect.arrayContaining([
@@ -78,7 +79,8 @@ describe('TrackedButton', () => {
         ]),
       })
     );
-    expect(spyTransport.handle).toHaveBeenNthCalledWith(2,
+    expect(spyTransport.handle).toHaveBeenNthCalledWith(
+      2,
       expect.objectContaining({
         _type: 'PressEvent',
         location_stack: expect.arrayContaining([
@@ -89,5 +91,5 @@ describe('TrackedButton', () => {
         ]),
       })
     );
-  })
+  });
 });

--- a/tracker/trackers/react/tests/TrackedButton.test.tsx
+++ b/tracker/trackers/react/tests/TrackedButton.test.tsx
@@ -48,4 +48,46 @@ describe('TrackedButton', () => {
       })
     );
   });
+
+  it('should allow disabling id normalization', () => {
+    const spyTransport = new SpyTransport();
+    jest.spyOn(spyTransport, 'handle');
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: spyTransport });
+
+    const { container } = render(
+      <ObjectivProvider tracker={tracker}>
+        <TrackedButton>Trigger Event 1</TrackedButton>
+        <TrackedButton normalizeId={false}>Trigger Event 2</TrackedButton>
+      </ObjectivProvider>
+    );
+
+    jest.resetAllMocks();
+
+    fireEvent.click(getByText(container, /trigger event 1/i));
+    fireEvent.click(getByText(container, /trigger event 2/i));
+
+    expect(spyTransport.handle).toHaveBeenCalledTimes(2);
+    expect(spyTransport.handle).toHaveBeenNthCalledWith(1,
+      expect.objectContaining({
+        _type: 'PressEvent',
+        location_stack: expect.arrayContaining([
+          expect.objectContaining({
+            _type: LocationContextName.PressableContext,
+            id: 'trigger-event-1',
+          }),
+        ]),
+      })
+    );
+    expect(spyTransport.handle).toHaveBeenNthCalledWith(2,
+      expect.objectContaining({
+        _type: 'PressEvent',
+        location_stack: expect.arrayContaining([
+          expect.objectContaining({
+            _type: LocationContextName.PressableContext,
+            id: 'Trigger Event 2',
+          }),
+        ]),
+      })
+    );
+  })
 });

--- a/tracker/trackers/react/tests/TrackedContentContext.test.tsx
+++ b/tracker/trackers/react/tests/TrackedContentContext.test.tsx
@@ -12,7 +12,7 @@ import {
   TrackedContentContext,
   TrackedDiv,
   TrackedRootLocationContext,
-  usePressEventTracker
+  usePressEventTracker,
 } from '../src';
 
 require('@objectiv/developer-tools');
@@ -73,7 +73,7 @@ describe('TrackedContentContext', () => {
     jest.spyOn(spyTransport, 'handle');
     const tracker = new ReactTracker({ applicationId: 'app-id', transport: spyTransport });
 
-    const TrackedButton = ({children}:{children: React.ReactNode}) => {
+    const TrackedButton = ({ children }: { children: React.ReactNode }) => {
       const trackPressEvent = usePressEventTracker();
       return <div onClick={trackPressEvent}>{children}</div>;
     };

--- a/tracker/trackers/react/tests/TrackedContentContext.test.tsx
+++ b/tracker/trackers/react/tests/TrackedContentContext.test.tsx
@@ -6,7 +6,14 @@ import { MockConsoleImplementation, SpyTransport } from '@objectiv/testing-tools
 import { LocationContextName } from '@objectiv/tracker-core';
 import { fireEvent, getByText, render, screen } from '@testing-library/react';
 import React, { createRef } from 'react';
-import { ObjectivProvider, ReactTracker, TrackedContentContext, usePressEventTracker } from '../src';
+import {
+  ObjectivProvider,
+  ReactTracker,
+  TrackedContentContext,
+  TrackedDiv,
+  TrackedRootLocationContext,
+  usePressEventTracker
+} from '../src';
 
 require('@objectiv/developer-tools');
 globalThis.objectiv?.TrackerConsole.setImplementation(MockConsoleImplementation);
@@ -58,6 +65,85 @@ describe('TrackedContentContext', () => {
           }),
         ]),
       })
+    );
+  });
+
+  it('should allow disabling id normalization', () => {
+    const spyTransport = new SpyTransport();
+    jest.spyOn(spyTransport, 'handle');
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: spyTransport });
+
+    const TrackedButton = ({children}:{children: React.ReactNode}) => {
+      const trackPressEvent = usePressEventTracker();
+      return <div onClick={trackPressEvent}>{children}</div>;
+    };
+
+    const { container } = render(
+      <ObjectivProvider tracker={tracker}>
+        <TrackedContentContext Component={'div'} id={'Content id 1'}>
+          <TrackedButton>Trigger Event 1</TrackedButton>
+        </TrackedContentContext>
+        <TrackedContentContext Component={'div'} id={'Content id 2'} normalizeId={false}>
+          <TrackedButton>Trigger Event 2</TrackedButton>
+        </TrackedContentContext>
+      </ObjectivProvider>
+    );
+
+    fireEvent.click(getByText(container, /trigger event 1/i));
+    fireEvent.click(getByText(container, /trigger event 2/i));
+
+    expect(spyTransport.handle).toHaveBeenCalledTimes(3);
+    expect(spyTransport.handle).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        _type: 'ApplicationLoadedEvent',
+      })
+    );
+    expect(spyTransport.handle).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        _type: 'PressEvent',
+        location_stack: expect.arrayContaining([
+          expect.objectContaining({
+            _type: LocationContextName.ContentContext,
+            id: 'content-id-1',
+          }),
+        ]),
+      })
+    );
+    expect(spyTransport.handle).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        _type: 'PressEvent',
+        location_stack: expect.arrayContaining([
+          expect.objectContaining({
+            _type: LocationContextName.ContentContext,
+            id: 'Content id 2',
+          }),
+        ]),
+      })
+    );
+  });
+
+  it('should console.error if an id cannot be automatically generated', () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: new SpyTransport() });
+
+    render(
+      <ObjectivProvider tracker={tracker}>
+        <TrackedRootLocationContext Component={'div'} id={'root'}>
+          <TrackedDiv id={'content'}>
+            <TrackedContentContext Component={'div'} id={'☹️'}>
+              {/* nothing to see here */}
+            </TrackedContentContext>
+          </TrackedDiv>
+        </TrackedRootLocationContext>
+      </ObjectivProvider>
+    );
+
+    expect(MockConsoleImplementation.error).toHaveBeenCalledTimes(1);
+    expect(MockConsoleImplementation.error).toHaveBeenCalledWith(
+      '｢objectiv｣ Could not generate a valid id for ContentContext @ RootLocation:root / Content:content. Please provide the `id` property.'
     );
   });
 

--- a/tracker/trackers/react/tests/TrackedDiv.test.tsx
+++ b/tracker/trackers/react/tests/TrackedDiv.test.tsx
@@ -6,7 +6,7 @@ import { MockConsoleImplementation, SpyTransport } from '@objectiv/testing-tools
 import { LocationContextName } from '@objectiv/tracker-core';
 import { fireEvent, getByText, render } from '@testing-library/react';
 import React from 'react';
-import { ObjectivProvider, ReactTracker, TrackedDiv, usePressEventTracker } from '../src';
+import { ObjectivProvider, ReactTracker, TrackedDiv, TrackedRootLocationContext, usePressEventTracker } from '../src';
 
 require('@objectiv/developer-tools');
 globalThis.objectiv?.TrackerConsole.setImplementation(MockConsoleImplementation);
@@ -53,6 +53,79 @@ describe('TrackedDiv', () => {
           }),
         ]),
       })
+    );
+  });
+
+  it('should allow disabling id normalization', () => {
+    const spyTransport = new SpyTransport();
+    jest.spyOn(spyTransport, 'handle');
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: spyTransport });
+
+    const TrackedButton = ({children}:{children: React.ReactNode}) => {
+      const trackPressEvent = usePressEventTracker();
+      return <div onClick={trackPressEvent}>{children}</div>;
+    };
+
+    const { container } = render(
+      <ObjectivProvider tracker={tracker}>
+        <TrackedDiv id={'Div id 1'}>
+          <TrackedButton>Trigger Event 1</TrackedButton>
+        </TrackedDiv>
+        <TrackedDiv id={'Div id 2'} normalizeId={false}>
+          <TrackedButton>Trigger Event 2</TrackedButton>
+        </TrackedDiv>
+      </ObjectivProvider>
+    );
+
+    jest.resetAllMocks();
+
+    fireEvent.click(getByText(container, /trigger event 1/i));
+    fireEvent.click(getByText(container, /trigger event 2/i));
+
+    expect(spyTransport.handle).toHaveBeenCalledTimes(2);
+    expect(spyTransport.handle).toHaveBeenNthCalledWith(1,
+      expect.objectContaining({
+        _type: 'PressEvent',
+        location_stack: expect.arrayContaining([
+          expect.objectContaining({
+            _type: LocationContextName.ContentContext,
+            id: 'div-id-1',
+          }),
+        ]),
+      })
+    );
+    expect(spyTransport.handle).toHaveBeenNthCalledWith(2,
+      expect.objectContaining({
+        _type: 'PressEvent',
+        location_stack: expect.arrayContaining([
+          expect.objectContaining({
+            _type: LocationContextName.ContentContext,
+            id: 'Div id 2',
+          }),
+        ]),
+      })
+    );
+  })
+
+  it('should console.error if an id cannot be automatically generated', () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: new SpyTransport() });
+
+    render(
+      <ObjectivProvider tracker={tracker}>
+        <TrackedRootLocationContext Component={'div'} id={'root'}>
+          <TrackedDiv id={'content'}>
+            <TrackedDiv id={'☹️'}>
+              {/* nothing to see here */}
+            </TrackedDiv>
+          </TrackedDiv>
+        </TrackedRootLocationContext>
+      </ObjectivProvider>
+    );
+
+    expect(MockConsoleImplementation.error).toHaveBeenCalledTimes(1);
+    expect(MockConsoleImplementation.error).toHaveBeenCalledWith(
+      '｢objectiv｣ Could not generate a valid id for ContentContext @ RootLocation:root / Content:content. Please provide the `id` property.'
     );
   });
 });

--- a/tracker/trackers/react/tests/TrackedDiv.test.tsx
+++ b/tracker/trackers/react/tests/TrackedDiv.test.tsx
@@ -61,7 +61,7 @@ describe('TrackedDiv', () => {
     jest.spyOn(spyTransport, 'handle');
     const tracker = new ReactTracker({ applicationId: 'app-id', transport: spyTransport });
 
-    const TrackedButton = ({children}:{children: React.ReactNode}) => {
+    const TrackedButton = ({ children }: { children: React.ReactNode }) => {
       const trackPressEvent = usePressEventTracker();
       return <div onClick={trackPressEvent}>{children}</div>;
     };
@@ -83,7 +83,8 @@ describe('TrackedDiv', () => {
     fireEvent.click(getByText(container, /trigger event 2/i));
 
     expect(spyTransport.handle).toHaveBeenCalledTimes(2);
-    expect(spyTransport.handle).toHaveBeenNthCalledWith(1,
+    expect(spyTransport.handle).toHaveBeenNthCalledWith(
+      1,
       expect.objectContaining({
         _type: 'PressEvent',
         location_stack: expect.arrayContaining([
@@ -94,7 +95,8 @@ describe('TrackedDiv', () => {
         ]),
       })
     );
-    expect(spyTransport.handle).toHaveBeenNthCalledWith(2,
+    expect(spyTransport.handle).toHaveBeenNthCalledWith(
+      2,
       expect.objectContaining({
         _type: 'PressEvent',
         location_stack: expect.arrayContaining([
@@ -105,7 +107,7 @@ describe('TrackedDiv', () => {
         ]),
       })
     );
-  })
+  });
 
   it('should console.error if an id cannot be automatically generated', () => {
     jest.spyOn(console, 'error').mockImplementation(() => {});
@@ -115,9 +117,7 @@ describe('TrackedDiv', () => {
       <ObjectivProvider tracker={tracker}>
         <TrackedRootLocationContext Component={'div'} id={'root'}>
           <TrackedDiv id={'content'}>
-            <TrackedDiv id={'☹️'}>
-              {/* nothing to see here */}
-            </TrackedDiv>
+            <TrackedDiv id={'☹️'}>{/* nothing to see here */}</TrackedDiv>
           </TrackedDiv>
         </TrackedRootLocationContext>
       </ObjectivProvider>

--- a/tracker/trackers/react/tests/TrackedExpandableContext.test.tsx
+++ b/tracker/trackers/react/tests/TrackedExpandableContext.test.tsx
@@ -143,7 +143,7 @@ describe('TrackedExpandableContext', () => {
 
     expect(MockConsoleImplementation.error).toHaveBeenCalledTimes(1);
     expect(MockConsoleImplementation.error).toHaveBeenCalledWith(
-      '｢objectiv｣ Could not generate a valid id for ContentContext @ RootLocation:root / Content:content. Please provide the `id` property.'
+      '｢objectiv｣ Could not generate a valid id for ExpandableContext @ RootLocation:root / Content:content. Please provide the `id` property.'
     );
   });
 

--- a/tracker/trackers/react/tests/TrackedExpandableContext.test.tsx
+++ b/tracker/trackers/react/tests/TrackedExpandableContext.test.tsx
@@ -6,7 +6,13 @@ import { MockConsoleImplementation, SpyTransport } from '@objectiv/testing-tools
 import { LocationContextName } from '@objectiv/tracker-core';
 import { fireEvent, getByText, render, screen } from '@testing-library/react';
 import React, { createRef } from 'react';
-import { ObjectivProvider, ReactTracker, TrackedExpandableContext, usePressEventTracker } from '../src';
+import {
+  ObjectivProvider,
+  ReactTracker, TrackedDiv,
+  TrackedExpandableContext,
+  TrackedRootLocationContext,
+  usePressEventTracker
+} from '../src';
 
 require('@objectiv/developer-tools');
 globalThis.objectiv?.TrackerConsole.setImplementation(MockConsoleImplementation);
@@ -58,6 +64,85 @@ describe('TrackedExpandableContext', () => {
           }),
         ]),
       })
+    );
+  });
+
+  it('should allow disabling id normalization', () => {
+    const spyTransport = new SpyTransport();
+    jest.spyOn(spyTransport, 'handle');
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: spyTransport });
+
+    const TrackedButton = ({children}:{children: React.ReactNode}) => {
+      const trackPressEvent = usePressEventTracker();
+      return <div onClick={trackPressEvent}>{children}</div>;
+    };
+
+    const { container } = render(
+      <ObjectivProvider tracker={tracker}>
+        <TrackedExpandableContext Component={'div'} id={'Expandable id 1'}>
+          <TrackedButton>Trigger Event 1</TrackedButton>
+        </TrackedExpandableContext>
+        <TrackedExpandableContext Component={'div'} id={'Expandable id 2'} normalizeId={false}>
+          <TrackedButton>Trigger Event 2</TrackedButton>
+        </TrackedExpandableContext>
+      </ObjectivProvider>
+    );
+
+    fireEvent.click(getByText(container, /trigger event 1/i));
+    fireEvent.click(getByText(container, /trigger event 2/i));
+
+    expect(spyTransport.handle).toHaveBeenCalledTimes(3);
+    expect(spyTransport.handle).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        _type: 'ApplicationLoadedEvent',
+      })
+    );
+    expect(spyTransport.handle).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        _type: 'PressEvent',
+        location_stack: expect.arrayContaining([
+          expect.objectContaining({
+            _type: LocationContextName.ExpandableContext,
+            id: 'expandable-id-1',
+          }),
+        ]),
+      })
+    );
+    expect(spyTransport.handle).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        _type: 'PressEvent',
+        location_stack: expect.arrayContaining([
+          expect.objectContaining({
+            _type: LocationContextName.ExpandableContext,
+            id: 'Expandable id 2',
+          }),
+        ]),
+      })
+    );
+  })
+
+  it('should console.error if an id cannot be automatically generated', () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: new SpyTransport() });
+
+    render(
+      <ObjectivProvider tracker={tracker}>
+        <TrackedRootLocationContext Component={'div'} id={'root'}>
+          <TrackedDiv id={'content'}>
+            <TrackedExpandableContext Component={'div'} id={'☹️'}>
+              {/* nothing to see here */}
+            </TrackedExpandableContext>
+          </TrackedDiv>
+        </TrackedRootLocationContext>
+      </ObjectivProvider>
+    );
+
+    expect(MockConsoleImplementation.error).toHaveBeenCalledTimes(1);
+    expect(MockConsoleImplementation.error).toHaveBeenCalledWith(
+      '｢objectiv｣ Could not generate a valid id for ContentContext @ RootLocation:root / Content:content. Please provide the `id` property.'
     );
   });
 

--- a/tracker/trackers/react/tests/TrackedExpandableContext.test.tsx
+++ b/tracker/trackers/react/tests/TrackedExpandableContext.test.tsx
@@ -8,10 +8,11 @@ import { fireEvent, getByText, render, screen } from '@testing-library/react';
 import React, { createRef } from 'react';
 import {
   ObjectivProvider,
-  ReactTracker, TrackedDiv,
+  ReactTracker,
+  TrackedDiv,
   TrackedExpandableContext,
   TrackedRootLocationContext,
-  usePressEventTracker
+  usePressEventTracker,
 } from '../src';
 
 require('@objectiv/developer-tools');
@@ -72,7 +73,7 @@ describe('TrackedExpandableContext', () => {
     jest.spyOn(spyTransport, 'handle');
     const tracker = new ReactTracker({ applicationId: 'app-id', transport: spyTransport });
 
-    const TrackedButton = ({children}:{children: React.ReactNode}) => {
+    const TrackedButton = ({ children }: { children: React.ReactNode }) => {
       const trackPressEvent = usePressEventTracker();
       return <div onClick={trackPressEvent}>{children}</div>;
     };
@@ -122,7 +123,7 @@ describe('TrackedExpandableContext', () => {
         ]),
       })
     );
-  })
+  });
 
   it('should console.error if an id cannot be automatically generated', () => {
     jest.spyOn(console, 'error').mockImplementation(() => {});

--- a/tracker/trackers/react/tests/TrackedFooter.test.tsx
+++ b/tracker/trackers/react/tests/TrackedFooter.test.tsx
@@ -6,7 +6,14 @@ import { MockConsoleImplementation, SpyTransport } from '@objectiv/testing-tools
 import { LocationContextName } from '@objectiv/tracker-core';
 import { fireEvent, getByText, render } from '@testing-library/react';
 import React from 'react';
-import { ObjectivProvider, ReactTracker, TrackedFooter, usePressEventTracker } from '../src';
+import {
+  ObjectivProvider,
+  ReactTracker,
+  TrackedDiv,
+  TrackedFooter,
+  TrackedRootLocationContext,
+  usePressEventTracker
+} from '../src';
 
 require('@objectiv/developer-tools');
 globalThis.objectiv?.TrackerConsole.setImplementation(MockConsoleImplementation);
@@ -55,6 +62,77 @@ describe('TrackedFooter', () => {
       })
     );
   });
+
+  it('should allow disabling id normalization', () => {
+    const spyTransport = new SpyTransport();
+    jest.spyOn(spyTransport, 'handle');
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: spyTransport });
+
+    const TrackedButton = ({children}:{children: React.ReactNode}) => {
+      const trackPressEvent = usePressEventTracker();
+      return <div onClick={trackPressEvent}>{children}</div>;
+    };
+
+    const { container } = render(
+      <ObjectivProvider tracker={tracker}>
+        <TrackedFooter id={'Footer 1'}>
+          <TrackedButton>Trigger Event 1</TrackedButton>
+        </TrackedFooter>
+        <TrackedFooter id={'Footer 2'} normalizeId={false}>
+          <TrackedButton>Trigger Event 2</TrackedButton>
+        </TrackedFooter>
+      </ObjectivProvider>
+    );
+
+    jest.resetAllMocks();
+
+    fireEvent.click(getByText(container, /trigger event 1/i));
+    fireEvent.click(getByText(container, /trigger event 2/i));
+
+    expect(spyTransport.handle).toHaveBeenCalledTimes(2);
+    expect(spyTransport.handle).toHaveBeenNthCalledWith(1,
+      expect.objectContaining({
+        _type: 'PressEvent',
+        location_stack: expect.arrayContaining([
+          expect.objectContaining({
+            _type: LocationContextName.ContentContext,
+            id: 'footer-1',
+          }),
+        ]),
+      })
+    );
+    expect(spyTransport.handle).toHaveBeenNthCalledWith(2,
+      expect.objectContaining({
+        _type: 'PressEvent',
+        location_stack: expect.arrayContaining([
+          expect.objectContaining({
+            _type: LocationContextName.ContentContext,
+            id: 'Footer 2',
+          }),
+        ]),
+      })
+    );
+  });
+
+  it('should console.error if an id cannot be automatically generated', () => {
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: new SpyTransport() });
+
+    render(
+      <ObjectivProvider tracker={tracker}>
+        <TrackedRootLocationContext Component={'div'} id={'root'}>
+          <TrackedDiv id={'content'}>
+            <TrackedFooter id={'☹️'}/>
+          </TrackedDiv>
+        </TrackedRootLocationContext>
+      </ObjectivProvider>
+    );
+
+    expect(MockConsoleImplementation.error).toHaveBeenCalledTimes(1);
+    expect(MockConsoleImplementation.error).toHaveBeenCalledWith(
+      '｢objectiv｣ Could not generate a valid id for ContentContext @ RootLocation:root / Content:content. Please provide the `id` property.'
+    );
+  })
 
   it('should allow specifying a custom id', () => {
     const spyTransport = new SpyTransport();

--- a/tracker/trackers/react/tests/TrackedFooter.test.tsx
+++ b/tracker/trackers/react/tests/TrackedFooter.test.tsx
@@ -12,7 +12,7 @@ import {
   TrackedDiv,
   TrackedFooter,
   TrackedRootLocationContext,
-  usePressEventTracker
+  usePressEventTracker,
 } from '../src';
 
 require('@objectiv/developer-tools');
@@ -68,7 +68,7 @@ describe('TrackedFooter', () => {
     jest.spyOn(spyTransport, 'handle');
     const tracker = new ReactTracker({ applicationId: 'app-id', transport: spyTransport });
 
-    const TrackedButton = ({children}:{children: React.ReactNode}) => {
+    const TrackedButton = ({ children }: { children: React.ReactNode }) => {
       const trackPressEvent = usePressEventTracker();
       return <div onClick={trackPressEvent}>{children}</div>;
     };
@@ -90,7 +90,8 @@ describe('TrackedFooter', () => {
     fireEvent.click(getByText(container, /trigger event 2/i));
 
     expect(spyTransport.handle).toHaveBeenCalledTimes(2);
-    expect(spyTransport.handle).toHaveBeenNthCalledWith(1,
+    expect(spyTransport.handle).toHaveBeenNthCalledWith(
+      1,
       expect.objectContaining({
         _type: 'PressEvent',
         location_stack: expect.arrayContaining([
@@ -101,7 +102,8 @@ describe('TrackedFooter', () => {
         ]),
       })
     );
-    expect(spyTransport.handle).toHaveBeenNthCalledWith(2,
+    expect(spyTransport.handle).toHaveBeenNthCalledWith(
+      2,
       expect.objectContaining({
         _type: 'PressEvent',
         location_stack: expect.arrayContaining([
@@ -115,14 +117,14 @@ describe('TrackedFooter', () => {
   });
 
   it('should console.error if an id cannot be automatically generated', () => {
-        jest.spyOn(console, 'error').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
     const tracker = new ReactTracker({ applicationId: 'app-id', transport: new SpyTransport() });
 
     render(
       <ObjectivProvider tracker={tracker}>
         <TrackedRootLocationContext Component={'div'} id={'root'}>
           <TrackedDiv id={'content'}>
-            <TrackedFooter id={'☹️'}/>
+            <TrackedFooter id={'☹️'} />
           </TrackedDiv>
         </TrackedRootLocationContext>
       </ObjectivProvider>
@@ -132,7 +134,7 @@ describe('TrackedFooter', () => {
     expect(MockConsoleImplementation.error).toHaveBeenCalledWith(
       '｢objectiv｣ Could not generate a valid id for ContentContext @ RootLocation:root / Content:content. Please provide the `id` property.'
     );
-  })
+  });
 
   it('should allow specifying a custom id', () => {
     const spyTransport = new SpyTransport();

--- a/tracker/trackers/react/tests/TrackedHeader.test.tsx
+++ b/tracker/trackers/react/tests/TrackedHeader.test.tsx
@@ -12,7 +12,7 @@ import {
   TrackedDiv,
   TrackedHeader,
   TrackedRootLocationContext,
-  usePressEventTracker
+  usePressEventTracker,
 } from '../src';
 
 require('@objectiv/developer-tools');
@@ -62,13 +62,13 @@ describe('TrackedHeader', () => {
       })
     );
   });
-  
+
   it('should allow disabling id normalization', () => {
     const spyTransport = new SpyTransport();
     jest.spyOn(spyTransport, 'handle');
     const tracker = new ReactTracker({ applicationId: 'app-id', transport: spyTransport });
 
-    const TrackedButton = ({children}:{children: React.ReactNode}) => {
+    const TrackedButton = ({ children }: { children: React.ReactNode }) => {
       const trackPressEvent = usePressEventTracker();
       return <div onClick={trackPressEvent}>{children}</div>;
     };
@@ -90,7 +90,8 @@ describe('TrackedHeader', () => {
     fireEvent.click(getByText(container, /trigger event 2/i));
 
     expect(spyTransport.handle).toHaveBeenCalledTimes(2);
-    expect(spyTransport.handle).toHaveBeenNthCalledWith(1,
+    expect(spyTransport.handle).toHaveBeenNthCalledWith(
+      1,
       expect.objectContaining({
         _type: 'PressEvent',
         location_stack: expect.arrayContaining([
@@ -101,7 +102,8 @@ describe('TrackedHeader', () => {
         ]),
       })
     );
-    expect(spyTransport.handle).toHaveBeenNthCalledWith(2,
+    expect(spyTransport.handle).toHaveBeenNthCalledWith(
+      2,
       expect.objectContaining({
         _type: 'PressEvent',
         location_stack: expect.arrayContaining([
@@ -115,14 +117,14 @@ describe('TrackedHeader', () => {
   });
 
   it('should console.error if an id cannot be automatically generated', () => {
-        jest.spyOn(console, 'error').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
     const tracker = new ReactTracker({ applicationId: 'app-id', transport: new SpyTransport() });
 
     render(
       <ObjectivProvider tracker={tracker}>
         <TrackedRootLocationContext Component={'div'} id={'root'}>
           <TrackedDiv id={'content'}>
-            <TrackedHeader id={'☹️'}/>
+            <TrackedHeader id={'☹️'} />
           </TrackedDiv>
         </TrackedRootLocationContext>
       </ObjectivProvider>
@@ -132,7 +134,7 @@ describe('TrackedHeader', () => {
     expect(MockConsoleImplementation.error).toHaveBeenCalledWith(
       '｢objectiv｣ Could not generate a valid id for ContentContext @ RootLocation:root / Content:content. Please provide the `id` property.'
     );
-  })  
+  });
 
   it('should allow specifying a custom id', () => {
     const spyTransport = new SpyTransport();

--- a/tracker/trackers/react/tests/TrackedHeader.test.tsx
+++ b/tracker/trackers/react/tests/TrackedHeader.test.tsx
@@ -6,7 +6,14 @@ import { MockConsoleImplementation, SpyTransport } from '@objectiv/testing-tools
 import { LocationContextName } from '@objectiv/tracker-core';
 import { fireEvent, getByText, render } from '@testing-library/react';
 import React from 'react';
-import { ObjectivProvider, ReactTracker, TrackedHeader, usePressEventTracker } from '../src';
+import {
+  ObjectivProvider,
+  ReactTracker,
+  TrackedDiv,
+  TrackedHeader,
+  TrackedRootLocationContext,
+  usePressEventTracker
+} from '../src';
 
 require('@objectiv/developer-tools');
 globalThis.objectiv?.TrackerConsole.setImplementation(MockConsoleImplementation);
@@ -55,6 +62,77 @@ describe('TrackedHeader', () => {
       })
     );
   });
+  
+  it('should allow disabling id normalization', () => {
+    const spyTransport = new SpyTransport();
+    jest.spyOn(spyTransport, 'handle');
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: spyTransport });
+
+    const TrackedButton = ({children}:{children: React.ReactNode}) => {
+      const trackPressEvent = usePressEventTracker();
+      return <div onClick={trackPressEvent}>{children}</div>;
+    };
+
+    const { container } = render(
+      <ObjectivProvider tracker={tracker}>
+        <TrackedHeader id={'Header 1'}>
+          <TrackedButton>Trigger Event 1</TrackedButton>
+        </TrackedHeader>
+        <TrackedHeader id={'Header 2'} normalizeId={false}>
+          <TrackedButton>Trigger Event 2</TrackedButton>
+        </TrackedHeader>
+      </ObjectivProvider>
+    );
+
+    jest.resetAllMocks();
+
+    fireEvent.click(getByText(container, /trigger event 1/i));
+    fireEvent.click(getByText(container, /trigger event 2/i));
+
+    expect(spyTransport.handle).toHaveBeenCalledTimes(2);
+    expect(spyTransport.handle).toHaveBeenNthCalledWith(1,
+      expect.objectContaining({
+        _type: 'PressEvent',
+        location_stack: expect.arrayContaining([
+          expect.objectContaining({
+            _type: LocationContextName.ContentContext,
+            id: 'header-1',
+          }),
+        ]),
+      })
+    );
+    expect(spyTransport.handle).toHaveBeenNthCalledWith(2,
+      expect.objectContaining({
+        _type: 'PressEvent',
+        location_stack: expect.arrayContaining([
+          expect.objectContaining({
+            _type: LocationContextName.ContentContext,
+            id: 'Header 2',
+          }),
+        ]),
+      })
+    );
+  });
+
+  it('should console.error if an id cannot be automatically generated', () => {
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: new SpyTransport() });
+
+    render(
+      <ObjectivProvider tracker={tracker}>
+        <TrackedRootLocationContext Component={'div'} id={'root'}>
+          <TrackedDiv id={'content'}>
+            <TrackedHeader id={'☹️'}/>
+          </TrackedDiv>
+        </TrackedRootLocationContext>
+      </ObjectivProvider>
+    );
+
+    expect(MockConsoleImplementation.error).toHaveBeenCalledTimes(1);
+    expect(MockConsoleImplementation.error).toHaveBeenCalledWith(
+      '｢objectiv｣ Could not generate a valid id for ContentContext @ RootLocation:root / Content:content. Please provide the `id` property.'
+    );
+  })  
 
   it('should allow specifying a custom id', () => {
     const spyTransport = new SpyTransport();

--- a/tracker/trackers/react/tests/TrackedInput.test.tsx
+++ b/tracker/trackers/react/tests/TrackedInput.test.tsx
@@ -6,7 +6,7 @@ import { MockConsoleImplementation, SpyTransport } from '@objectiv/testing-tools
 import { LocationContextName } from '@objectiv/tracker-core';
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
-import { ObjectivProvider, ReactTracker, TrackedInput } from '../src';
+import { ObjectivProvider, ReactTracker, TrackedDiv, TrackedInput, TrackedRootLocationContext } from '../src';
 
 require('@objectiv/developer-tools');
 globalThis.objectiv?.TrackerConsole.setImplementation(MockConsoleImplementation);
@@ -46,6 +46,76 @@ describe('TrackedInputContext', () => {
           }),
         ]),
       })
+    );
+  });
+
+  it('should allow disabling id normalization', () => {
+    const spyTransport = new SpyTransport();
+    jest.spyOn(spyTransport, 'handle');
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: spyTransport });
+
+    render(
+      <ObjectivProvider tracker={tracker}>
+        <TrackedInput type={'text'} id={'Input id 1'} data-testid={'test-input-1'} defaultValue={'text'} />
+        <TrackedInput
+          type={'text'}
+          id={'Input id 2'}
+          normalizeId={false}
+          data-testid={'test-input-2'}
+          defaultValue={'text'}
+        />
+      </ObjectivProvider>
+    );
+
+    jest.resetAllMocks();
+
+    fireEvent.blur(screen.getByTestId('test-input-1'), { target: { value: 'some new text 1' } });
+    fireEvent.blur(screen.getByTestId('test-input-2'), { target: { value: 'some new text 2' } });
+
+    expect(spyTransport.handle).toHaveBeenCalledTimes(2);
+    expect(spyTransport.handle).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        _type: 'InputChangeEvent',
+        location_stack: expect.arrayContaining([
+          expect.objectContaining({
+            _type: LocationContextName.InputContext,
+            id: 'input-id-1',
+          }),
+        ]),
+      })
+    );
+    expect(spyTransport.handle).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        _type: 'InputChangeEvent',
+        location_stack: expect.arrayContaining([
+          expect.objectContaining({
+            _type: LocationContextName.InputContext,
+            id: 'Input id 2',
+          }),
+        ]),
+      })
+    );
+  });
+
+  it('should console.error if an id cannot be automatically generated', () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: new SpyTransport() });
+
+    render(
+      <ObjectivProvider tracker={tracker}>
+        <TrackedRootLocationContext Component={'div'} id={'root'}>
+          <TrackedDiv id={'content'}>
+            <TrackedInput type={'text'} id={'☹️'} />
+          </TrackedDiv>
+        </TrackedRootLocationContext>
+      </ObjectivProvider>
+    );
+
+    expect(MockConsoleImplementation.error).toHaveBeenCalledTimes(1);
+    expect(MockConsoleImplementation.error).toHaveBeenCalledWith(
+      '｢objectiv｣ Could not generate a valid id for InputContext @ RootLocation:root / Content:content. Please provide the `id` property.'
     );
   });
 });

--- a/tracker/trackers/react/tests/TrackedInputContext.test.tsx
+++ b/tracker/trackers/react/tests/TrackedInputContext.test.tsx
@@ -6,7 +6,7 @@ import { MockConsoleImplementation, SpyTransport } from '@objectiv/testing-tools
 import { LocationContextName } from '@objectiv/tracker-core';
 import { fireEvent, render, screen } from '@testing-library/react';
 import React, { createRef } from 'react';
-import { ObjectivProvider, ReactTracker, TrackedInputContext } from '../src';
+import { ObjectivProvider, ReactTracker, TrackedDiv, TrackedInputContext, TrackedRootLocationContext } from '../src';
 
 require('@objectiv/developer-tools');
 globalThis.objectiv?.TrackerConsole.setImplementation(MockConsoleImplementation);
@@ -39,6 +39,76 @@ describe('TrackedInputContext', () => {
       expect.objectContaining({
         _type: 'ApplicationLoadedEvent',
       })
+    );
+  });
+
+  it('should allow disabling id normalization', () => {
+    const spyTransport = new SpyTransport();
+    jest.spyOn(spyTransport, 'handle');
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: spyTransport });
+
+    render(
+      <ObjectivProvider tracker={tracker}>
+        <TrackedInputContext Component={'input'} type={'text'} id={'Input id 1'} data-testid={'test-input-1'} />
+        <TrackedInputContext
+          Component={'input'}
+          type={'text'}
+          id={'Input id 2'}
+          normalizeId={false}
+          data-testid={'test-input-2'}
+        />
+      </ObjectivProvider>
+    );
+
+    jest.resetAllMocks();
+
+    fireEvent.blur(screen.getByTestId('test-input-1'), { target: { value: 'some new text 1' } });
+    fireEvent.blur(screen.getByTestId('test-input-2'), { target: { value: 'some new text 2' } });
+
+    expect(spyTransport.handle).toHaveBeenCalledTimes(2);
+    expect(spyTransport.handle).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        _type: 'InputChangeEvent',
+        location_stack: expect.arrayContaining([
+          expect.objectContaining({
+            _type: LocationContextName.InputContext,
+            id: 'input-id-1',
+          }),
+        ]),
+      })
+    );
+    expect(spyTransport.handle).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        _type: 'InputChangeEvent',
+        location_stack: expect.arrayContaining([
+          expect.objectContaining({
+            _type: LocationContextName.InputContext,
+            id: 'Input id 2',
+          }),
+        ]),
+      })
+    );
+  });
+
+  it('should console.error if an id cannot be automatically generated', () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: new SpyTransport() });
+
+    render(
+      <ObjectivProvider tracker={tracker}>
+        <TrackedRootLocationContext Component={'div'} id={'root'}>
+          <TrackedDiv id={'content'}>
+            <TrackedInputContext Component={'input'} type={'text'} id={'☹️'} />
+          </TrackedDiv>
+        </TrackedRootLocationContext>
+      </ObjectivProvider>
+    );
+
+    expect(MockConsoleImplementation.error).toHaveBeenCalledTimes(1);
+    expect(MockConsoleImplementation.error).toHaveBeenCalledWith(
+      '｢objectiv｣ Could not generate a valid id for InputContext @ RootLocation:root / Content:content. Please provide the `id` property.'
     );
   });
 

--- a/tracker/trackers/react/tests/TrackedMain.test.tsx
+++ b/tracker/trackers/react/tests/TrackedMain.test.tsx
@@ -6,7 +6,14 @@ import { MockConsoleImplementation, SpyTransport } from '@objectiv/testing-tools
 import { LocationContextName } from '@objectiv/tracker-core';
 import { fireEvent, getByText, render } from '@testing-library/react';
 import React from 'react';
-import { ObjectivProvider, ReactTracker, TrackedMain, usePressEventTracker } from '../src';
+import {
+  ObjectivProvider,
+  ReactTracker,
+  TrackedDiv,
+  TrackedMain,
+  TrackedRootLocationContext,
+  usePressEventTracker
+} from '../src';
 
 require('@objectiv/developer-tools');
 globalThis.objectiv?.TrackerConsole.setImplementation(MockConsoleImplementation);
@@ -56,6 +63,77 @@ describe('TrackedMain', () => {
     );
   });
 
+  it('should allow disabling id normalization', () => {
+    const spyTransport = new SpyTransport();
+    jest.spyOn(spyTransport, 'handle');
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: spyTransport });
+
+    const TrackedButton = ({children}:{children: React.ReactNode}) => {
+      const trackPressEvent = usePressEventTracker();
+      return <div onClick={trackPressEvent}>{children}</div>;
+    };
+
+    const { container } = render(
+      <ObjectivProvider tracker={tracker}>
+        <TrackedMain id={'Main 1'}>
+          <TrackedButton>Trigger Event 1</TrackedButton>
+        </TrackedMain>
+        <TrackedMain id={'Main 2'} normalizeId={false}>
+          <TrackedButton>Trigger Event 2</TrackedButton>
+        </TrackedMain>
+      </ObjectivProvider>
+    );
+
+    jest.resetAllMocks();
+
+    fireEvent.click(getByText(container, /trigger event 1/i));
+    fireEvent.click(getByText(container, /trigger event 2/i));
+
+    expect(spyTransport.handle).toHaveBeenCalledTimes(2);
+    expect(spyTransport.handle).toHaveBeenNthCalledWith(1,
+      expect.objectContaining({
+        _type: 'PressEvent',
+        location_stack: expect.arrayContaining([
+          expect.objectContaining({
+            _type: LocationContextName.ContentContext,
+            id: 'main-1',
+          }),
+        ]),
+      })
+    );
+    expect(spyTransport.handle).toHaveBeenNthCalledWith(2,
+      expect.objectContaining({
+        _type: 'PressEvent',
+        location_stack: expect.arrayContaining([
+          expect.objectContaining({
+            _type: LocationContextName.ContentContext,
+            id: 'Main 2',
+          }),
+        ]),
+      })
+    );
+  });
+
+  it('should console.error if an id cannot be automatically generated', () => {
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: new SpyTransport() });
+
+    render(
+      <ObjectivProvider tracker={tracker}>
+        <TrackedRootLocationContext Component={'div'} id={'root'}>
+          <TrackedDiv id={'content'}>
+            <TrackedMain id={'☹️'}/>
+          </TrackedDiv>
+        </TrackedRootLocationContext>
+      </ObjectivProvider>
+    );
+
+    expect(MockConsoleImplementation.error).toHaveBeenCalledTimes(1);
+    expect(MockConsoleImplementation.error).toHaveBeenCalledWith(
+      '｢objectiv｣ Could not generate a valid id for ContentContext @ RootLocation:root / Content:content. Please provide the `id` property.'
+    );
+  })    
+  
   it('should allow specifying a custom id', () => {
     const spyTransport = new SpyTransport();
     jest.spyOn(spyTransport, 'handle');

--- a/tracker/trackers/react/tests/TrackedMain.test.tsx
+++ b/tracker/trackers/react/tests/TrackedMain.test.tsx
@@ -12,7 +12,7 @@ import {
   TrackedDiv,
   TrackedMain,
   TrackedRootLocationContext,
-  usePressEventTracker
+  usePressEventTracker,
 } from '../src';
 
 require('@objectiv/developer-tools');
@@ -68,7 +68,7 @@ describe('TrackedMain', () => {
     jest.spyOn(spyTransport, 'handle');
     const tracker = new ReactTracker({ applicationId: 'app-id', transport: spyTransport });
 
-    const TrackedButton = ({children}:{children: React.ReactNode}) => {
+    const TrackedButton = ({ children }: { children: React.ReactNode }) => {
       const trackPressEvent = usePressEventTracker();
       return <div onClick={trackPressEvent}>{children}</div>;
     };
@@ -90,7 +90,8 @@ describe('TrackedMain', () => {
     fireEvent.click(getByText(container, /trigger event 2/i));
 
     expect(spyTransport.handle).toHaveBeenCalledTimes(2);
-    expect(spyTransport.handle).toHaveBeenNthCalledWith(1,
+    expect(spyTransport.handle).toHaveBeenNthCalledWith(
+      1,
       expect.objectContaining({
         _type: 'PressEvent',
         location_stack: expect.arrayContaining([
@@ -101,7 +102,8 @@ describe('TrackedMain', () => {
         ]),
       })
     );
-    expect(spyTransport.handle).toHaveBeenNthCalledWith(2,
+    expect(spyTransport.handle).toHaveBeenNthCalledWith(
+      2,
       expect.objectContaining({
         _type: 'PressEvent',
         location_stack: expect.arrayContaining([
@@ -115,14 +117,14 @@ describe('TrackedMain', () => {
   });
 
   it('should console.error if an id cannot be automatically generated', () => {
-        jest.spyOn(console, 'error').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
     const tracker = new ReactTracker({ applicationId: 'app-id', transport: new SpyTransport() });
 
     render(
       <ObjectivProvider tracker={tracker}>
         <TrackedRootLocationContext Component={'div'} id={'root'}>
           <TrackedDiv id={'content'}>
-            <TrackedMain id={'☹️'}/>
+            <TrackedMain id={'☹️'} />
           </TrackedDiv>
         </TrackedRootLocationContext>
       </ObjectivProvider>
@@ -132,8 +134,8 @@ describe('TrackedMain', () => {
     expect(MockConsoleImplementation.error).toHaveBeenCalledWith(
       '｢objectiv｣ Could not generate a valid id for ContentContext @ RootLocation:root / Content:content. Please provide the `id` property.'
     );
-  })    
-  
+  });
+
   it('should allow specifying a custom id', () => {
     const spyTransport = new SpyTransport();
     jest.spyOn(spyTransport, 'handle');

--- a/tracker/trackers/react/tests/TrackedMediaPlayerContext.test.tsx
+++ b/tracker/trackers/react/tests/TrackedMediaPlayerContext.test.tsx
@@ -6,7 +6,14 @@ import { MockConsoleImplementation, SpyTransport } from '@objectiv/testing-tools
 import { LocationContextName } from '@objectiv/tracker-core';
 import { fireEvent, getByText, render, screen } from '@testing-library/react';
 import React, { createRef } from 'react';
-import { ObjectivProvider, ReactTracker, TrackedMediaPlayerContext, usePressEventTracker } from '../src';
+import {
+  ObjectivProvider,
+  ReactTracker,
+  TrackedDiv,
+  TrackedMediaPlayerContext,
+  TrackedRootLocationContext,
+  usePressEventTracker
+} from '../src';
 
 require('@objectiv/developer-tools');
 globalThis.objectiv?.TrackerConsole.setImplementation(MockConsoleImplementation);
@@ -58,6 +65,83 @@ describe('TrackedMediaPlayerContext', () => {
           }),
         ]),
       })
+    );
+  });
+
+  it('should allow disabling id normalization', () => {
+    const spyTransport = new SpyTransport();
+    jest.spyOn(spyTransport, 'handle');
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: spyTransport });
+
+    const TrackedButton = ({ children }: { children: React.ReactNode }) => {
+      const trackPressEvent = usePressEventTracker();
+      return <div onClick={trackPressEvent}>{children}</div>;
+    };
+
+    const { container } = render(
+      <ObjectivProvider tracker={tracker}>
+        <TrackedMediaPlayerContext Component={'video'} id={'Video id 1'}>
+          <TrackedButton>Trigger Event 1</TrackedButton>
+        </TrackedMediaPlayerContext>
+        <TrackedMediaPlayerContext Component={'video'} id={'Video id 2'} normalizeId={false}>
+          <TrackedButton>Trigger Event 2</TrackedButton>
+        </TrackedMediaPlayerContext>
+      </ObjectivProvider>
+    );
+
+    fireEvent.click(getByText(container, /trigger event 1/i));
+    fireEvent.click(getByText(container, /trigger event 2/i));
+
+    expect(spyTransport.handle).toHaveBeenCalledTimes(3);
+    expect(spyTransport.handle).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        _type: 'ApplicationLoadedEvent',
+      })
+    );
+    expect(spyTransport.handle).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        _type: 'PressEvent',
+        location_stack: expect.arrayContaining([
+          expect.objectContaining({
+            _type: LocationContextName.MediaPlayerContext,
+            id: 'video-id-1',
+          }),
+        ]),
+      })
+    );
+    expect(spyTransport.handle).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        _type: 'PressEvent',
+        location_stack: expect.arrayContaining([
+          expect.objectContaining({
+            _type: LocationContextName.MediaPlayerContext,
+            id: 'Video id 2',
+          }),
+        ]),
+      })
+    );
+  });
+
+  it('should console.error if an id cannot be automatically generated', () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: new SpyTransport() });
+
+    render(
+      <ObjectivProvider tracker={tracker}>
+        <TrackedRootLocationContext Component={'div'} id={'root'}>
+          <TrackedDiv id={'content'}>
+            <TrackedMediaPlayerContext Component={'video'} id={'☹️'} />
+          </TrackedDiv>
+        </TrackedRootLocationContext>
+      </ObjectivProvider>
+    );
+
+    expect(MockConsoleImplementation.error).toHaveBeenCalledTimes(1);
+    expect(MockConsoleImplementation.error).toHaveBeenCalledWith(
+      '｢objectiv｣ Could not generate a valid id for MediaPlayerContext @ RootLocation:root / Content:content. Please provide the `id` property.'
     );
   });
 

--- a/tracker/trackers/react/tests/TrackedMediaPlayerContext.test.tsx
+++ b/tracker/trackers/react/tests/TrackedMediaPlayerContext.test.tsx
@@ -12,7 +12,7 @@ import {
   TrackedDiv,
   TrackedMediaPlayerContext,
   TrackedRootLocationContext,
-  usePressEventTracker
+  usePressEventTracker,
 } from '../src';
 
 require('@objectiv/developer-tools');

--- a/tracker/trackers/react/tests/TrackedNav.test.tsx
+++ b/tracker/trackers/react/tests/TrackedNav.test.tsx
@@ -12,7 +12,7 @@ import {
   TrackedDiv,
   TrackedNav,
   TrackedRootLocationContext,
-  usePressEventTracker
+  usePressEventTracker,
 } from '../src';
 
 require('@objectiv/developer-tools');
@@ -62,13 +62,13 @@ describe('TrackedNav', () => {
       })
     );
   });
-  
+
   it('should allow disabling id normalization', () => {
     const spyTransport = new SpyTransport();
     jest.spyOn(spyTransport, 'handle');
     const tracker = new ReactTracker({ applicationId: 'app-id', transport: spyTransport });
 
-    const TrackedButton = ({children}:{children: React.ReactNode}) => {
+    const TrackedButton = ({ children }: { children: React.ReactNode }) => {
       const trackPressEvent = usePressEventTracker();
       return <div onClick={trackPressEvent}>{children}</div>;
     };
@@ -90,7 +90,8 @@ describe('TrackedNav', () => {
     fireEvent.click(getByText(container, /trigger event 2/i));
 
     expect(spyTransport.handle).toHaveBeenCalledTimes(2);
-    expect(spyTransport.handle).toHaveBeenNthCalledWith(1,
+    expect(spyTransport.handle).toHaveBeenNthCalledWith(
+      1,
       expect.objectContaining({
         _type: 'PressEvent',
         location_stack: expect.arrayContaining([
@@ -101,7 +102,8 @@ describe('TrackedNav', () => {
         ]),
       })
     );
-    expect(spyTransport.handle).toHaveBeenNthCalledWith(2,
+    expect(spyTransport.handle).toHaveBeenNthCalledWith(
+      2,
       expect.objectContaining({
         _type: 'PressEvent',
         location_stack: expect.arrayContaining([
@@ -115,14 +117,14 @@ describe('TrackedNav', () => {
   });
 
   it('should console.error if an id cannot be automatically generated', () => {
-        jest.spyOn(console, 'error').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
     const tracker = new ReactTracker({ applicationId: 'app-id', transport: new SpyTransport() });
 
     render(
       <ObjectivProvider tracker={tracker}>
         <TrackedRootLocationContext Component={'div'} id={'root'}>
           <TrackedDiv id={'content'}>
-            <TrackedNav id={'☹️'}/>
+            <TrackedNav id={'☹️'} />
           </TrackedDiv>
         </TrackedRootLocationContext>
       </ObjectivProvider>
@@ -132,7 +134,7 @@ describe('TrackedNav', () => {
     expect(MockConsoleImplementation.error).toHaveBeenCalledWith(
       '｢objectiv｣ Could not generate a valid id for NavigationContext @ RootLocation:root / Content:content. Please provide the `id` property.'
     );
-  })
+  });
 
   it('should allow specifying a custom id', () => {
     const spyTransport = new SpyTransport();

--- a/tracker/trackers/react/tests/TrackedNav.test.tsx
+++ b/tracker/trackers/react/tests/TrackedNav.test.tsx
@@ -6,7 +6,14 @@ import { MockConsoleImplementation, SpyTransport } from '@objectiv/testing-tools
 import { LocationContextName } from '@objectiv/tracker-core';
 import { fireEvent, getByText, render } from '@testing-library/react';
 import React from 'react';
-import { ObjectivProvider, ReactTracker, TrackedNav, usePressEventTracker } from '../src';
+import {
+  ObjectivProvider,
+  ReactTracker,
+  TrackedDiv,
+  TrackedNav,
+  TrackedRootLocationContext,
+  usePressEventTracker
+} from '../src';
 
 require('@objectiv/developer-tools');
 globalThis.objectiv?.TrackerConsole.setImplementation(MockConsoleImplementation);
@@ -55,6 +62,78 @@ describe('TrackedNav', () => {
       })
     );
   });
+  
+  it('should allow disabling id normalization', () => {
+    const spyTransport = new SpyTransport();
+    jest.spyOn(spyTransport, 'handle');
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: spyTransport });
+
+    const TrackedButton = ({children}:{children: React.ReactNode}) => {
+      const trackPressEvent = usePressEventTracker();
+      return <div onClick={trackPressEvent}>{children}</div>;
+    };
+
+    const { container } = render(
+      <ObjectivProvider tracker={tracker}>
+        <TrackedNav id={'Nav 1'}>
+          <TrackedButton>Trigger Event 1</TrackedButton>
+        </TrackedNav>
+        <TrackedNav id={'Nav 2'} normalizeId={false}>
+          <TrackedButton>Trigger Event 2</TrackedButton>
+        </TrackedNav>
+      </ObjectivProvider>
+    );
+
+    jest.resetAllMocks();
+
+    fireEvent.click(getByText(container, /trigger event 1/i));
+    fireEvent.click(getByText(container, /trigger event 2/i));
+
+    expect(spyTransport.handle).toHaveBeenCalledTimes(2);
+    expect(spyTransport.handle).toHaveBeenNthCalledWith(1,
+      expect.objectContaining({
+        _type: 'PressEvent',
+        location_stack: expect.arrayContaining([
+          expect.objectContaining({
+            _type: LocationContextName.NavigationContext,
+            id: 'nav-1',
+          }),
+        ]),
+      })
+    );
+    expect(spyTransport.handle).toHaveBeenNthCalledWith(2,
+      expect.objectContaining({
+        _type: 'PressEvent',
+        location_stack: expect.arrayContaining([
+          expect.objectContaining({
+            _type: LocationContextName.NavigationContext,
+            id: 'Nav 2',
+          }),
+        ]),
+      })
+    );
+  });
+
+  it('should console.error if an id cannot be automatically generated', () => {
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: new SpyTransport() });
+
+    render(
+      <ObjectivProvider tracker={tracker}>
+        <TrackedRootLocationContext Component={'div'} id={'root'}>
+          <TrackedDiv id={'content'}>
+            <TrackedNav id={'☹️'}/>
+          </TrackedDiv>
+        </TrackedRootLocationContext>
+      </ObjectivProvider>
+    );
+
+    expect(MockConsoleImplementation.error).toHaveBeenCalledTimes(1);
+    expect(MockConsoleImplementation.error).toHaveBeenCalledWith(
+      '｢objectiv｣ Could not generate a valid id for ContentContext @ RootLocation:root / Content:content. Please provide the `id` property.'
+    );
+  })    
+  
 
   it('should allow specifying a custom id', () => {
     const spyTransport = new SpyTransport();

--- a/tracker/trackers/react/tests/TrackedNav.test.tsx
+++ b/tracker/trackers/react/tests/TrackedNav.test.tsx
@@ -130,10 +130,9 @@ describe('TrackedNav', () => {
 
     expect(MockConsoleImplementation.error).toHaveBeenCalledTimes(1);
     expect(MockConsoleImplementation.error).toHaveBeenCalledWith(
-      '｢objectiv｣ Could not generate a valid id for ContentContext @ RootLocation:root / Content:content. Please provide the `id` property.'
+      '｢objectiv｣ Could not generate a valid id for NavigationContext @ RootLocation:root / Content:content. Please provide the `id` property.'
     );
-  })    
-  
+  })
 
   it('should allow specifying a custom id', () => {
     const spyTransport = new SpyTransport();

--- a/tracker/trackers/react/tests/TrackedNavigationContext.test.tsx
+++ b/tracker/trackers/react/tests/TrackedNavigationContext.test.tsx
@@ -6,7 +6,13 @@ import { MockConsoleImplementation, SpyTransport } from '@objectiv/testing-tools
 import { LocationContextName } from '@objectiv/tracker-core';
 import { fireEvent, getByText, render, screen } from '@testing-library/react';
 import React, { createRef } from 'react';
-import { ObjectivProvider, ReactTracker, TrackedNavigationContext, usePressEventTracker } from '../src';
+import {
+  ObjectivProvider,
+  ReactTracker, TrackedDiv,
+  TrackedNavigationContext,
+  TrackedRootLocationContext,
+  usePressEventTracker
+} from '../src';
 
 require('@objectiv/developer-tools');
 globalThis.objectiv?.TrackerConsole.setImplementation(MockConsoleImplementation);
@@ -60,6 +66,77 @@ describe('TrackedNavigationContext', () => {
       })
     );
   });
+  
+it('should allow disabling id normalization', () => {
+    const spyTransport = new SpyTransport();
+    jest.spyOn(spyTransport, 'handle');
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: spyTransport });
+
+    const TrackedButton = ({children}:{children: React.ReactNode}) => {
+      const trackPressEvent = usePressEventTracker();
+      return <div onClick={trackPressEvent}>{children}</div>;
+    };
+
+    const { container } = render(
+      <ObjectivProvider tracker={tracker}>
+        <TrackedNavigationContext Component={'nav'} id={'Nav 1'}>
+          <TrackedButton>Trigger Event 1</TrackedButton>
+        </TrackedNavigationContext>
+        <TrackedNavigationContext Component={'nav'} id={'Nav 2'} normalizeId={false}>
+          <TrackedButton>Trigger Event 2</TrackedButton>
+        </TrackedNavigationContext>
+      </ObjectivProvider>
+    );
+
+    jest.resetAllMocks();
+
+    fireEvent.click(getByText(container, /trigger event 1/i));
+    fireEvent.click(getByText(container, /trigger event 2/i));
+
+    expect(spyTransport.handle).toHaveBeenCalledTimes(2);
+    expect(spyTransport.handle).toHaveBeenNthCalledWith(1,
+      expect.objectContaining({
+        _type: 'PressEvent',
+        location_stack: expect.arrayContaining([
+          expect.objectContaining({
+            _type: LocationContextName.NavigationContext,
+            id: 'nav-1',
+          }),
+        ]),
+      })
+    );
+    expect(spyTransport.handle).toHaveBeenNthCalledWith(2,
+      expect.objectContaining({
+        _type: 'PressEvent',
+        location_stack: expect.arrayContaining([
+          expect.objectContaining({
+            _type: LocationContextName.NavigationContext,
+            id: 'Nav 2',
+          }),
+        ]),
+      })
+    );
+  });
+
+  it('should console.error if an id cannot be automatically generated', () => {
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: new SpyTransport() });
+
+    render(
+      <ObjectivProvider tracker={tracker}>
+        <TrackedRootLocationContext Component={'div'} id={'root'}>
+          <TrackedDiv id={'content'}>
+            <TrackedNavigationContext Component={'nav'} id={'☹️'}/>
+          </TrackedDiv>
+        </TrackedRootLocationContext>
+      </ObjectivProvider>
+    );
+
+    expect(MockConsoleImplementation.error).toHaveBeenCalledTimes(1);
+    expect(MockConsoleImplementation.error).toHaveBeenCalledWith(
+      '｢objectiv｣ Could not generate a valid id for NavigationContext @ RootLocation:root / Content:content. Please provide the `id` property.'
+    );
+  })  
 
   it('should allow forwarding the id property', () => {
     const tracker = new ReactTracker({ applicationId: 'app-id', transport: new SpyTransport() });

--- a/tracker/trackers/react/tests/TrackedNavigationContext.test.tsx
+++ b/tracker/trackers/react/tests/TrackedNavigationContext.test.tsx
@@ -8,10 +8,11 @@ import { fireEvent, getByText, render, screen } from '@testing-library/react';
 import React, { createRef } from 'react';
 import {
   ObjectivProvider,
-  ReactTracker, TrackedDiv,
+  ReactTracker,
+  TrackedDiv,
   TrackedNavigationContext,
   TrackedRootLocationContext,
-  usePressEventTracker
+  usePressEventTracker,
 } from '../src';
 
 require('@objectiv/developer-tools');
@@ -66,13 +67,13 @@ describe('TrackedNavigationContext', () => {
       })
     );
   });
-  
-it('should allow disabling id normalization', () => {
+
+  it('should allow disabling id normalization', () => {
     const spyTransport = new SpyTransport();
     jest.spyOn(spyTransport, 'handle');
     const tracker = new ReactTracker({ applicationId: 'app-id', transport: spyTransport });
 
-    const TrackedButton = ({children}:{children: React.ReactNode}) => {
+    const TrackedButton = ({ children }: { children: React.ReactNode }) => {
       const trackPressEvent = usePressEventTracker();
       return <div onClick={trackPressEvent}>{children}</div>;
     };
@@ -94,7 +95,8 @@ it('should allow disabling id normalization', () => {
     fireEvent.click(getByText(container, /trigger event 2/i));
 
     expect(spyTransport.handle).toHaveBeenCalledTimes(2);
-    expect(spyTransport.handle).toHaveBeenNthCalledWith(1,
+    expect(spyTransport.handle).toHaveBeenNthCalledWith(
+      1,
       expect.objectContaining({
         _type: 'PressEvent',
         location_stack: expect.arrayContaining([
@@ -105,7 +107,8 @@ it('should allow disabling id normalization', () => {
         ]),
       })
     );
-    expect(spyTransport.handle).toHaveBeenNthCalledWith(2,
+    expect(spyTransport.handle).toHaveBeenNthCalledWith(
+      2,
       expect.objectContaining({
         _type: 'PressEvent',
         location_stack: expect.arrayContaining([
@@ -119,14 +122,14 @@ it('should allow disabling id normalization', () => {
   });
 
   it('should console.error if an id cannot be automatically generated', () => {
-        jest.spyOn(console, 'error').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
     const tracker = new ReactTracker({ applicationId: 'app-id', transport: new SpyTransport() });
 
     render(
       <ObjectivProvider tracker={tracker}>
         <TrackedRootLocationContext Component={'div'} id={'root'}>
           <TrackedDiv id={'content'}>
-            <TrackedNavigationContext Component={'nav'} id={'☹️'}/>
+            <TrackedNavigationContext Component={'nav'} id={'☹️'} />
           </TrackedDiv>
         </TrackedRootLocationContext>
       </ObjectivProvider>
@@ -136,7 +139,7 @@ it('should allow disabling id normalization', () => {
     expect(MockConsoleImplementation.error).toHaveBeenCalledWith(
       '｢objectiv｣ Could not generate a valid id for NavigationContext @ RootLocation:root / Content:content. Please provide the `id` property.'
     );
-  })  
+  });
 
   it('should allow forwarding the id property', () => {
     const tracker = new ReactTracker({ applicationId: 'app-id', transport: new SpyTransport() });

--- a/tracker/trackers/react/tests/TrackedOverlayContext.test.tsx
+++ b/tracker/trackers/react/tests/TrackedOverlayContext.test.tsx
@@ -6,7 +6,14 @@ import { MockConsoleImplementation, SpyTransport } from '@objectiv/testing-tools
 import { LocationContextName } from '@objectiv/tracker-core';
 import { fireEvent, getByText, render, screen } from '@testing-library/react';
 import React, { createRef } from 'react';
-import { ObjectivProvider, ReactTracker, TrackedOverlayContext, usePressEventTracker } from '../src';
+import {
+  ObjectivProvider,
+  ReactTracker,
+  TrackedDiv,
+  TrackedOverlayContext,
+  TrackedRootLocationContext,
+  usePressEventTracker
+} from '../src';
 
 require('@objectiv/developer-tools');
 globalThis.objectiv?.TrackerConsole.setImplementation(MockConsoleImplementation);
@@ -58,6 +65,83 @@ describe('TrackedOverlayContext', () => {
           }),
         ]),
       })
+    );
+  });
+
+  it('should allow disabling id normalization', () => {
+    const spyTransport = new SpyTransport();
+    jest.spyOn(spyTransport, 'handle');
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: spyTransport });
+
+    const TrackedButton = ({ children }: { children: React.ReactNode }) => {
+      const trackPressEvent = usePressEventTracker();
+      return <div onClick={trackPressEvent}>{children}</div>;
+    };
+
+    const { container } = render(
+      <ObjectivProvider tracker={tracker}>
+        <TrackedOverlayContext Component={'div'} id={'Modal id 1'}>
+          <TrackedButton>Trigger Event 1</TrackedButton>
+        </TrackedOverlayContext>
+        <TrackedOverlayContext Component={'div'} id={'Modal id 2'} normalizeId={false}>
+          <TrackedButton>Trigger Event 2</TrackedButton>
+        </TrackedOverlayContext>
+      </ObjectivProvider>
+    );
+
+    fireEvent.click(getByText(container, /trigger event 1/i));
+    fireEvent.click(getByText(container, /trigger event 2/i));
+
+    expect(spyTransport.handle).toHaveBeenCalledTimes(3);
+    expect(spyTransport.handle).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        _type: 'ApplicationLoadedEvent',
+      })
+    );
+    expect(spyTransport.handle).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        _type: 'PressEvent',
+        location_stack: expect.arrayContaining([
+          expect.objectContaining({
+            _type: LocationContextName.OverlayContext,
+            id: 'modal-id-1',
+          }),
+        ]),
+      })
+    );
+    expect(spyTransport.handle).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        _type: 'PressEvent',
+        location_stack: expect.arrayContaining([
+          expect.objectContaining({
+            _type: LocationContextName.OverlayContext,
+            id: 'Modal id 2',
+          }),
+        ]),
+      })
+    );
+  })
+
+  it('should console.error if an id cannot be automatically generated', () => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: new SpyTransport() });
+
+    render(
+      <ObjectivProvider tracker={tracker}>
+        <TrackedRootLocationContext Component={'div'} id={'root'}>
+          <TrackedDiv id={'content'}>
+            <TrackedOverlayContext Component={'div'} id={'☹️'} />
+          </TrackedDiv>
+        </TrackedRootLocationContext>
+      </ObjectivProvider>
+    );
+
+    expect(MockConsoleImplementation.error).toHaveBeenCalledTimes(1);
+    expect(MockConsoleImplementation.error).toHaveBeenCalledWith(
+      '｢objectiv｣ Could not generate a valid id for OverlayContext @ RootLocation:root / Content:content. Please provide the `id` property.'
     );
   });
 

--- a/tracker/trackers/react/tests/TrackedOverlayContext.test.tsx
+++ b/tracker/trackers/react/tests/TrackedOverlayContext.test.tsx
@@ -12,7 +12,7 @@ import {
   TrackedDiv,
   TrackedOverlayContext,
   TrackedRootLocationContext,
-  usePressEventTracker
+  usePressEventTracker,
 } from '../src';
 
 require('@objectiv/developer-tools');
@@ -123,7 +123,7 @@ describe('TrackedOverlayContext', () => {
         ]),
       })
     );
-  })
+  });
 
   it('should console.error if an id cannot be automatically generated', () => {
     jest.spyOn(console, 'error').mockImplementation(() => {});

--- a/tracker/trackers/react/tests/TrackedPressableContext.test.tsx
+++ b/tracker/trackers/react/tests/TrackedPressableContext.test.tsx
@@ -113,7 +113,7 @@ describe('TrackedPressableContext', () => {
         ]),
       })
     );
-  })
+  });
 
   it('should allow forwarding the id property', () => {
     const tracker = new ReactTracker({ applicationId: 'app-id', transport: new SpyTransport() });

--- a/tracker/trackers/react/tests/TrackedPressableContext.test.tsx
+++ b/tracker/trackers/react/tests/TrackedPressableContext.test.tsx
@@ -63,6 +63,58 @@ describe('TrackedPressableContext', () => {
     );
   });
 
+  it('should allow disabling id normalization', () => {
+    const spyTransport = new SpyTransport();
+    jest.spyOn(spyTransport, 'handle');
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: spyTransport });
+
+    const { container } = render(
+      <ObjectivProvider tracker={tracker}>
+        <TrackedPressableContext Component={'button'} id={'Pressable id 1'}>
+          Trigger Event 1
+        </TrackedPressableContext>
+        <TrackedPressableContext Component={'button'} id={'Pressable id 2'} normalizeId={false}>
+          Trigger Event 2
+        </TrackedPressableContext>
+      </ObjectivProvider>
+    );
+
+    fireEvent.click(getByText(container, /trigger event 1/i));
+    fireEvent.click(getByText(container, /trigger event 2/i));
+
+    expect(spyTransport.handle).toHaveBeenCalledTimes(3);
+    expect(spyTransport.handle).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        _type: 'ApplicationLoadedEvent',
+      })
+    );
+    expect(spyTransport.handle).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        _type: 'PressEvent',
+        location_stack: expect.arrayContaining([
+          expect.objectContaining({
+            _type: LocationContextName.PressableContext,
+            id: 'pressable-id-1',
+          }),
+        ]),
+      })
+    );
+    expect(spyTransport.handle).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({
+        _type: 'PressEvent',
+        location_stack: expect.arrayContaining([
+          expect.objectContaining({
+            _type: LocationContextName.PressableContext,
+            id: 'Pressable id 2',
+          }),
+        ]),
+      })
+    );
+  })
+
   it('should allow forwarding the id property', () => {
     const tracker = new ReactTracker({ applicationId: 'app-id', transport: new SpyTransport() });
 

--- a/tracker/trackers/react/tests/TrackedRootLocationContext.test.tsx
+++ b/tracker/trackers/react/tests/TrackedRootLocationContext.test.tsx
@@ -116,7 +116,7 @@ describe('TrackedRootLocationContext', () => {
         ]),
       })
     );
-  })
+  });
 
   it('should console.error if an id cannot be automatically generated', () => {
     jest.spyOn(console, 'error').mockImplementation(() => {});

--- a/tracker/trackers/react/tests/TrackedSection.test.tsx
+++ b/tracker/trackers/react/tests/TrackedSection.test.tsx
@@ -12,7 +12,7 @@ import {
   TrackedDiv,
   TrackedRootLocationContext,
   TrackedSection,
-  usePressEventTracker
+  usePressEventTracker,
 } from '../src';
 
 require('@objectiv/developer-tools');
@@ -62,13 +62,13 @@ describe('TrackedSection', () => {
       })
     );
   });
-  
+
   it('should allow disabling id normalization', () => {
     const spyTransport = new SpyTransport();
     jest.spyOn(spyTransport, 'handle');
     const tracker = new ReactTracker({ applicationId: 'app-id', transport: spyTransport });
 
-    const TrackedButton = ({children}:{children: React.ReactNode}) => {
+    const TrackedButton = ({ children }: { children: React.ReactNode }) => {
       const trackPressEvent = usePressEventTracker();
       return <div onClick={trackPressEvent}>{children}</div>;
     };
@@ -90,7 +90,8 @@ describe('TrackedSection', () => {
     fireEvent.click(getByText(container, /trigger event 2/i));
 
     expect(spyTransport.handle).toHaveBeenCalledTimes(2);
-    expect(spyTransport.handle).toHaveBeenNthCalledWith(1,
+    expect(spyTransport.handle).toHaveBeenNthCalledWith(
+      1,
       expect.objectContaining({
         _type: 'PressEvent',
         location_stack: expect.arrayContaining([
@@ -101,7 +102,8 @@ describe('TrackedSection', () => {
         ]),
       })
     );
-    expect(spyTransport.handle).toHaveBeenNthCalledWith(2,
+    expect(spyTransport.handle).toHaveBeenNthCalledWith(
+      2,
       expect.objectContaining({
         _type: 'PressEvent',
         location_stack: expect.arrayContaining([
@@ -115,14 +117,14 @@ describe('TrackedSection', () => {
   });
 
   it('should console.error if an id cannot be automatically generated', () => {
-        jest.spyOn(console, 'error').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
     const tracker = new ReactTracker({ applicationId: 'app-id', transport: new SpyTransport() });
 
     render(
       <ObjectivProvider tracker={tracker}>
         <TrackedRootLocationContext Component={'div'} id={'root'}>
           <TrackedDiv id={'content'}>
-            <TrackedSection id={'☹️'}/>
+            <TrackedSection id={'☹️'} />
           </TrackedDiv>
         </TrackedRootLocationContext>
       </ObjectivProvider>
@@ -132,5 +134,5 @@ describe('TrackedSection', () => {
     expect(MockConsoleImplementation.error).toHaveBeenCalledWith(
       '｢objectiv｣ Could not generate a valid id for ContentContext @ RootLocation:root / Content:content. Please provide the `id` property.'
     );
-  })     
+  });
 });

--- a/tracker/trackers/react/tests/TrackedSection.test.tsx
+++ b/tracker/trackers/react/tests/TrackedSection.test.tsx
@@ -6,7 +6,14 @@ import { MockConsoleImplementation, SpyTransport } from '@objectiv/testing-tools
 import { LocationContextName } from '@objectiv/tracker-core';
 import { fireEvent, getByText, render } from '@testing-library/react';
 import React from 'react';
-import { ObjectivProvider, ReactTracker, TrackedSection, usePressEventTracker } from '../src';
+import {
+  ObjectivProvider,
+  ReactTracker,
+  TrackedDiv,
+  TrackedRootLocationContext,
+  TrackedSection,
+  usePressEventTracker
+} from '../src';
 
 require('@objectiv/developer-tools');
 globalThis.objectiv?.TrackerConsole.setImplementation(MockConsoleImplementation);
@@ -55,4 +62,75 @@ describe('TrackedSection', () => {
       })
     );
   });
+  
+  it('should allow disabling id normalization', () => {
+    const spyTransport = new SpyTransport();
+    jest.spyOn(spyTransport, 'handle');
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: spyTransport });
+
+    const TrackedButton = ({children}:{children: React.ReactNode}) => {
+      const trackPressEvent = usePressEventTracker();
+      return <div onClick={trackPressEvent}>{children}</div>;
+    };
+
+    const { container } = render(
+      <ObjectivProvider tracker={tracker}>
+        <TrackedSection id={'Section 1'}>
+          <TrackedButton>Trigger Event 1</TrackedButton>
+        </TrackedSection>
+        <TrackedSection id={'Section 2'} normalizeId={false}>
+          <TrackedButton>Trigger Event 2</TrackedButton>
+        </TrackedSection>
+      </ObjectivProvider>
+    );
+
+    jest.resetAllMocks();
+
+    fireEvent.click(getByText(container, /trigger event 1/i));
+    fireEvent.click(getByText(container, /trigger event 2/i));
+
+    expect(spyTransport.handle).toHaveBeenCalledTimes(2);
+    expect(spyTransport.handle).toHaveBeenNthCalledWith(1,
+      expect.objectContaining({
+        _type: 'PressEvent',
+        location_stack: expect.arrayContaining([
+          expect.objectContaining({
+            _type: LocationContextName.ContentContext,
+            id: 'section-1',
+          }),
+        ]),
+      })
+    );
+    expect(spyTransport.handle).toHaveBeenNthCalledWith(2,
+      expect.objectContaining({
+        _type: 'PressEvent',
+        location_stack: expect.arrayContaining([
+          expect.objectContaining({
+            _type: LocationContextName.ContentContext,
+            id: 'Section 2',
+          }),
+        ]),
+      })
+    );
+  });
+
+  it('should console.error if an id cannot be automatically generated', () => {
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+    const tracker = new ReactTracker({ applicationId: 'app-id', transport: new SpyTransport() });
+
+    render(
+      <ObjectivProvider tracker={tracker}>
+        <TrackedRootLocationContext Component={'div'} id={'root'}>
+          <TrackedDiv id={'content'}>
+            <TrackedSection id={'☹️'}/>
+          </TrackedDiv>
+        </TrackedRootLocationContext>
+      </ObjectivProvider>
+    );
+
+    expect(MockConsoleImplementation.error).toHaveBeenCalledTimes(1);
+    expect(MockConsoleImplementation.error).toHaveBeenCalledWith(
+      '｢objectiv｣ Could not generate a valid id for ContentContext @ RootLocation:root / Content:content. Please provide the `id` property.'
+    );
+  })     
 });

--- a/tracker/trackers/react/tests/makeIdFromTrackedAnchorProps.test.ts
+++ b/tracker/trackers/react/tests/makeIdFromTrackedAnchorProps.test.ts
@@ -8,13 +8,17 @@ describe('makeIdFromTrackedAnchorProps', () => {
   const testCases: [input: {}, output: string | null][] = [
     [{}, null],
     [{ id: 'test' }, 'test'],
-    [{ id: 'Click Me' }, 'Click Me'],
-    [{ objectiv: { contextId: 'test' } }, 'test'],
-    [{ objectiv: { contextId: 'Click Me' } }, 'Click Me'],
+    [{ id: 'Click Me' }, 'click-me'],
+    [{ id: 'Click Me', normalizeId: false }, 'Click Me'],
+    [{ contextId: 'test' }, 'test'],
+    [{ contextId: 'Click Me' }, 'click-me'],
+    [{ contextId: 'Click Me', normalizeId: false }, 'Click Me'],
     [{ title: 'test' }, 'test'],
     [{ title: 'Click Me' }, 'click-me'],
+    [{ title: 'Click Me', normalizeId: false }, 'Click Me'],
     [{ children: 'test' }, 'test'],
     [{ children: 'Click Me' }, 'click-me'],
+    [{ children: 'Click Me', normalizeId: false }, 'Click Me'],
   ];
 
   testCases.forEach(([input, output]) =>

--- a/tracker/trackers/react/tests/makeIdFromTrackedAnchorProps.test.ts
+++ b/tracker/trackers/react/tests/makeIdFromTrackedAnchorProps.test.ts
@@ -8,9 +8,9 @@ describe('makeIdFromTrackedAnchorProps', () => {
   const testCases: [input: {}, output: string | null][] = [
     [{}, null],
     [{ id: 'test' }, 'test'],
-    [{ id: 'Click Me' }, 'click-me'],
+    [{ id: 'Click Me' }, 'Click Me'],
     [{ objectiv: { contextId: 'test' } }, 'test'],
-    [{ objectiv: { contextId: 'Click Me' } }, 'click-me'],
+    [{ objectiv: { contextId: 'Click Me' } }, 'Click Me'],
     [{ title: 'test' }, 'test'],
     [{ title: 'Click Me' }, 'click-me'],
     [{ children: 'test' }, 'test'],


### PR DESCRIPTION
Some components, like TrackedLinkContext or TrackedButton, gather text from their children or title properties and normalize it to an identifier used for the corresponding context id property. 

This behavior until now was completely automatic and not configurable. In this PR we solve two issues:
1. We make id normalization configurable. Every Component has now a `normalizeId` option to disable normalization if needed. This can be useful when manually mapping identifiers across different applications, where interactions may have different copy for the same logical buttons.
2. We fix an inconsistency with anchors and links. These were the only components performing normalization in a different way than all the other components. 

Documentation update: https://github.com/objectiv/objectiv.io/pull/444

---

**Examples**
```
<TrackedOverlayContext Component={'div'} id={'Modal id 1'}>
```
Will produce an OverlayContext with identifier 'modal-id-1'. While the following:
```
<TrackedOverlayContext Component={'div'} id={'Modal id 2'} normalizeId={false}>
```
Will produce an OverlayContext with identifier 'Modal id 2'.

The same applies to Components that infer their ID from their children:
```
<TrackedAnchor href={'/some-url'}>Trigger Event 1</TrackedAnchor>
```
Will produce a LinkContext with identifier 'trigger-event-1'. While the following:

```
<TrackedAnchor href={'/some-url'} normalizeId={false}>Trigger Event 2</TrackedAnchor>
```

Will produce a LinkContext with identifier 'Trigger Event 2'.
