### PR TITLE
Add required contexts to AbstractLocationContext

### DIFF
--- a/schema/base_schema.json5
+++ b/schema/base_schema.json5
@@ -246,7 +246,8 @@
     },
     "AbstractLocationContext": {
       "description": "AbstractLocationContext are the abstract parents of all Location Contexts. Location Contexts are meant to describe where an event originated from in the visual UI.",
-      "parents": ["AbstractContext"]
+      "parents": ["AbstractContext"],
+      "requiresContext": ["RootLocationContext", "PathContext"]
     },
     "InputContext": {
       "description": "A Location Context that describes an element that accepts user input, i.e. a form field.",


### PR DESCRIPTION
Add required contexts to AbstractLocationContext. This will enforce a  RootLocationContext and PathContext be present, when at least 1 instance of AbstractLocationContext is present. Additionally, as an InteractiveEvent requires an AbstractLocationContext, this will make sure all InteractiveEvents will have a RootLocationContext and a PathContext.

This depends on https://github.com/objectiv/objectiv-analytics/pull/824 for validation to work properly