### PR TITLE
[Bach]: `NULLS LAST` by default in Order By Clause

### DIFF
--- a/bach/bach/dataframe.py
+++ b/bach/bach/dataframe.py
@@ -1988,7 +1988,8 @@ class DataFrame:
             fmtstr = []
 
             for sc in self._order_by:
-                fmt = f"{{}} {'asc' if sc.asc else 'desc'}"
+                # pandas sorts by default all nulls last
+                fmt = f"{{}} {'asc' if sc.asc else 'desc'} nulls last"
                 if not sc.expression.has_multi_level_expressions:
                     exprs.append(sc.expression)
                     fmtstr.append(fmt)

--- a/bach/tests/functional/bach/test_cut.py
+++ b/bach/tests/functional/bach/test_cut.py
@@ -3,7 +3,7 @@ import pandas as pd
 
 from bach import Series, DataFrame
 from bach.operations.cut import CutOperation, QCutOperation
-from sql_models.util import quote_identifier, is_bigquery
+from sql_models.util import quote_identifier
 from tests.functional.bach.test_data_and_utils import assert_equals_data
 
 PD_TESTING_SETTINGS = {
@@ -122,16 +122,9 @@ def test_cut_w_include_empty_bins(engine) -> None:
         pd.Interval(5.667, 8),
         pd.Interval(5.667, 8),
         pd.Interval(5.667, 8),
+        empty_interval,
     ]
-    expected_index = [1., 1., 2., 3., 6., 7., 8.]
-
-    if is_bigquery(engine):
-        # TODO: Remove this, None value should be last after sorting
-        expected_data = [empty_interval] + expected_data
-        expected_index = [np.nan] + expected_index
-    else:
-        expected_data.append(empty_interval)
-        expected_index.append(np.nan)
+    expected_index = [1., 1., 2., 3., 6., 7., 8., np.nan]
     expected = pd.Series(data=expected_data, index=expected_index)
     compare_boundaries(expected, result)
 

--- a/bach/tests/functional/bach/test_df_fillna.py
+++ b/bach/tests/functional/bach/test_df_fillna.py
@@ -50,49 +50,6 @@ def test_basic_fillna(engine) -> None:
     )
 
 
-def test_fillna_w_methods(pg_engine) -> None:
-    engine = pg_engine  # TODO: BigQuery
-    pdf = pd.DataFrame(DATA, columns=list("ABCDEFG"))
-    df = DataFrame.from_pandas(engine=engine, df=pdf, convert_objects=True)
-
-    result_ffill = df.fillna(
-        method='ffill', sort_by=['A', 'B', 'C'], ascending=[False, True, False],
-    )
-    result_ffill = result_ffill.sort_values(['A', 'B', 'C'], ascending=[False, True, False])
-    assert_equals_data(
-        result_ffill,
-        expected_columns=['_index_0', 'A', 'B', 'C', 'D', 'E', 'F', 'G'],
-        expected_data=[
-            [3, None, 2, None, 0,  None, 'c',  None],
-            [2, None, 3, None, 4,  None, 'b',  None],
-            [0, None, 3, None, 4,  None, 'a',  datetime(2022, 1, 1)],
-            [4, None, 3, None, 4,  2,    'a',  datetime(2022, 1, 1)],
-            [6, None, 3, None, 4,  3,    'e',  datetime(2022, 1, 6)],
-            [7, None, 3, 1,    4,  3,    'f',  datetime(2022, 1, 6)],
-            [1, 3,    4, 1,    1,  1,    'f',  datetime(2022, 1, 2)],
-            [5, 1,    4, 1,    1,  1,    'd',  datetime(2022, 1, 5)],
-        ],
-    )
-
-    result_bfill = df.fillna(
-        method='bfill', sort_by=['A', 'B', 'C'], ascending=[False, True, False],
-    )
-    assert_equals_data(
-        result_bfill,
-        expected_columns=['_index_0', 'A', 'B', 'C', 'D', 'E', 'F', 'G'],
-        expected_data=[
-            [3, 3, 2,    1,    0,    3,    'c', datetime(2022, 1, 6)],
-            [2, 3, 3,    1,    4,    3,    'b', datetime(2022, 1, 6)],
-            [1, 3, 4,    None, 1,    1,    'd', datetime(2022, 1, 2)],
-            [6, 3, 4,    1,    1,    3,    'e', datetime(2022, 1, 6)],
-            [0, 3, 4,    1,    1,    2,    'a', datetime(2022, 1, 1)],
-            [7, 3, 4,    1,    1,    1,    'f', datetime(2022, 1, 2)],
-            [4, 3, 4,    1,    1,    2,    'f', datetime(2022, 1, 2)],
-            [5, 1, None, None, None, None, 'd', datetime(2022, 1, 5)],
-        ],
-    )
-
-
 def test_fillna_w_methods_w_sorted_df(pg_engine) -> None:
     engine = pg_engine  # TODO: BigQuery
 

--- a/bach/tests/functional/bach/test_df_merge.py
+++ b/bach/tests/functional/bach/test_df_merge.py
@@ -8,7 +8,6 @@ import pytest
 
 from bach import DataFrame
 
-from sql_models.util import is_bigquery
 from tests.functional.bach.test_data_and_utils import (
     get_df_with_test_data, get_df_with_food_data,
     assert_equals_data, get_df_with_railway_data,
@@ -346,14 +345,9 @@ def test_merge_outer_join(engine):
         [2, 6, 2, 'Snits', 'Sneek', 2],
         [2, 7, 2, 'Snits', 'Sneek Noord', 2],
         [3, None, 3, 'Drylts', None, None],
+        [None, 4, None, None, 'Leeuwarden', 4]
     ]
 
-    # bigquery by default when sorting returns nulls first
-    # todo: support nulls first in sort_values and sort_index
-    if is_bigquery(engine):
-        expected_data = [[None, 4, None, None, 'Leeuwarden', 4]] + expected_data
-    else:
-        expected_data.append([None, 4, None, None, 'Leeuwarden', 4])
     assert_equals_data(
         result,
         expected_columns=[

--- a/bach/tests/functional/bach/test_df_sort_values.py
+++ b/bach/tests/functional/bach/test_df_sort_values.py
@@ -98,12 +98,8 @@ def test_sort_values_parameters(engine):
 
 
 @pytest.mark.parametrize(
-    "ascending",  [
-        *[list(perm) for perm in itertools.permutations([True, False, False])],
-        *[list(perm) for perm in itertools.permutations([True, True, False])],
-        [True, True, True],
-        [False, False, False],
-    ]
+    "ascending",  # generate all eight possible combinations of True/False for three parameters
+    [list(asc) for asc in itertools.product((True, False), (True, False), (True, False))]
 )
 def test_sorting_df_against_pandas(dataframes_sort, ascending) -> None:
     pdf, df = dataframes_sort

--- a/bach/tests/functional/bach/test_df_sort_values.py
+++ b/bach/tests/functional/bach/test_df_sort_values.py
@@ -1,7 +1,35 @@
 """
 Copyright 2021 Objectiv B.V.
 """
+import itertools
+from typing import Tuple
+
+import pandas as pd
+import pytest
+
+from bach import DataFrame
 from tests.functional.bach.test_data_and_utils import assert_equals_data, df_to_list, get_df_with_test_data
+
+
+@pytest.fixture
+def dataframes_sort(engine) -> Tuple[pd.DataFrame, DataFrame]:
+    pdf = pd.DataFrame(
+        [
+            [None, 1,        2],
+            [None, None,     3],
+            [None, 4,     None],
+            [1,    4,        5],
+            [None, None,  None],
+            [None, 2,        3],
+            [1,    None,  None],
+            [1,    None,     2],
+            [1,       2,  None],
+        ],
+        columns=['A', 'B', 'C']
+    )
+    df = DataFrame.from_pandas(engine, pdf, convert_objects=True).reset_index(drop=True)
+
+    return pdf, df
 
 
 def test_sort_values_basic(engine):
@@ -67,3 +95,19 @@ def test_sort_values_parameters(engine):
                               'founding'],
             expected_data=df_to_list(bt.to_pandas().sort_values(**kwargs))
         )
+
+
+@pytest.mark.parametrize(
+    "ascending",  [
+        *[list(perm) for perm in itertools.permutations([True, False, False])],
+        *[list(perm) for perm in itertools.permutations([True, True, False])],
+        [True, True, True],
+        [False, False, False],
+    ]
+)
+def test_sorting_df_against_pandas(dataframes_sort, ascending) -> None:
+    pdf, df = dataframes_sort
+    sort_by = ['A', 'B', 'C']
+    expected = pdf.sort_values(by=sort_by, ascending=ascending).reset_index(drop=True)
+    result = df.sort_values(by=sort_by, ascending=ascending).to_pandas()
+    pd.testing.assert_frame_equal(expected, result)

--- a/bach/tests/unit/bach/test_df_sort_values.py
+++ b/bach/tests/unit/bach/test_df_sort_values.py
@@ -1,54 +1,113 @@
 """
-Copyright 2022 Objectiv B.V.
+Copyright 2021 Objectiv B.V.
 """
+import itertools
+from typing import Tuple
+
+import pandas as pd
 import pytest
 
-from sql_models.util import is_postgres, is_bigquery
-from tests.unit.bach.util import get_fake_df_test_data
+from bach import DataFrame
+from tests.functional.bach.test_data_and_utils import assert_equals_data, df_to_list, get_df_with_test_data
 
 
-def test_sort_values_wrong_parameters(dialect):
-    bt = get_fake_df_test_data(dialect)
-    with pytest.raises(KeyError):
-        bt.sort_values('cityX')
-    with pytest.raises(KeyError):
-        bt.sort_values(['municipalityX', 'city'])
-    with pytest.raises(TypeError):
-        bt.sort_values({'municipality': False})
-    with pytest.raises(ValueError):
-        bt.sort_values(['municipality'], [False, True, True])
-    with pytest.raises(ValueError):
-        bt.sort_values(['municipality', 'city'], [False])
+@pytest.fixture
+def dataframes_sort(engine) -> Tuple[pd.DataFrame, DataFrame]:
+    pdf = pd.DataFrame(
+        [
+            [None, 1,        2],
+            [None, None,     3],
+            [None, 4,     None],
+            [1,    4,        5],
+            [None, None,  None],
+            [None, 2,        3],
+            [1,    None,  None],
+            [1,    None,     2],
+            [1,       2,  None],
+        ],
+        columns=['A', 'B', 'C']
+    )
+    df = DataFrame.from_pandas(engine, pdf, convert_objects=True).reset_index(drop=True)
+
+    return pdf, df
 
 
-def test_generated_sql_order_last_select(dialect):
-    # An earlier version of our code did include 'order by' statements, but not in the final select statement
-    # This is not correct, but will often work and give a false sense of correctness.
-    # The order by statement should be present in the final sql select. We test this by checking the last X
-    # characters, this is a bit fragile but works okayish.
-    bt = get_fake_df_test_data(dialect)
-    sql_not_sorted = bt.view_sql()
-    bt_sorted = bt.sort_values(by='city')
-    sql_sorted = bt_sorted.view_sql()
-
-    if is_postgres(dialect):
-        expected_order_str = 'order by "city" asc'
-    elif is_bigquery(dialect):
-        expected_order_str = 'order by `city` asc'
-    else:
-        raise Exception(f'Need to expand test to support {dialect}')
-
-    assert 'order by' not in sql_not_sorted[-60:]
-    assert expected_order_str in sql_sorted[-60:]
+def test_sort_values_basic(engine):
+    bt = get_df_with_test_data(engine)[['city']]
+    bt = bt.sort_values('city')
+    assert_equals_data(
+        bt,
+        expected_columns=['_index_skating_order', 'city'],
+        expected_data=[
+            [3, 'Drylts'],
+            [1, 'Ljouwert'],
+            [2, 'Snits'],
+        ]
+    )
 
 
-def test_generated_sql_no_duplicate_sorting(dialect):
-    # calling sort_values multiple times shouldn't result in multiple select statements being generated as
-    # later sort statements cancel out earlier sort statements
-    bt = get_fake_df_test_data(dialect)
-    bt = bt.sort_values(by='city')
-    first_sql = bt.view_sql()
-    bt = bt.sort_values(by='municipality')
-    bt = bt.sort_values(by='city')
-    final_sql = bt.view_sql()
-    assert first_sql == final_sql
+def test_sort_values_expression(pg_engine):
+    # TODO: BigQuery
+    bt = get_df_with_test_data(pg_engine)[['city', 'inhabitants']]
+    bt['city'] = bt['city'].str[2:]
+    bt = bt.sort_values('city')
+    assert_equals_data(
+        bt,
+        expected_columns=['_index_skating_order', 'city', 'inhabitants'],
+        expected_data=[
+            [2, 'its', 33520],
+            [1, 'ouwert', 93485],
+            [3, 'ylts', 3055],
+        ]
+    )
+
+
+def test_sort_values_non_existing_column(engine):
+    # Sort by an expression that is not in the DataFrame anymore
+    bt = get_df_with_test_data(engine)[['city', 'inhabitants']]
+    bt['city'] = bt['city'].str[2:]
+    bt['City_Copy'] = bt['city']
+    bt = bt.sort_values('City_Copy')
+    bt = bt[['inhabitants']]
+    assert_equals_data(
+        bt,
+        expected_columns=['_index_skating_order', 'inhabitants'],
+        expected_data=[
+            [2, 33520],
+            [1, 93485],
+            [3, 3055],
+        ]
+    )
+
+
+def test_sort_values_parameters(engine):
+    # call sort_values with different parameters, and compare with pandas output
+    bt = get_df_with_test_data(engine, full_data_set=True)
+    kwargs_list = [{'by': 'city'},
+                   {'by': ['municipality', 'city']},
+                   {'by': ['municipality', 'city'], 'ascending': False},
+                   {'by': ['municipality', 'city'], 'ascending': [False, True]},
+                   ]
+    for kwargs in kwargs_list:
+        assert_equals_data(
+            bt.sort_values(**kwargs),
+            expected_columns=['_index_skating_order', 'skating_order', 'city', 'municipality', 'inhabitants',
+                              'founding'],
+            expected_data=df_to_list(bt.to_pandas().sort_values(**kwargs))
+        )
+
+
+@pytest.mark.parametrize(
+    "ascending",  [
+        *[list(perm) for perm in itertools.permutations([True, False, False])],
+        *[list(perm) for perm in itertools.permutations([True, True, False])],
+        [True, True, True],
+        [False, False, False],
+    ]
+)
+def test_sorting_df_against_pandas(dataframes_sort, ascending) -> None:
+    pdf, df = dataframes_sort
+    sort_by = ['A', 'B', 'C']
+    expected = pdf.sort_values(by=sort_by, ascending=ascending).reset_index(drop=True)
+    result = df.sort_values(by=sort_by, ascending=ascending).to_pandas()
+    pd.testing.assert_frame_equal(expected, result)

--- a/bach/tests/unit/bach/test_df_sort_values.py
+++ b/bach/tests/unit/bach/test_df_sort_values.py
@@ -1,113 +1,54 @@
 """
-Copyright 2021 Objectiv B.V.
+Copyright 2022 Objectiv B.V.
 """
-import itertools
-from typing import Tuple
-
-import pandas as pd
 import pytest
 
-from bach import DataFrame
-from tests.functional.bach.test_data_and_utils import assert_equals_data, df_to_list, get_df_with_test_data
+from sql_models.util import is_postgres, is_bigquery
+from tests.unit.bach.util import get_fake_df_test_data
 
 
-@pytest.fixture
-def dataframes_sort(engine) -> Tuple[pd.DataFrame, DataFrame]:
-    pdf = pd.DataFrame(
-        [
-            [None, 1,        2],
-            [None, None,     3],
-            [None, 4,     None],
-            [1,    4,        5],
-            [None, None,  None],
-            [None, 2,        3],
-            [1,    None,  None],
-            [1,    None,     2],
-            [1,       2,  None],
-        ],
-        columns=['A', 'B', 'C']
-    )
-    df = DataFrame.from_pandas(engine, pdf, convert_objects=True).reset_index(drop=True)
-
-    return pdf, df
+def test_sort_values_wrong_parameters(dialect):
+    bt = get_fake_df_test_data(dialect)
+    with pytest.raises(KeyError):
+        bt.sort_values('cityX')
+    with pytest.raises(KeyError):
+        bt.sort_values(['municipalityX', 'city'])
+    with pytest.raises(TypeError):
+        bt.sort_values({'municipality': False})
+    with pytest.raises(ValueError):
+        bt.sort_values(['municipality'], [False, True, True])
+    with pytest.raises(ValueError):
+        bt.sort_values(['municipality', 'city'], [False])
 
 
-def test_sort_values_basic(engine):
-    bt = get_df_with_test_data(engine)[['city']]
-    bt = bt.sort_values('city')
-    assert_equals_data(
-        bt,
-        expected_columns=['_index_skating_order', 'city'],
-        expected_data=[
-            [3, 'Drylts'],
-            [1, 'Ljouwert'],
-            [2, 'Snits'],
-        ]
-    )
+def test_generated_sql_order_last_select(dialect):
+    # An earlier version of our code did include 'order by' statements, but not in the final select statement
+    # This is not correct, but will often work and give a false sense of correctness.
+    # The order by statement should be present in the final sql select. We test this by checking the last X
+    # characters, this is a bit fragile but works okayish.
+    bt = get_fake_df_test_data(dialect)
+    sql_not_sorted = bt.view_sql()
+    bt_sorted = bt.sort_values(by='city')
+    sql_sorted = bt_sorted.view_sql()
+
+    if is_postgres(dialect):
+        expected_order_str = 'order by "city" asc'
+    elif is_bigquery(dialect):
+        expected_order_str = 'order by `city` asc'
+    else:
+        raise Exception(f'Need to expand test to support {dialect}')
+
+    assert 'order by' not in sql_not_sorted[-60:]
+    assert expected_order_str in sql_sorted[-60:]
 
 
-def test_sort_values_expression(pg_engine):
-    # TODO: BigQuery
-    bt = get_df_with_test_data(pg_engine)[['city', 'inhabitants']]
-    bt['city'] = bt['city'].str[2:]
-    bt = bt.sort_values('city')
-    assert_equals_data(
-        bt,
-        expected_columns=['_index_skating_order', 'city', 'inhabitants'],
-        expected_data=[
-            [2, 'its', 33520],
-            [1, 'ouwert', 93485],
-            [3, 'ylts', 3055],
-        ]
-    )
-
-
-def test_sort_values_non_existing_column(engine):
-    # Sort by an expression that is not in the DataFrame anymore
-    bt = get_df_with_test_data(engine)[['city', 'inhabitants']]
-    bt['city'] = bt['city'].str[2:]
-    bt['City_Copy'] = bt['city']
-    bt = bt.sort_values('City_Copy')
-    bt = bt[['inhabitants']]
-    assert_equals_data(
-        bt,
-        expected_columns=['_index_skating_order', 'inhabitants'],
-        expected_data=[
-            [2, 33520],
-            [1, 93485],
-            [3, 3055],
-        ]
-    )
-
-
-def test_sort_values_parameters(engine):
-    # call sort_values with different parameters, and compare with pandas output
-    bt = get_df_with_test_data(engine, full_data_set=True)
-    kwargs_list = [{'by': 'city'},
-                   {'by': ['municipality', 'city']},
-                   {'by': ['municipality', 'city'], 'ascending': False},
-                   {'by': ['municipality', 'city'], 'ascending': [False, True]},
-                   ]
-    for kwargs in kwargs_list:
-        assert_equals_data(
-            bt.sort_values(**kwargs),
-            expected_columns=['_index_skating_order', 'skating_order', 'city', 'municipality', 'inhabitants',
-                              'founding'],
-            expected_data=df_to_list(bt.to_pandas().sort_values(**kwargs))
-        )
-
-
-@pytest.mark.parametrize(
-    "ascending",  [
-        *[list(perm) for perm in itertools.permutations([True, False, False])],
-        *[list(perm) for perm in itertools.permutations([True, True, False])],
-        [True, True, True],
-        [False, False, False],
-    ]
-)
-def test_sorting_df_against_pandas(dataframes_sort, ascending) -> None:
-    pdf, df = dataframes_sort
-    sort_by = ['A', 'B', 'C']
-    expected = pdf.sort_values(by=sort_by, ascending=ascending).reset_index(drop=True)
-    result = df.sort_values(by=sort_by, ascending=ascending).to_pandas()
-    pd.testing.assert_frame_equal(expected, result)
+def test_generated_sql_no_duplicate_sorting(dialect):
+    # calling sort_values multiple times shouldn't result in multiple select statements being generated as
+    # later sort statements cancel out earlier sort statements
+    bt = get_fake_df_test_data(dialect)
+    bt = bt.sort_values(by='city')
+    first_sql = bt.view_sql()
+    bt = bt.sort_values(by='municipality')
+    bt = bt.sort_values(by='city')
+    final_sql = bt.view_sql()
+    assert first_sql == final_sql


### PR DESCRIPTION
Pandas by default will sort values with nulls last (Postgres too). We should follow the same behavior for all engines.