### PR TITLE
Add `dependabot[bot]` to CLA workflow allowlist

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -27,7 +27,7 @@ jobs:
           path-to-signatures: 'signatures/cla_signatures.json'
           path-to-document: 'https://objectiv.io/cla/'
           branch: 'main'
-          allowlist: dependabot,jansenbob,hendrik-obj,ivarpruijn,KathiaBarahona,borft,afroald,sdirosa,thijs-obj,jansentom,vard-obj,vincenthoogsteder
+          allowlist: dependabot,dependabot[bot],jansenbob,hendrik-obj,ivarpruijn,KathiaBarahona,borft,afroald,sdirosa,thijs-obj,jansentom,vard-obj,vincenthoogsteder
           lock-pullrequest-aftermerge: true
           signed-commit-message: '$contributorName has signed the CLA in #$pullRequestNo'
           custom-allsigned-prcomment: 'All contributors have signed the CLA.'


### PR DESCRIPTION
The [CLA bot is blocking the dependabot](https://github.com/objectiv/objectiv-analytics/pull/827).

The fix seems to be [to add it to the allowlist as `dependabot[bot]`](https://github.com/contributor-assistant/github-action/issues/34).