### PR TITLE
Support recent NPM

### DIFF
--- a/tracker/.gitignore
+++ b/tracker/.gitignore
@@ -9,6 +9,9 @@
 !.yarn/sdks
 !.yarn/versions
 
+# NPM
+.npmrc
+
 # Dependencies
 node_modules/
 

--- a/tracker/.yarn/plugins/@objectiv/plugin-engines-check.js
+++ b/tracker/.yarn/plugins/@objectiv/plugin-engines-check.js
@@ -14,7 +14,7 @@ module.exports = {
     const nodeVersion = process.version;
 
     // Retrieve npm version
-    const npmVersion = execSync('npm -v').toString();
+    const npmVersion = execSync('npm -v').toString().trim();
 
     return {
       default: {

--- a/tracker/.yarn/plugins/@objectiv/plugin-engines-check.js
+++ b/tracker/.yarn/plugins/@objectiv/plugin-engines-check.js
@@ -1,12 +1,29 @@
 module.exports = {
   name: `plugin-engines-check`,
   factory: require => {
-    const { execSync } = require("child_process");
-    const { readFileSync } = require('fs');
+    const child_process = require("child_process");
+    const fs = require('fs');
+    const path = require("path");
     const semver = require('semver');
 
+    function getRootPath() {
+        return (function getRoot(dir) {
+            try {
+                const isPkgJson = fs.accessSync(path.join(dir, './package.json'));
+                const is_node_modules = fs.accessSync(path.join(dir, './node_modules'));
+            }
+            catch (e) {
+              if (dir === '/') {
+                throw new Error('Could not find root');
+              }
+              return getRoot(path.join(dir, '..'));
+            }
+            return dir;
+        }(path.join(__dirname, '../..')));
+    }
+
     // Read `node` and `npm` engines from package.json
-    const data = readFileSync('package.json');
+    const data = fs.readFileSync(getRootPath() + '/package.json');
     const { engines } = JSON.parse(data.toString());
     const { node, npm } = engines;
 
@@ -14,7 +31,7 @@ module.exports = {
     const nodeVersion = process.version;
 
     // Retrieve npm version
-    const npmVersion = execSync('npm -v').toString().trim();
+    const npmVersion = child_process.execSync('npm -v').toString().trim();
 
     return {
       default: {

--- a/tracker/.yarn/plugins/@objectiv/plugin-engines-check.js
+++ b/tracker/.yarn/plugins/@objectiv/plugin-engines-check.js
@@ -9,12 +9,12 @@ module.exports = {
     function getRootPath() {
         return (function getRoot(dir) {
             try {
-                const isPkgJson = fs.accessSync(path.join(dir, './package.json'));
-                const is_node_modules = fs.accessSync(path.join(dir, './node_modules'));
+                const isMonorepoRoot = fs.accessSync(path.join(dir, '.yarn'));
             }
             catch (e) {
               if (dir === '/') {
-                throw new Error('Could not find root');
+                // This should never happen, just for sanity
+                throw new Error('Could not find monorepo root');
               }
               return getRoot(path.join(dir, '..'));
             }

--- a/tracker/.yarn/plugins/plugin-engines-check.js
+++ b/tracker/.yarn/plugins/plugin-engines-check.js
@@ -1,4 +1,3 @@
-const {execSync} = require("child_process");
 module.exports = {
   name: `plugin-engines-check`,
   factory: require => {
@@ -11,11 +10,11 @@ module.exports = {
     const { engines } = JSON.parse(data.toString());
     const { node, npm } = engines;
 
-    // Retrieve npm version
-    const npmVersion = execSync('npm -v').toString();
-
     // Retrieve node version
     const nodeVersion = process.version;
+
+    // Retrieve npm version
+    const npmVersion = execSync('npm -v').toString();
 
     return {
       default: {

--- a/tracker/.yarn/plugins/plugin-engines-check.js
+++ b/tracker/.yarn/plugins/plugin-engines-check.js
@@ -1,0 +1,39 @@
+const {execSync} = require("child_process");
+module.exports = {
+  name: `plugin-engines-check`,
+  factory: require => {
+    const { execSync } = require("child_process");
+    const { readFileSync } = require('fs');
+    const semver = require('semver');
+
+    // Read `node` and `npm` engines from package.json
+    const data = readFileSync('package.json');
+    const { engines } = JSON.parse(data.toString());
+    const { node, npm } = engines;
+
+    // Retrieve npm version
+    const npmVersion = execSync('npm -v').toString();
+
+    // Retrieve node version
+    const nodeVersion = process.version;
+
+    return {
+      default: {
+        hooks: {
+          validateProject(project) {
+            if (!semver.satisfies(nodeVersion, node)) {
+              throw new Error(
+                `The current node version ${nodeVersion} does not satisfy the required version ${node}.`,
+              );
+            }
+            if (!semver.satisfies(npmVersion, npm)) {
+              throw new Error(
+                `The current npm version ${npmVersion} does not satisfy the required version ${npm}.`,
+              );
+            }
+          },
+        },
+      },
+    };
+  },
+};

--- a/tracker/.yarnrc.yml
+++ b/tracker/.yarnrc.yml
@@ -9,6 +9,8 @@ plugins:
     spec: "@yarnpkg/plugin-interactive-tools"
   - path: .yarn/plugins/@yarnpkg/plugin-version.cjs
     spec: "@yarnpkg/plugin-version"
+  - path: .yarn/plugins/plugin-engines-check.js
+    spec: "@yarnpkg/plugin-version"
 
 yarnPath: .yarn/releases/yarn-3.0.2.cjs
 

--- a/tracker/.yarnrc.yml
+++ b/tracker/.yarnrc.yml
@@ -9,8 +9,8 @@ plugins:
     spec: "@yarnpkg/plugin-interactive-tools"
   - path: .yarn/plugins/@yarnpkg/plugin-version.cjs
     spec: "@yarnpkg/plugin-version"
-  - path: .yarn/plugins/plugin-engines-check.js
-    spec: "@yarnpkg/plugin-version"
+  - path: .yarn/plugins/@objectiv/plugin-engines-check.js
+    spec: "@objectiv/plugin-engines-check"
 
 yarnPath: .yarn/releases/yarn-3.0.2.cjs
 

--- a/tracker/CONTRIBUTING.md
+++ b/tracker/CONTRIBUTING.md
@@ -53,6 +53,7 @@ The monorepo is configured to allow for live development on any package without 
 - git
 - Node.js 12
 - Yarn
+- NPM 8.5
 
 ## Workspace commands
 

--- a/tracker/Makefile
+++ b/tracker/Makefile
@@ -1,6 +1,7 @@
 clean:
 	# clean up caches
 	find core plugins queues trackers transports -type d -name dist -o -name coverage -o -name .npmrc -not -path '*node_modules*'  | xargs rm -rf
+	rm .npmrc
 
 build: clean
 	yarn install && yarn build

--- a/tracker/core/developer-tools/package.json
+++ b/tracker/core/developer-tools/package.json
@@ -51,8 +51,8 @@
     "test:ci": "jest --silent --ci --runInBand",
     "test:coverage": "jest --silent --coverage --runInBand",
     "check:dependencies": "npx depcheck",
-    "npm-publish": "shx rm -f .npmrc && npm publish --access=public --tag=$TAG",
-    "npm-publish:verdaccio": "shx cp ../../verdaccio/.npmrc .npmrc && npm publish --tag=$TAG && shx rm -f .npmrc"
+    "npm-publish": "npm publish --access=public --tag=$TAG",
+    "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
     "@objectiv/testing-tools": "^0.0.20-0",
@@ -61,7 +61,6 @@
     "jest": "^27.5.1",
     "jest-standard-reporter": "^2.0.0",
     "prettier": "^2.5.1",
-    "shx": "^0.3.4",
     "ts-jest": "^27.1.3",
     "ts-node": "^10.7.0",
     "tsconfig-paths": "^3.14.1",

--- a/tracker/core/react/package.json
+++ b/tracker/core/react/package.json
@@ -47,8 +47,8 @@
     "test:ci": "jest --silent --ci --runInBand",
     "test:coverage": "jest --silent --coverage --runInBand",
     "check:dependencies": "npx depcheck",
-    "npm-publish": "shx rm -f .npmrc && npm publish --access=public --tag=$TAG",
-    "npm-publish:verdaccio": "shx cp ../../verdaccio/.npmrc .npmrc && npm publish --tag=$TAG && shx rm -f .npmrc"
+    "npm-publish": "npm publish --access=public --tag=$TAG",
+    "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
     "@objectiv/developer-tools": "^0.0.20-0",
@@ -62,7 +62,6 @@
     "prettier": "^2.5.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "shx": "^0.3.4",
     "ts-jest": "^27.1.3",
     "tsup": "^5.12.0",
     "typescript": "^4.6.2"

--- a/tracker/core/schema/package.json
+++ b/tracker/core/schema/package.json
@@ -34,12 +34,11 @@
     "prettify:generated": "yarn prettier --write ./src",
     "tsc": "tsc --noEmit",
     "check:dependencies": "npx depcheck",
-    "npm-publish": "shx rm -f .npmrc && npm publish --access=public --tag=$TAG",
-    "npm-publish:verdaccio": "shx cp ../../verdaccio/.npmrc .npmrc && npm publish --tag=$TAG && shx rm -f .npmrc"
+    "npm-publish": "npm publish --access=public --tag=$TAG",
+    "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
     "prettier": "^2.5.1",
-    "shx": "^0.3.4",
     "typescript": "^4.6.2"
   }
 }

--- a/tracker/core/tracker/package.json
+++ b/tracker/core/tracker/package.json
@@ -46,8 +46,8 @@
     "test:ci": "jest --silent --ci --runInBand",
     "test:coverage": "jest --silent --coverage --runInBand",
     "check:dependencies": "npx depcheck",
-    "npm-publish": "shx rm -f .npmrc && npm publish --access=public --tag=$TAG",
-    "npm-publish:verdaccio": "shx cp ../../verdaccio/.npmrc .npmrc && npm publish --tag=$TAG && shx rm -f .npmrc"
+    "npm-publish": "npm publish --access=public --tag=$TAG",
+    "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
     "@objectiv/testing-tools": "^0.0.20-0",
@@ -57,7 +57,6 @@
     "jest-standard-reporter": "^2.0.0",
     "mockdate": "^3.0.5",
     "prettier": "^2.5.1",
-    "shx": "^0.3.4",
     "ts-jest": "^27.1.3",
     "tsup": "^5.12.0",
     "typescript": "^4.6.2"

--- a/tracker/package.json
+++ b/tracker/package.json
@@ -10,6 +10,10 @@
     "trackers/*",
     "transports/*"
   ],
+  "engines": {
+    "node": ">= 12",
+    "npm": ">= 8.5"
+  },
   "scripts": {
     "clear": "yarn exec make clean && yarn test --clearCache && yarn cache clean",
     "build-core": "yarn workspaces foreach --include @objectiv/developer-tools --include @objectiv/tracker-core --include @objectiv/tracker-react-core --verbose run build",

--- a/tracker/package.json
+++ b/tracker/package.json
@@ -27,12 +27,15 @@
     "test:ci": "yarn workspaces foreach --parallel --exclude root --exclude @objectiv/schema --exclude @objectiv/utilities --exclude @objectiv/testing-tools --exclude @objectiv/tracker-angular --verbose run test:ci",
     "test:coverage": "yarn workspaces foreach --parallel --exclude root --exclude @objectiv/schema --exclude @objectiv/utilities --exclude @objectiv/testing-tools --exclude @objectiv/tracker-angular --verbose run test:coverage",
     "check:dependencies": "yarn workspaces foreach --parallel --exclude root --exclude @objectiv/tracker-angular --verbose run check:dependencies",
-    "publish": "yarn workspaces foreach --exclude root --exclude @objectiv/utilities --exclude @objectiv/testing-tools --verbose run npm-publish",
-    "publish:verdaccio": "yarn workspaces foreach --exclude root --exclude @objectiv/utilities --exclude @objectiv/testing-tools --verbose run npm-publish:verdaccio",
+    "publish": "shx rm -f .npmrc && yarn workspaces foreach --exclude root --exclude @objectiv/utilities --exclude @objectiv/testing-tools --verbose run npm-publish",
+    "publish:verdaccio": "shx cp ./verdaccio/.npmrc .npmrc && yarn workspaces foreach --exclude root --exclude @objectiv/utilities --exclude @objectiv/testing-tools --verbose run npm-publish:verdaccio && shx rm -f .npmrc",
     "utils:generate": "yarn workspace @objectiv/utilities generate && yarn workspace @objectiv/developer-tools generate && yarn prettify:generated && yarn tsc:generated",
     "version:major": "yarn workspaces foreach --exclude root --verbose version major && rm -rf .yarn/versions",
     "version:minor": "yarn workspaces foreach --exclude root --verbose version minor && rm -rf .yarn/versions",
     "version:patch": "yarn workspaces foreach --exclude root --verbose version patch && rm -rf .yarn/versions",
     "version:prerelease": "yarn workspaces foreach --exclude root --verbose version prerelease && rm -rf .yarn/versions"
+  },
+  "devDependencies": {
+    "shx": "^0.3.4"
   }
 }

--- a/tracker/plugins/http-context/package.json
+++ b/tracker/plugins/http-context/package.json
@@ -50,8 +50,8 @@
     "test:ci": "jest --silent --ci --runInBand",
     "test:coverage": "jest --silent --coverage --runInBand",
     "check:dependencies": "npx depcheck",
-    "npm-publish": "shx rm -f .npmrc && npm publish --access=public --tag=$TAG",
-    "npm-publish:verdaccio": "shx cp ../../verdaccio/.npmrc .npmrc && npm publish --tag=$TAG && shx rm -f .npmrc"
+    "npm-publish": "npm publish --access=public --tag=$TAG",
+    "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
     "@objectiv/developer-tools": "^0.0.20-0",
@@ -61,7 +61,6 @@
     "jest-extended": "^2.0.0",
     "jest-standard-reporter": "^2.0.0",
     "prettier": "^2.5.1",
-    "shx": "^0.3.4",
     "ts-jest": "^27.1.3",
     "tsup": "^5.12.0",
     "typescript": "^4.6.2"

--- a/tracker/plugins/path-context-from-url/package.json
+++ b/tracker/plugins/path-context-from-url/package.json
@@ -48,8 +48,8 @@
     "test:ci": "jest --silent --ci --runInBand",
     "test:coverage": "jest --silent --coverage --runInBand",
     "check:dependencies": "npx depcheck",
-    "npm-publish": "shx rm -f .npmrc && npm publish --access=public --tag=$TAG",
-    "npm-publish:verdaccio": "shx cp ../../verdaccio/.npmrc .npmrc && npm publish --tag=$TAG && shx rm -f .npmrc"
+    "npm-publish": "npm publish --access=public --tag=$TAG",
+    "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
     "@objectiv/developer-tools": "^0.0.20-0",
@@ -59,7 +59,6 @@
     "jest-extended": "^2.0.0",
     "jest-standard-reporter": "^2.0.0",
     "prettier": "^2.5.1",
-    "shx": "^0.3.4",
     "ts-jest": "^27.1.3",
     "tsup": "^5.12.0",
     "typescript": "^4.6.2"

--- a/tracker/plugins/react-navigation/package.json
+++ b/tracker/plugins/react-navigation/package.json
@@ -49,8 +49,8 @@
     "test:ci": "jest --silent --ci --runInBand",
     "test:coverage": "jest --silent --coverage --runInBand",
     "check:dependencies": "npx depcheck",
-    "npm-publish": "shx rm -f .npmrc && npm publish --access=public --tag=$TAG",
-    "npm-publish:verdaccio": "shx cp ../../verdaccio/.npmrc .npmrc && npm publish --tag=$TAG && shx rm -f .npmrc"
+    "npm-publish": "npm publish --access=public --tag=$TAG",
+    "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "dependencies": {
     "@objectiv/tracker-react-core": "^0.0.20-0",
@@ -73,7 +73,6 @@
     "react-native-safe-area-context": "^4.1.2",
     "react-native-screens": "^3.13.1",
     "react-test-renderer": "^17.0.2",
-    "shx": "^0.3.3",
     "tsup": "^5.12.0",
     "typescript": "^4.6.2"
   },

--- a/tracker/plugins/react-router-tracked-components/package.json
+++ b/tracker/plugins/react-router-tracked-components/package.json
@@ -50,8 +50,8 @@
     "test:ci": "jest --silent --ci --runInBand",
     "test:coverage": "jest --silent --coverage --runInBand",
     "check:dependencies": "npx depcheck",
-    "npm-publish": "shx rm -f .npmrc && npm publish --access=public --tag=$TAG",
-    "npm-publish:verdaccio": "shx cp ../../verdaccio/.npmrc .npmrc && npm publish --tag=$TAG && shx rm -f .npmrc"
+    "npm-publish": "npm publish --access=public --tag=$TAG",
+    "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "dependencies": {
     "@objectiv/tracker-core": "^0.0.20-0",
@@ -66,7 +66,6 @@
     "jest-standard-reporter": "^2.0.0",
     "prettier": "^2.5.1",
     "react-router-dom": "^6.2.2",
-    "shx": "^0.3.4",
     "ts-jest": "^27.1.3",
     "tsup": "^5.12.0",
     "typescript": "^4.6.2"

--- a/tracker/plugins/root-location-context-from-url/package.json
+++ b/tracker/plugins/root-location-context-from-url/package.json
@@ -49,8 +49,8 @@
     "test:ci": "jest --silent --ci --runInBand",
     "test:coverage": "jest --silent --coverage --runInBand",
     "check:dependencies": "npx depcheck",
-    "npm-publish": "shx rm -f .npmrc && npm publish --access=public --tag=$TAG",
-    "npm-publish:verdaccio": "shx cp ../../verdaccio/.npmrc .npmrc && npm publish --tag=$TAG && shx rm -f .npmrc"
+    "npm-publish": "npm publish --access=public --tag=$TAG",
+    "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
     "@objectiv/developer-tools": "^0.0.20-0",
@@ -60,7 +60,6 @@
     "jest-extended": "^2.0.0",
     "jest-standard-reporter": "^2.0.0",
     "prettier": "^2.5.1",
-    "shx": "^0.3.4",
     "ts-jest": "^27.1.3",
     "tsup": "^5.12.0",
     "typescript": "^4.6.2"

--- a/tracker/queues/local-storage/package.json
+++ b/tracker/queues/local-storage/package.json
@@ -47,8 +47,8 @@
     "test:ci": "jest --silent --ci --runInBand",
     "test:coverage": "jest --silent --coverage --runInBand",
     "check:dependencies": "npx depcheck",
-    "npm-publish": "shx rm -f .npmrc && npm publish --access=public --tag=$TAG",
-    "npm-publish:verdaccio": "shx cp ../../verdaccio/.npmrc .npmrc && npm publish --tag=$TAG && shx rm -f .npmrc"
+    "npm-publish": "npm publish --access=public --tag=$TAG",
+    "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
     "@objectiv/developer-tools": "^0.0.20-0",
@@ -57,7 +57,6 @@
     "jest": "^27.5.1",
     "jest-standard-reporter": "^2.0.0",
     "prettier": "^2.5.1",
-    "shx": "^0.3.4",
     "ts-jest": "^27.1.3",
     "tsup": "^5.12.0",
     "typescript": "^4.6.2"

--- a/tracker/trackers/angular/package.json
+++ b/tracker/trackers/angular/package.json
@@ -32,8 +32,8 @@
     "build": "ng-packagr -p ng-package.json",
     "prettify": "prettier --write .",
     "tsc": "tsc --noEmit",
-    "npm-publish": "shx rm -f .npmrc && npm publish --access=public --tag=$TAG",
-    "npm-publish:verdaccio": "shx cp ../../verdaccio/.npmrc .npmrc && npm publish --tag=$TAG && shx rm -f .npmrc"
+    "npm-publish": "npm publish --access=public --tag=$TAG",
+    "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "peerDependencies": {
     "@angular/common": "^9.0.0",
@@ -48,7 +48,6 @@
     "ng-packagr": "^9.0.0",
     "prettier": "^2.5.1",
     "rxjs": "~6.5.4",
-    "shx": "^0.3.4",
     "tslib": "^1.10.0",
     "typescript": "~3.8.3",
     "zone.js": "~0.10.2"

--- a/tracker/trackers/browser/package.json
+++ b/tracker/trackers/browser/package.json
@@ -46,8 +46,8 @@
     "test:ci": "jest --silent --ci --runInBand",
     "test:coverage": "jest --silent --coverage --runInBand",
     "check:dependencies": "npx depcheck",
-    "npm-publish": "shx rm -f .npmrc && npm publish --access=public --tag=$TAG",
-    "npm-publish:verdaccio": "shx cp ../../verdaccio/.npmrc .npmrc && npm publish --tag=$TAG && shx rm -f .npmrc"
+    "npm-publish": "npm publish --access=public --tag=$TAG",
+    "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
     "@objectiv/developer-tools": "^0.0.20-0",
@@ -58,7 +58,6 @@
     "jest-standard-reporter": "^2.0.0",
     "jest-useragent-mock": "^0.1.1",
     "prettier": "^2.5.1",
-    "shx": "^0.3.4",
     "ts-jest": "^27.1.3",
     "tsup": "^5.12.0",
     "typescript": "^4.6.2"

--- a/tracker/trackers/react-native/package.json
+++ b/tracker/trackers/react-native/package.json
@@ -46,8 +46,8 @@
     "test:ci": "jest --silent --ci --runInBand",
     "test:coverage": "jest --silent --coverage --runInBand",
     "check:dependencies": "npx depcheck",
-    "npm-publish": "shx rm -f .npmrc && npm publish --access=public --tag=$TAG",
-    "npm-publish:verdaccio": "shx cp ../../verdaccio/.npmrc .npmrc && npm publish --tag=$TAG && shx rm -f .npmrc"
+    "npm-publish": "npm publish --access=public --tag=$TAG",
+    "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
     "@objectiv/developer-tools": "^0.0.20-0",
@@ -61,7 +61,6 @@
     "prettier": "^2.5.1",
     "react-native": "^0.67.3",
     "react-test-renderer": "^17.0.2",
-    "shx": "^0.3.4",
     "tsup": "^5.12.0",
     "typescript": "^4.6.2"
   },

--- a/tracker/trackers/react/package.json
+++ b/tracker/trackers/react/package.json
@@ -46,8 +46,8 @@
     "test:ci": "jest --silent --ci --runInBand",
     "test:coverage": "jest --silent --coverage --runInBand",
     "check:dependencies": "npx depcheck",
-    "npm-publish": "shx rm -f .npmrc && npm publish --access=public --tag=$TAG",
-    "npm-publish:verdaccio": "shx cp ../../verdaccio/.npmrc .npmrc && npm publish --tag=$TAG && shx rm -f .npmrc"
+    "npm-publish": "publish --access=public --tag=$TAG",
+    "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
     "@objectiv/developer-tools": "^0.0.20-0",
@@ -63,7 +63,6 @@
     "prettier": "^2.5.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "shx": "^0.3.4",
     "ts-jest": "^27.1.3",
     "tsup": "^5.12.0",
     "typescript": "^4.6.2"

--- a/tracker/transports/debug/package.json
+++ b/tracker/transports/debug/package.json
@@ -48,15 +48,14 @@
     "test:ci": "jest --silent --ci --runInBand",
     "test:coverage": "jest --silent --coverage --runInBand",
     "check:dependencies": "npx depcheck",
-    "npm-publish": "shx rm -f .npmrc && npm publish --access=public --tag=$TAG",
-    "npm-publish:verdaccio": "shx cp ../../verdaccio/.npmrc .npmrc && npm publish --tag=$TAG && shx rm -f .npmrc"
+    "npm-publish": "npm publish --access=public --tag=$TAG",
+    "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
     "@types/jest": "^27.4.1",
     "jest": "^27.5.1",
     "jest-standard-reporter": "^2.0.0",
     "prettier": "^2.5.1",
-    "shx": "^0.3.4",
     "ts-jest": "^27.1.3",
     "tsup": "^5.12.0",
     "typescript": "^4.6.2"

--- a/tracker/transports/fetch/package.json
+++ b/tracker/transports/fetch/package.json
@@ -47,8 +47,8 @@
     "test:ci": "jest --silent --ci --runInBand",
     "test:coverage": "jest --silent --coverage --runInBand",
     "check:dependencies": "npx depcheck",
-    "npm-publish": "shx rm -f .npmrc && npm publish --access=public --tag=$TAG",
-    "npm-publish:verdaccio": "shx cp ../../verdaccio/.npmrc .npmrc && npm publish --tag=$TAG && shx rm -f .npmrc"
+    "npm-publish": "npm publish --access=public --tag=$TAG",
+    "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
     "@objectiv/developer-tools": "^0.0.20-0",
@@ -58,7 +58,6 @@
     "jest-fetch-mock": "^3.0.3",
     "jest-standard-reporter": "^2.0.0",
     "prettier": "^2.5.1",
-    "shx": "^0.3.4",
     "ts-jest": "^27.1.3",
     "tsup": "^5.12.0",
     "typescript": "^4.6.2"

--- a/tracker/transports/xhr/package.json
+++ b/tracker/transports/xhr/package.json
@@ -48,8 +48,8 @@
     "test:ci": "jest --silent --ci --runInBand",
     "test:coverage": "jest --silent --coverage --runInBand",
     "check:dependencies": "npx depcheck",
-    "npm-publish": "shx rm -f .npmrc && npm publish --access=public --tag=$TAG",
-    "npm-publish:verdaccio": "shx cp ../../verdaccio/.npmrc .npmrc && npm publish --tag=$TAG && shx rm -f .npmrc"
+    "npm-publish": "npm publish --access=public --tag=$TAG",
+    "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
     "@objectiv/developer-tools": "^0.0.20-0",
@@ -58,7 +58,6 @@
     "jest": "^27.5.1",
     "jest-standard-reporter": "^2.0.0",
     "prettier": "^2.5.1",
-    "shx": "^0.3.4",
     "ts-jest": "^27.1.3",
     "tsup": "^5.12.0",
     "typescript": "^4.6.2",

--- a/tracker/yarn.lock
+++ b/tracker/yarn.lock
@@ -1515,7 +1515,6 @@ __metadata:
     jest: ^27.5.1
     jest-standard-reporter: ^2.0.0
     prettier: ^2.5.1
-    shx: ^0.3.4
     ts-jest: ^27.1.3
     ts-node: ^10.7.0
     tsconfig-paths: ^3.14.1
@@ -1538,7 +1537,6 @@ __metadata:
     jest-extended: ^2.0.0
     jest-standard-reporter: ^2.0.0
     prettier: ^2.5.1
-    shx: ^0.3.4
     ts-jest: ^27.1.3
     tsup: ^5.12.0
     typescript: ^4.6.2
@@ -1558,7 +1556,6 @@ __metadata:
     jest-extended: ^2.0.0
     jest-standard-reporter: ^2.0.0
     prettier: ^2.5.1
-    shx: ^0.3.4
     ts-jest: ^27.1.3
     tsup: ^5.12.0
     typescript: ^4.6.2
@@ -1589,7 +1586,6 @@ __metadata:
     react-native-safe-area-context: ^4.1.2
     react-native-screens: ^3.13.1
     react-test-renderer: ^17.0.2
-    shx: ^0.3.3
     tsup: ^5.12.0
     typescript: ^4.6.2
   peerDependencies:
@@ -1614,7 +1610,6 @@ __metadata:
     jest-standard-reporter: ^2.0.0
     prettier: ^2.5.1
     react-router-dom: ^6.2.2
-    shx: ^0.3.4
     ts-jest: ^27.1.3
     tsup: ^5.12.0
     typescript: ^4.6.2
@@ -1636,7 +1631,6 @@ __metadata:
     jest-extended: ^2.0.0
     jest-standard-reporter: ^2.0.0
     prettier: ^2.5.1
-    shx: ^0.3.4
     ts-jest: ^27.1.3
     tsup: ^5.12.0
     typescript: ^4.6.2
@@ -1656,7 +1650,6 @@ __metadata:
     jest: ^27.5.1
     jest-standard-reporter: ^2.0.0
     prettier: ^2.5.1
-    shx: ^0.3.4
     ts-jest: ^27.1.3
     tsup: ^5.12.0
     typescript: ^4.6.2
@@ -1668,7 +1661,6 @@ __metadata:
   resolution: "@objectiv/schema@workspace:core/schema"
   dependencies:
     prettier: ^2.5.1
-    shx: ^0.3.4
     typescript: ^4.6.2
   languageName: unknown
   linkType: soft
@@ -1694,7 +1686,6 @@ __metadata:
     ng-packagr: ^9.0.0
     prettier: ^2.5.1
     rxjs: ~6.5.4
-    shx: ^0.3.4
     tslib: ^1.10.0
     typescript: ~3.8.3
     zone.js: ~0.10.2
@@ -1726,7 +1717,6 @@ __metadata:
     jest-standard-reporter: ^2.0.0
     jest-useragent-mock: ^0.1.1
     prettier: ^2.5.1
-    shx: ^0.3.4
     ts-jest: ^27.1.3
     tsup: ^5.12.0
     typescript: ^4.6.2
@@ -1746,7 +1736,6 @@ __metadata:
     jest-standard-reporter: ^2.0.0
     mockdate: ^3.0.5
     prettier: ^2.5.1
-    shx: ^0.3.4
     ts-jest: ^27.1.3
     tsup: ^5.12.0
     typescript: ^4.6.2
@@ -1772,7 +1761,6 @@ __metadata:
     prettier: ^2.5.1
     react: ^17.0.2
     react-dom: ^17.0.2
-    shx: ^0.3.4
     ts-jest: ^27.1.3
     tsup: ^5.12.0
     typescript: ^4.6.2
@@ -1801,7 +1789,6 @@ __metadata:
     react-native: ^0.67.3
     react-native-get-random-values: ^1.7.2
     react-test-renderer: ^17.0.2
-    shx: ^0.3.4
     tsup: ^5.12.0
     typescript: ^4.6.2
   peerDependencies:
@@ -1835,7 +1822,6 @@ __metadata:
     prettier: ^2.5.1
     react: ^17.0.2
     react-dom: ^17.0.2
-    shx: ^0.3.4
     ts-jest: ^27.1.3
     tsup: ^5.12.0
     typescript: ^4.6.2
@@ -1854,7 +1840,6 @@ __metadata:
     jest: ^27.5.1
     jest-standard-reporter: ^2.0.0
     prettier: ^2.5.1
-    shx: ^0.3.4
     ts-jest: ^27.1.3
     tsup: ^5.12.0
     typescript: ^4.6.2
@@ -1873,7 +1858,6 @@ __metadata:
     jest-fetch-mock: ^3.0.3
     jest-standard-reporter: ^2.0.0
     prettier: ^2.5.1
-    shx: ^0.3.4
     ts-jest: ^27.1.3
     tsup: ^5.12.0
     typescript: ^4.6.2
@@ -1891,7 +1875,6 @@ __metadata:
     jest: ^27.5.1
     jest-standard-reporter: ^2.0.0
     prettier: ^2.5.1
-    shx: ^0.3.4
     ts-jest: ^27.1.3
     tsup: ^5.12.0
     typescript: ^4.6.2
@@ -9893,7 +9876,7 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"shx@npm:^0.3.3, shx@npm:^0.3.4":
+"shx@npm:^0.3.4":
   version: 0.3.4
   resolution: "shx@npm:0.3.4"
   dependencies:

--- a/tracker/yarn.lock
+++ b/tracker/yarn.lock
@@ -9580,6 +9580,8 @@ fsevents@~2.1.2:
 "root@workspace:.":
   version: 0.0.0-use.local
   resolution: "root@workspace:."
+  dependencies:
+    shx: ^0.3.4
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
Latest npm versions started supporting monorepos.

One of the first breaking changes we encountered is that .npmrc gets ignored in subdirectories and instead it's expected to be placed in the monorepo root. 

We use this file to switch between publishing to Verdaccio or npm. 

In this PR:
- Added a custom plugin for Yarn 2 to check the engines.node and engines.npm values of package.json. This will ensure developers contributing get meaningful errors if they have mismatching versions.

- Removed .npmrc logic from individual packages and moved it to the root of the monorepo, along with the shx dependency we use to execute shell commands cross platform.

- Updated CONTRIBUTING.MD with the correct npm version needed.

Resolves #837