### PR TITLE
ModelHub BQ: Use `dt.strftime` instead of `dt.sql_format`

### DIFF
--- a/modelhub/modelhub/modelhub.py
+++ b/modelhub/modelhub/modelhub.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 GroupByType = Union[List[Union[str, bach.Series]], str, bach.Series, NotSet]
 ConversionEventDefinitionType = Tuple[Optional['SeriesLocationStack'], Optional[str]]
 
-TIME_DEFAULT_FORMAT = 'YYYY-MM-DD HH24:MI:SS.MS'
+TIME_DEFAULT_FORMAT = '%Y-%m-%d %H:%M:%S.%f'
 
 
 class ModelHub:
@@ -181,7 +181,7 @@ class ModelHub:
         """
 
         time_aggregation = self.time_aggregation if time_aggregation is None else time_aggregation
-        return data.moment.dt.sql_format(time_aggregation).copy_override(name='time_aggregation')
+        return data.moment.dt.strftime(time_aggregation).copy_override(name='time_aggregation')
 
     _metabase: Union[None, MetaBase] = None
 

--- a/modelhub/modelhub/modelhub.py
+++ b/modelhub/modelhub/modelhub.py
@@ -174,9 +174,9 @@ class ModelHub:
 
         :param data: :py:class:`bach.DataFrame` to apply the method on.
         :param time_aggregation: if None, it uses :py:attr:`time_aggregation` set from the
-            ModelHub. Use any template for aggregation from:
-            https://www.postgresql.org/docs/14/functions-formatting.html
-            ie. ``time_aggregation=='YYYY-MM-DD'`` aggregates by date.
+            ModelHub. Use any template for aggregation based on 1989 C standard format codes:
+            https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes
+            ie. ``time_aggregation=='%Y-%m-%d'`` aggregates by date.
         :returns: SeriesString.
         """
 

--- a/modelhub/tests_modelhub/functional/modelhub/test_model_hub.py
+++ b/modelhub/tests_modelhub/functional/modelhub/test_model_hub.py
@@ -11,7 +11,7 @@ from uuid import UUID
 
 # map
 def test_is_first_session(db_params):
-    df, modelhub = get_objectiv_dataframe_test(db_params, time_aggregation='YYYY-MM-DD')
+    df, modelhub = get_objectiv_dataframe_test(db_params, time_aggregation='%Y-%m-%d')
 
     s = modelhub.map.is_first_session(df)
 
@@ -57,7 +57,7 @@ def test_is_first_session(db_params):
 
 @pytest.mark.skip_bigquery
 def test_is_new_user(db_params):
-    df, modelhub = get_objectiv_dataframe_test(db_params, time_aggregation='YYYY-MM-DD')
+    df, modelhub = get_objectiv_dataframe_test(db_params, time_aggregation='%Y-%m-%d')
 
     s = modelhub.map.is_new_user(df)
 
@@ -101,7 +101,7 @@ def test_is_new_user(db_params):
         convert_uuid=True,
     )
 
-    s = modelhub.map.is_new_user(df, time_aggregation='YYYY-MM')
+    s = modelhub.map.is_new_user(df, time_aggregation='%Y-%m')
 
     assert_equals_data(
         s,
@@ -127,7 +127,7 @@ def test_is_new_user(db_params):
 
 @pytest.mark.skip_bigquery
 def test_add_conversion_event(db_params):
-    df, modelhub = get_objectiv_dataframe_test(db_params, time_aggregation='YYYY-MM-DD')
+    df, modelhub = get_objectiv_dataframe_test(db_params, time_aggregation='%Y-%m-%d')
 
     location_stack = df.location_stack.json[{'_type': 'LinkContext', 'id': 'cta-repo-button'}:]
     event_type = 'ClickEvent'
@@ -190,7 +190,7 @@ def test_add_conversion_event(db_params):
     )
 
     # event_type not set
-    df, modelhub = get_objectiv_dataframe_test(db_params, time_aggregation='YYYY-MM-DD')
+    df, modelhub = get_objectiv_dataframe_test(db_params, time_aggregation='%Y-%m-%d')
     modelhub.add_conversion_event(location_stack=location_stack, name='github_clicks')
     assert len(modelhub._conversion_events) == 1
     assert modelhub._conversion_events[conversion] == (location_stack, None)
@@ -249,7 +249,7 @@ def test_add_conversion_event(db_params):
 
 @pytest.mark.skip_bigquery
 def test_is_conversion_event(db_params): # TODO: Remove when bach supports json slicing for BigQuery
-    df, modelhub = get_objectiv_dataframe_test(db_params, time_aggregation='YYYY-MM-DD')
+    df, modelhub = get_objectiv_dataframe_test(db_params, time_aggregation='%Y-%m-%d')
 
     # add conversion event
     modelhub.add_conversion_event(location_stack=df.location_stack.json[{'_type': 'LinkContext',
@@ -301,7 +301,7 @@ def test_is_conversion_event(db_params): # TODO: Remove when bach supports json 
 
 @pytest.mark.skip_bigquery  # TODO: Remove when bach supports json slicing for BigQuery
 def test_conversions_counter(db_params):
-    df, modelhub = get_objectiv_dataframe_test(db_params, time_aggregation='YYYY-MM-DD')
+    df, modelhub = get_objectiv_dataframe_test(db_params, time_aggregation='%Y-%m-%d')
 
     # add conversion event
     modelhub.add_conversion_event(location_stack=df.location_stack.json[{'_type': 'LinkContext', 'id': 'cta-repo-button'}:],
@@ -372,7 +372,7 @@ def test_conversions_counter(db_params):
 
 @pytest.mark.skip_bigquery  # TODO: Remove when bach supports json slicing for BigQuery
 def test_conversions_in_time(db_params):
-    df, modelhub = get_objectiv_dataframe_test(db_params, time_aggregation='YYYY-MM-DD')
+    df, modelhub = get_objectiv_dataframe_test(db_params, time_aggregation='%Y-%m-%d')
 
     # add conversion event
     modelhub.add_conversion_event(
@@ -418,7 +418,7 @@ def test_conversions_in_time(db_params):
 
 @pytest.mark.skip_bigquery  # TODO: Remove when bach supports json slicing for BigQuery
 def test_pre_conversion_hit_number(db_params):
-    df, modelhub = get_objectiv_dataframe_test(db_params, time_aggregation='YYYY-MM-DD')
+    df, modelhub = get_objectiv_dataframe_test(db_params, time_aggregation='%Y-%m-%d')
 
     # add conversion event
     modelhub.add_conversion_event(location_stack=df.location_stack.json[{'_type': 'LinkContext', 'id': 'cta-repo-button'}:],
@@ -484,7 +484,6 @@ def test_pre_conversion_hit_number(db_params):
     )
 
 
-@pytest.mark.skip_bigquery
 def test_time_agg(db_params):
     df, modelhub = get_objectiv_dataframe_test(db_params)
     s = modelhub.time_agg(df)
@@ -493,24 +492,24 @@ def test_time_agg(db_params):
         s,
         expected_columns=['event_id', 'time_aggregation'],
         expected_data=[
-            [UUID('12b55ed5-4295-4fc1-bf1f-88d64d1ac301'), '2021-11-30 10:23:36.287'],
-            [UUID('12b55ed5-4295-4fc1-bf1f-88d64d1ac302'), '2021-11-30 10:23:36.290'],
-            [UUID('12b55ed5-4295-4fc1-bf1f-88d64d1ac303'), '2021-11-30 10:23:36.291'],
-            [UUID('12b55ed5-4295-4fc1-bf1f-88d64d1ac304'), '2021-11-30 10:23:36.267'],
-            [UUID('12b55ed5-4295-4fc1-bf1f-88d64d1ac305'), '2021-12-01 10:23:36.276'],
-            [UUID('12b55ed5-4295-4fc1-bf1f-88d64d1ac306'), '2021-12-01 10:23:36.279'],
-            [UUID('12b55ed5-4295-4fc1-bf1f-88d64d1ac307'), '2021-12-02 10:23:36.281'],
-            [UUID('12b55ed5-4295-4fc1-bf1f-88d64d1ac308'), '2021-12-02 10:23:36.281'],
-            [UUID('12b55ed5-4295-4fc1-bf1f-88d64d1ac309'), '2021-12-02 14:23:36.282'],
-            [UUID('12b55ed5-4295-4fc1-bf1f-88d64d1ac310'), '2021-12-03 10:23:36.283'],
-            [UUID('12b55ed5-4295-4fc1-bf1f-88d64d1ac311'), '2021-11-29 10:23:36.286'],
-            [UUID('12b55ed5-4295-4fc1-bf1f-88d64d1ac312'), '2021-11-29 10:23:36.287']
+            [UUID('12b55ed5-4295-4fc1-bf1f-88d64d1ac301'), '2021-11-30 10:23:36.287000'],
+            [UUID('12b55ed5-4295-4fc1-bf1f-88d64d1ac302'), '2021-11-30 10:23:36.290000'],
+            [UUID('12b55ed5-4295-4fc1-bf1f-88d64d1ac303'), '2021-11-30 10:23:36.291000'],
+            [UUID('12b55ed5-4295-4fc1-bf1f-88d64d1ac304'), '2021-11-30 10:23:36.267000'],
+            [UUID('12b55ed5-4295-4fc1-bf1f-88d64d1ac305'), '2021-12-01 10:23:36.276000'],
+            [UUID('12b55ed5-4295-4fc1-bf1f-88d64d1ac306'), '2021-12-01 10:23:36.279000'],
+            [UUID('12b55ed5-4295-4fc1-bf1f-88d64d1ac307'), '2021-12-02 10:23:36.281000'],
+            [UUID('12b55ed5-4295-4fc1-bf1f-88d64d1ac308'), '2021-12-02 10:23:36.281000'],
+            [UUID('12b55ed5-4295-4fc1-bf1f-88d64d1ac309'), '2021-12-02 14:23:36.282000'],
+            [UUID('12b55ed5-4295-4fc1-bf1f-88d64d1ac310'), '2021-12-03 10:23:36.283000'],
+            [UUID('12b55ed5-4295-4fc1-bf1f-88d64d1ac311'), '2021-11-29 10:23:36.286000'],
+            [UUID('12b55ed5-4295-4fc1-bf1f-88d64d1ac312'), '2021-11-29 10:23:36.287000']
         ],
         order_by='event_id',
         convert_uuid=True,
     )
 
-    df, modelhub = get_objectiv_dataframe_test(db_params, time_aggregation='YYYY-MM')
+    df, modelhub = get_objectiv_dataframe_test(db_params, time_aggregation='%Y-%m')
     s = modelhub.time_agg(df)
 
     assert_equals_data(
@@ -535,7 +534,7 @@ def test_time_agg(db_params):
     )
 
     df, modelhub = get_objectiv_dataframe_test(db_params)
-    s = modelhub.time_agg(df, time_aggregation='YYYY-MM-DD')
+    s = modelhub.time_agg(df, time_aggregation='%Y-%m-%d')
 
     assert_equals_data(
         s,
@@ -557,8 +556,8 @@ def test_time_agg(db_params):
         convert_uuid=True,
     )
 
-    df, modelhub = get_objectiv_dataframe_test(db_params, time_aggregation='YYYY-MM-DD')
-    s = modelhub.time_agg(df, time_aggregation='YYYY')
+    df, modelhub = get_objectiv_dataframe_test(db_params, time_aggregation='%Y-%m-%d')
+    s = modelhub.time_agg(df, time_aggregation='%Y')
 
     assert_equals_data(
         s,

--- a/modelhub/tests_modelhub/functional/modelhub/test_model_hub_session_duration.py
+++ b/modelhub/tests_modelhub/functional/modelhub/test_model_hub_session_duration.py
@@ -36,7 +36,7 @@ def test_no_grouping(db_params, exclude_bounces, expected_data):
 
 def test_time_aggregation_in_df(db_params):
     # using time_aggregation (and default groupby: mh.time_agg(df, ))
-    df, modelhub = get_objectiv_dataframe_test(db_params, time_aggregation='YYYY-MM-DD')
+    df, modelhub = get_objectiv_dataframe_test(db_params, time_aggregation='%Y-%m-%d')
     s = modelhub.aggregate.session_duration(df)
 
     assert_equals_data(
@@ -52,7 +52,7 @@ def test_time_aggregation_in_df(db_params):
 def test_overriding_time_aggregation_in(db_params):
     # overriding time_aggregation
     df, modelhub = get_objectiv_dataframe_test(db_params)
-    bts = modelhub.aggregate.session_duration(df, groupby=modelhub.time_agg(df, 'YYYY-MM'))
+    bts = modelhub.aggregate.session_duration(df, groupby=modelhub.time_agg(df, '%Y-%m'))
 
     assert_equals_data(
         bts,
@@ -61,7 +61,7 @@ def test_overriding_time_aggregation_in(db_params):
             ['2021-12', datetime.timedelta(microseconds=3000)]]
     )
 
-    bts = modelhub.aggregate.session_duration(df, groupby=modelhub.time_agg(df, 'YYYY-MM'), method='sum')
+    bts = modelhub.aggregate.session_duration(df, groupby=modelhub.time_agg(df, '%Y-%m'), method='sum')
 
     assert_equals_data(
         bts,
@@ -72,7 +72,7 @@ def test_overriding_time_aggregation_in(db_params):
 
 def test_groupby(db_params):
     # group by other columns
-    df, modelhub = get_objectiv_dataframe_test(db_params, time_aggregation='YYYY-MM-DD')
+    df, modelhub = get_objectiv_dataframe_test(db_params, time_aggregation='%Y-%m-%d')
     s = modelhub.aggregate.session_duration(df, groupby='event_type')
 
     assert_equals_data(
@@ -83,8 +83,8 @@ def test_groupby(db_params):
 
 def test_groupby_incl_time_agg(db_params):
     # group by other columns (as series), including time_agg
-    df, modelhub = get_objectiv_dataframe_test(db_params, time_aggregation='YYYY-MM-DD')
-    s = modelhub.aggregate.session_duration(df, groupby=[modelhub.time_agg(df, 'YYYY-MM'), df.session_id])
+    df, modelhub = get_objectiv_dataframe_test(db_params, time_aggregation='%Y-%m-%d')
+    s = modelhub.aggregate.session_duration(df, groupby=[modelhub.time_agg(df, '%Y-%m'), df.session_id])
 
     assert_equals_data(
         s,

--- a/modelhub/tests_modelhub/functional/modelhub/test_model_hub_unique_sessions.py
+++ b/modelhub/tests_modelhub/functional/modelhub/test_model_hub_unique_sessions.py
@@ -8,7 +8,6 @@ from modelhub import __version__
 from tests_modelhub.data_and_utils.utils import get_objectiv_dataframe_test
 from tests.functional.bach.test_data_and_utils import assert_equals_data
 from uuid import UUID
-pytestmark = [pytest.mark.skip_bigquery]  # TODO: BigQuery
 
 
 def test_defaults(db_params):
@@ -20,18 +19,19 @@ def test_defaults(db_params):
         s,
         expected_columns=['time_aggregation', 'unique_sessions'],
         expected_data=[
-            ['2021-11-29 10:23:36.286', 1],
-            ['2021-11-29 10:23:36.287', 1],
-            ['2021-11-30 10:23:36.267', 1],
-            ['2021-11-30 10:23:36.287', 1],
-            ['2021-11-30 10:23:36.290', 1],
-            ['2021-11-30 10:23:36.291', 1],
-            ['2021-12-01 10:23:36.276', 1],
-            ['2021-12-01 10:23:36.279', 1],
-            ['2021-12-02 10:23:36.281', 1],
-            ['2021-12-02 14:23:36.282', 1],
-            ['2021-12-03 10:23:36.283', 1]]
+            ['2021-11-29 10:23:36.286000', 1],
+            ['2021-11-29 10:23:36.287000', 1],
+            ['2021-11-30 10:23:36.267000', 1],
+            ['2021-11-30 10:23:36.287000', 1],
+            ['2021-11-30 10:23:36.290000', 1],
+            ['2021-11-30 10:23:36.291000', 1],
+            ['2021-12-01 10:23:36.276000', 1],
+            ['2021-12-01 10:23:36.279000', 1],
+            ['2021-12-02 10:23:36.281000', 1],
+            ['2021-12-02 14:23:36.282000', 1],
+            ['2021-12-03 10:23:36.283000', 1]]
     )
+
 
 def test_no_grouping(db_params):
     # not grouping to anything
@@ -46,9 +46,10 @@ def test_no_grouping(db_params):
         ]
     )
 
+
 def test_time_aggregation_in_df(db_params):
     # using time_aggregation (and default groupby: mh.time_agg(df, ))
-    df, modelhub = get_objectiv_dataframe_test(db_params, time_aggregation='YYYY-MM-DD')
+    df, modelhub = get_objectiv_dataframe_test(db_params, time_aggregation='%Y-%m-%d')
     s = modelhub.aggregate.unique_sessions(df)
 
     assert_equals_data(
@@ -61,10 +62,11 @@ def test_time_aggregation_in_df(db_params):
             ['2021-12-03', 1]]
     )
 
+
 def test_overriding_time_aggregation_in(db_params):
     # overriding time_aggregation
-    df, modelhub = get_objectiv_dataframe_test(db_params, time_aggregation='YYYY-MM-DD')
-    s = modelhub.aggregate.unique_sessions(df, groupby=modelhub.time_agg(df, 'YYYY-MM'))
+    df, modelhub = get_objectiv_dataframe_test(db_params, time_aggregation='%Y-%m-%d')
+    s = modelhub.aggregate.unique_sessions(df, groupby=modelhub.time_agg(df, '%Y-%m'))
 
     assert_equals_data(
         s,
@@ -73,9 +75,10 @@ def test_overriding_time_aggregation_in(db_params):
             ['2021-12', 4]]
     )
 
+
 def test_groupby(db_params):
     # group by other columns
-    df, modelhub = get_objectiv_dataframe_test(db_params, time_aggregation='YYYY-MM-DD')
+    df, modelhub = get_objectiv_dataframe_test(db_params, time_aggregation='%Y-%m-%d')
     s = modelhub.aggregate.unique_sessions(df, groupby='event_type')
 
     assert_equals_data(
@@ -84,10 +87,11 @@ def test_groupby(db_params):
         expected_data=[['ClickEvent', 7]]
     )
 
+
 def test_groupby_incl_time_agg(db_params):
     # group by other columns (as series), including time_agg
-    df, modelhub = get_objectiv_dataframe_test(db_params, time_aggregation='YYYY-MM-DD')
-    s = modelhub.aggregate.unique_sessions(df, groupby=[modelhub.time_agg(df, 'YYYY-MM'), df.user_id])
+    df, modelhub = get_objectiv_dataframe_test(db_params, time_aggregation='%Y-%m-%d')
+    s = modelhub.aggregate.unique_sessions(df, groupby=[modelhub.time_agg(df, '%Y-%m'), df.user_id])
 
     assert_equals_data(
         s,
@@ -102,9 +106,10 @@ def test_groupby_incl_time_agg(db_params):
         convert_uuid=True,
     )
 
+
 def test_groupby_illegal_column(db_params):
     # include column that is used for grouping in groupby
-    df, modelhub = get_objectiv_dataframe_test(db_params, time_aggregation='YYYY-MM-DD')
+    df, modelhub = get_objectiv_dataframe_test(db_params, time_aggregation='%Y-%m-%d')
     with pytest.raises(KeyError, match='is in groupby but is needed for aggregation: not allowed to '
                                          'group on that'):
-        modelhub.aggregate.unique_sessions(df, groupby=[modelhub.time_agg(df, 'YYYY-MM'), df.session_id])
+        modelhub.aggregate.unique_sessions(df, groupby=[modelhub.time_agg(df, '%Y-%m'), df.session_id])

--- a/modelhub/tests_modelhub/functional/modelhub/test_model_hub_unique_users.py
+++ b/modelhub/tests_modelhub/functional/modelhub/test_model_hub_unique_users.py
@@ -7,7 +7,6 @@ import pytest
 from modelhub import __version__
 from tests_modelhub.data_and_utils.utils import get_objectiv_dataframe_test
 from tests.functional.bach.test_data_and_utils import assert_equals_data
-pytestmark = [pytest.mark.skip_bigquery]  # TODO: BigQuery
 
 
 def test_defaults(db_params):
@@ -19,19 +18,20 @@ def test_defaults(db_params):
         s,
         expected_columns=['time_aggregation', 'unique_users'],
         expected_data=[
-            ['2021-11-29 10:23:36.286', 1],
-            ['2021-11-29 10:23:36.287', 1],
-            ['2021-11-30 10:23:36.267', 1],
-            ['2021-11-30 10:23:36.287', 1],
-            ['2021-11-30 10:23:36.290', 1],
-            ['2021-11-30 10:23:36.291', 1],
-            ['2021-12-01 10:23:36.276', 1],
-            ['2021-12-01 10:23:36.279', 1],
-            ['2021-12-02 10:23:36.281', 1],
-            ['2021-12-02 14:23:36.282', 1],
-            ['2021-12-03 10:23:36.283', 1]
+            ['2021-11-29 10:23:36.286000', 1],
+            ['2021-11-29 10:23:36.287000', 1],
+            ['2021-11-30 10:23:36.267000', 1],
+            ['2021-11-30 10:23:36.287000', 1],
+            ['2021-11-30 10:23:36.290000', 1],
+            ['2021-11-30 10:23:36.291000', 1],
+            ['2021-12-01 10:23:36.276000', 1],
+            ['2021-12-01 10:23:36.279000', 1],
+            ['2021-12-02 10:23:36.281000', 1],
+            ['2021-12-02 14:23:36.282000', 1],
+            ['2021-12-03 10:23:36.283000', 1]
         ]
     )
+
 
 def test_no_grouping(db_params):
     # not grouping to anything
@@ -46,9 +46,10 @@ def test_no_grouping(db_params):
         ]
     )
 
+
 def test_time_aggregation_in_df(db_params):
     # using time_aggregation (and default groupby: mh.time_agg())
-    df, modelhub = get_objectiv_dataframe_test(db_params, time_aggregation='YYYY-MM-DD')
+    df, modelhub = get_objectiv_dataframe_test(db_params, time_aggregation='%Y-%m-%d')
     s = modelhub.aggregate.unique_users(df)
 
     assert_equals_data(
@@ -63,10 +64,11 @@ def test_time_aggregation_in_df(db_params):
         ]
     )
 
+
 def test_overriding_time_aggregation_in(db_params):
     # overriding time_aggregation
-    df, modelhub = get_objectiv_dataframe_test(db_params, time_aggregation='YYYY-MM-DD')
-    s = modelhub.aggregate.unique_users(df, groupby=modelhub.time_agg(df, 'YYYY-MM'))
+    df, modelhub = get_objectiv_dataframe_test(db_params, time_aggregation='%Y-%m-%d')
+    s = modelhub.aggregate.unique_users(df, groupby=modelhub.time_agg(df, '%Y-%m'))
 
     assert_equals_data(
         s,
@@ -77,9 +79,10 @@ def test_overriding_time_aggregation_in(db_params):
         ]
     )
 
+
 def test_groupby(db_params):
     # group by other columns
-    df, modelhub = get_objectiv_dataframe_test(db_params, time_aggregation='YYYY-MM-DD')
+    df, modelhub = get_objectiv_dataframe_test(db_params, time_aggregation='%Y-%m-%d')
     s = modelhub.aggregate.unique_users(df, groupby='event_type')
 
     assert_equals_data(
@@ -88,10 +91,11 @@ def test_groupby(db_params):
         expected_data=[['ClickEvent', 4]]
     )
 
+
 def test_groupby_incl_time_agg(db_params):
     # group by other columns (as series), including time_agg
-    df, modelhub = get_objectiv_dataframe_test(db_params, time_aggregation='YYYY-MM-DD')
-    s = modelhub.aggregate.unique_users(df, groupby=[modelhub.time_agg(df, 'YYYY-MM'), df.session_id])
+    df, modelhub = get_objectiv_dataframe_test(db_params, time_aggregation='%Y-%m-%d')
+    s = modelhub.aggregate.unique_users(df, groupby=[modelhub.time_agg(df, '%Y-%m'), df.session_id])
 
     assert_equals_data(
         s,
@@ -108,9 +112,10 @@ def test_groupby_incl_time_agg(db_params):
 
     )
 
+
 def test_groupby_illegal_column(db_params):
     # include column that is used for grouping in groupby
-    df, modelhub = get_objectiv_dataframe_test(db_params, time_aggregation='YYYY-MM-DD')
+    df, modelhub = get_objectiv_dataframe_test(db_params, time_aggregation='%Y-%m-%d')
     with pytest.raises(KeyError, match='is in groupby but is needed for aggregation: not allowed to '
                                          'group on that'):
-        modelhub.aggregate.unique_users(df, groupby=[modelhub.time_agg(df, 'YYYY-MM'), df.user_id])
+        modelhub.aggregate.unique_users(df, groupby=[modelhub.time_agg(df, '%Y-%m'), df.user_id])

--- a/notebooks/basic-product-analytics.ipynb
+++ b/notebooks/basic-product-analytics.ipynb
@@ -3,7 +3,11 @@
   {
    "cell_type": "markdown",
    "id": "afb5dddf",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "This is one of the Objectiv example notebooks. For more examples visit the \n",
     "[example notebooks](https://objectiv.io/docs/modeling/example-notebooks/) section of our docs. The notebooks can run with the demo data set that comes with the our [quickstart](https://objectiv.io/docs/home/quickstart-guide/), but can be used to run on your own collected data as well.\n",
@@ -14,7 +18,11 @@
   {
    "cell_type": "markdown",
    "id": "990f0ae2-48cd-4220-8960-844af284fcce",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "# Basic product analytics"
    ]
@@ -22,7 +30,11 @@
   {
    "cell_type": "markdown",
    "id": "fc19e049-754f-4c0e-8a5a-0ff89bdb7724",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "In this notebook, we briefly demonstrate how you can easily do basic product analytics on your data."
    ]
@@ -30,7 +42,11 @@
   {
    "cell_type": "markdown",
    "id": "277e303e",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Getting started"
    ]
@@ -38,7 +54,11 @@
   {
    "cell_type": "markdown",
    "id": "96aeea32",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "### Import the required packages for this notebook\n",
     "The open model hub package can be installed with `pip install objectiv-modelhub` (this installs Bach as well).  \n",
@@ -49,7 +69,12 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "4bd369f6",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n",
+     "is_executing": true
+    }
+   },
    "outputs": [],
    "source": [
     "from modelhub import ModelHub\n",
@@ -59,7 +84,11 @@
   {
    "cell_type": "markdown",
    "id": "765624df",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "At first we have to instantiate the Objectiv DataFrame object and the model hub."
    ]
@@ -68,11 +97,15 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "da4ec1a0",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# instantiate the model hub and set the default time aggregation to daily\n",
-    "modelhub = ModelHub(time_aggregation='YYYY-MM-DD')\n",
+    "modelhub = ModelHub(time_aggregation='%Y-%m-%d')\n",
     "# get the Bach DataFrame with Objectiv data\n",
     "df = modelhub.get_objectiv_dataframe(start_date='2022-02-02')"
    ]
@@ -80,7 +113,11 @@
   {
    "cell_type": "markdown",
    "id": "a1b3f9b1",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "The columns 'global_contexts' and the 'location_stack' contain most of the event specific data. These columns\n",
     "are json type columns and we can extract data from it based on the keys of the json objects using `SeriesGlobalContexts` or `SeriesLocationStack` methods to extract the data."
@@ -90,7 +127,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "4e130b67",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# adding specific contexts to the data as columns\n",
@@ -109,7 +150,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "3c4ad65e",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# have a look at the data\n",
@@ -120,7 +165,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "38aa346a",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# explore the data with describe\n",
@@ -130,7 +179,11 @@
   {
    "cell_type": "markdown",
    "id": "a1ced327",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "Now we will go though a selection of basic analytics metrics. We can use models from the model hub for this purpose or use Bach to do data analysis directly on the data stored in the\n",
     "SQL database using pandas like syntax.\n",
@@ -142,7 +195,11 @@
   {
    "cell_type": "markdown",
    "id": "03bfa810",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Unique users\n",
     "The `daily_users` uses the `time_aggregation` as set when the model hub was instantiated. In this case the\n",
@@ -154,11 +211,15 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "08ad4e39",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# model hub: unique users, monthly\n",
-    "montly_users = modelhub.aggregate.unique_users(df, groupby=modelhub.time_agg(df, 'YYYY-MM'))\n",
+    "montly_users = modelhub.aggregate.unique_users(df, groupby=modelhub.time_agg(df, '%Y-%m'))\n",
     "montly_users.head()"
    ]
   },
@@ -166,7 +227,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "172f431c",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# model hub: unique users, daily\n",
@@ -178,7 +243,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "fec344a2",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "users_root = modelhub.aggregate.unique_users(df, groupby=['application', 'root_location'])\n",
@@ -188,7 +257,11 @@
   {
    "cell_type": "markdown",
    "id": "1a6de3da",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## User time spent\n",
     "Similarly we can calculate the average session duration for time intervals. `duration_root_month` gives the\n",
@@ -199,11 +272,15 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "5ad07abd-e62e-41d3-9033-cdacb906551f",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# model hub: duration, monthly average\n",
-    "duration_monthly = modelhub.aggregate.session_duration(df, groupby=modelhub.time_agg(df, 'YYYY-MM'))\n",
+    "duration_monthly = modelhub.aggregate.session_duration(df, groupby=modelhub.time_agg(df, '%Y-%m'))\n",
     "duration_monthly.sort_index(ascending=False).head()"
    ]
   },
@@ -211,7 +288,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "9fb041b2",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# model hub: duration, daily average\n",
@@ -223,11 +304,15 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "4f929f0a",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# model hub: duration, monthly average per root location\n",
-    "duration_root_month = modelhub.aggregate.session_duration(df, groupby=['application', 'root_location', modelhub.time_agg(df, 'YYYY-MM')]).sort_index()\n",
+    "duration_root_month = modelhub.aggregate.session_duration(df, groupby=['application', 'root_location', modelhub.time_agg(df, '%Y-%m')]).sort_index()\n",
     "duration_root_month.head(10)"
    ]
   },
@@ -235,7 +320,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "8e2c4158",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# how is this time spent distributed?\n",
@@ -247,7 +336,11 @@
   {
    "cell_type": "markdown",
    "id": "c0e6a29a",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Top used product features"
    ]
@@ -255,7 +348,11 @@
   {
    "cell_type": "markdown",
    "id": "58e63222",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "Let's get the top used features in the product by our users, for that we can call the `top_product_features` function from the model hub. "
    ]
@@ -264,7 +361,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a19d8210",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# by default we select only user actions\n",
@@ -275,7 +376,11 @@
   {
    "cell_type": "markdown",
    "id": "dcf82009",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Top used product areas\n",
     "First we use the model hub to get the unique users per application, root location, feature, and event type.\n",
@@ -286,7 +391,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a757be5a",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# select only user actions, so stack_event_types must be a superset of ['InteractiveEvent']\n",
@@ -300,7 +409,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "3ba9b3cf",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "home_users = top_interactions[(top_interactions.application == 'objectiv-website') &\n",
@@ -311,7 +424,11 @@
   {
    "cell_type": "markdown",
    "id": "e9e5de5a",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "From the same `top_interactions` object, we can select the top interactions for the 'docs' page."
    ]
@@ -320,7 +437,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "3f8c4ae0",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "docs_users = top_interactions[top_interactions.application == 'objectiv-docs']\n",
@@ -330,7 +451,11 @@
   {
    "cell_type": "markdown",
    "id": "eb7374f3",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## User origin"
    ]
@@ -339,7 +464,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "6aa28364",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# users by referrer\n",
@@ -349,7 +478,11 @@
   {
    "cell_type": "markdown",
    "id": "f0bdf159",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Marketing\n",
     "Calculate the number of users per campaign."
@@ -359,7 +492,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "d60fe2d6",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# users by marketing campaign\n",
@@ -372,7 +509,11 @@
   {
    "cell_type": "markdown",
    "id": "59bb032a",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "Look at top used features by campaign, using the previously created interactive_events to focus just on user\n",
     "interactions."
@@ -382,7 +523,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "c701379c",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# users by feature per campaign source & term\n",
@@ -395,7 +540,11 @@
   {
    "cell_type": "markdown",
    "id": "3bda262d",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Conversions\n",
     "First we define a conversion event in the Objectiv DataFrame."
@@ -406,7 +555,10 @@
    "execution_count": null,
    "id": "897180ac",
    "metadata": {
-    "scrolled": true
+    "scrolled": true,
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -421,7 +573,11 @@
   {
    "cell_type": "markdown",
    "id": "b8fd7827",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "This can be used by several models from the model hub using the defined name ('github_press'). First we calculate\n",
     "the number of unique converted users."
@@ -431,7 +587,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "f4f6f7e7",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# model hub: calculate conversions\n",
@@ -443,7 +603,11 @@
   {
    "cell_type": "markdown",
    "id": "6ee9995c",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "We use the earlier created `daily_users` to calculate the daily conversion rate."
    ]
@@ -452,7 +616,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "f4fa4649-1300-4647-bd67-616e95bc96d6",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# calculate conversion rate\n",
@@ -463,7 +631,11 @@
   {
    "cell_type": "markdown",
    "id": "cbc4e9a4",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "From where do users convert most?"
    ]
@@ -472,7 +644,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "88a0e85b",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "conversion_locations = modelhub.agg.unique_users(df[df.is_conversion_event], \n",
@@ -485,7 +661,11 @@
   {
    "cell_type": "markdown",
    "id": "eeb9e9d4",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "We can calculate what users did _before_ converting."
    ]
@@ -494,7 +674,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "b6762c39",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "top_features_before_conversion = modelhub.agg.top_product_features_before_conversion(df, name='github_press')\n",
@@ -504,7 +688,11 @@
   {
    "cell_type": "markdown",
    "id": "fb84157f",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "At last we want to know how much time users that converted spent on our site before they converted."
    ]
@@ -513,7 +701,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "191ead42",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# label sessions with a conversion\n",
@@ -532,7 +724,11 @@
   {
    "cell_type": "markdown",
    "id": "c4b5b4d2-d72b-4f10-9702-afe22015b74f",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Get the SQL for any analysis"
    ]
@@ -541,7 +737,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "3503632c-bd17-462f-a7e2-9b27a390c673",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# just one analysis as an example, this works for anything you do with Objectiv Bach\n",

--- a/notebooks/basic-product-analytics.ipynb
+++ b/notebooks/basic-product-analytics.ipynb
@@ -3,11 +3,7 @@
   {
    "cell_type": "markdown",
    "id": "afb5dddf",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "This is one of the Objectiv example notebooks. For more examples visit the \n",
     "[example notebooks](https://objectiv.io/docs/modeling/example-notebooks/) section of our docs. The notebooks can run with the demo data set that comes with the our [quickstart](https://objectiv.io/docs/home/quickstart-guide/), but can be used to run on your own collected data as well.\n",
@@ -18,11 +14,7 @@
   {
    "cell_type": "markdown",
    "id": "990f0ae2-48cd-4220-8960-844af284fcce",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "# Basic product analytics"
    ]
@@ -30,11 +22,7 @@
   {
    "cell_type": "markdown",
    "id": "fc19e049-754f-4c0e-8a5a-0ff89bdb7724",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "In this notebook, we briefly demonstrate how you can easily do basic product analytics on your data."
    ]
@@ -42,11 +30,7 @@
   {
    "cell_type": "markdown",
    "id": "277e303e",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "## Getting started"
    ]
@@ -54,11 +38,7 @@
   {
    "cell_type": "markdown",
    "id": "96aeea32",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "### Import the required packages for this notebook\n",
     "The open model hub package can be installed with `pip install objectiv-modelhub` (this installs Bach as well).  \n",
@@ -69,12 +49,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "4bd369f6",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n",
-     "is_executing": true
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from modelhub import ModelHub\n",
@@ -84,11 +59,7 @@
   {
    "cell_type": "markdown",
    "id": "765624df",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "At first we have to instantiate the Objectiv DataFrame object and the model hub."
    ]
@@ -97,11 +68,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "da4ec1a0",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# instantiate the model hub and set the default time aggregation to daily\n",
@@ -113,11 +80,7 @@
   {
    "cell_type": "markdown",
    "id": "a1b3f9b1",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "The columns 'global_contexts' and the 'location_stack' contain most of the event specific data. These columns\n",
     "are json type columns and we can extract data from it based on the keys of the json objects using `SeriesGlobalContexts` or `SeriesLocationStack` methods to extract the data."
@@ -127,11 +90,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "4e130b67",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# adding specific contexts to the data as columns\n",
@@ -150,11 +109,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "3c4ad65e",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# have a look at the data\n",
@@ -165,11 +120,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "38aa346a",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# explore the data with describe\n",
@@ -179,11 +130,7 @@
   {
    "cell_type": "markdown",
    "id": "a1ced327",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "Now we will go though a selection of basic analytics metrics. We can use models from the model hub for this purpose or use Bach to do data analysis directly on the data stored in the\n",
     "SQL database using pandas like syntax.\n",
@@ -195,11 +142,7 @@
   {
    "cell_type": "markdown",
    "id": "03bfa810",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "## Unique users\n",
     "The `daily_users` uses the `time_aggregation` as set when the model hub was instantiated. In this case the\n",
@@ -211,11 +154,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "08ad4e39",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# model hub: unique users, monthly\n",
@@ -227,11 +166,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "172f431c",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# model hub: unique users, daily\n",
@@ -243,11 +178,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "fec344a2",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "users_root = modelhub.aggregate.unique_users(df, groupby=['application', 'root_location'])\n",
@@ -257,11 +188,7 @@
   {
    "cell_type": "markdown",
    "id": "1a6de3da",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "## User time spent\n",
     "Similarly we can calculate the average session duration for time intervals. `duration_root_month` gives the\n",
@@ -272,11 +199,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "5ad07abd-e62e-41d3-9033-cdacb906551f",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# model hub: duration, monthly average\n",
@@ -288,11 +211,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "9fb041b2",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# model hub: duration, daily average\n",
@@ -304,11 +223,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "4f929f0a",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# model hub: duration, monthly average per root location\n",
@@ -320,11 +235,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "8e2c4158",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# how is this time spent distributed?\n",
@@ -336,11 +247,7 @@
   {
    "cell_type": "markdown",
    "id": "c0e6a29a",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "## Top used product features"
    ]
@@ -348,11 +255,7 @@
   {
    "cell_type": "markdown",
    "id": "58e63222",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "Let's get the top used features in the product by our users, for that we can call the `top_product_features` function from the model hub. "
    ]
@@ -361,11 +264,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a19d8210",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# by default we select only user actions\n",
@@ -376,11 +275,7 @@
   {
    "cell_type": "markdown",
    "id": "dcf82009",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "## Top used product areas\n",
     "First we use the model hub to get the unique users per application, root location, feature, and event type.\n",
@@ -391,11 +286,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a757be5a",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# select only user actions, so stack_event_types must be a superset of ['InteractiveEvent']\n",
@@ -409,11 +300,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "3ba9b3cf",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "home_users = top_interactions[(top_interactions.application == 'objectiv-website') &\n",
@@ -424,11 +311,7 @@
   {
    "cell_type": "markdown",
    "id": "e9e5de5a",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "From the same `top_interactions` object, we can select the top interactions for the 'docs' page."
    ]
@@ -437,11 +320,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "3f8c4ae0",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "docs_users = top_interactions[top_interactions.application == 'objectiv-docs']\n",
@@ -451,11 +330,7 @@
   {
    "cell_type": "markdown",
    "id": "eb7374f3",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "## User origin"
    ]
@@ -464,11 +339,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "6aa28364",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# users by referrer\n",
@@ -478,11 +349,7 @@
   {
    "cell_type": "markdown",
    "id": "f0bdf159",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "## Marketing\n",
     "Calculate the number of users per campaign."
@@ -492,11 +359,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "d60fe2d6",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# users by marketing campaign\n",
@@ -509,11 +372,7 @@
   {
    "cell_type": "markdown",
    "id": "59bb032a",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "Look at top used features by campaign, using the previously created interactive_events to focus just on user\n",
     "interactions."
@@ -523,11 +382,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "c701379c",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# users by feature per campaign source & term\n",
@@ -540,11 +395,7 @@
   {
    "cell_type": "markdown",
    "id": "3bda262d",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "## Conversions\n",
     "First we define a conversion event in the Objectiv DataFrame."
@@ -555,10 +406,7 @@
    "execution_count": null,
    "id": "897180ac",
    "metadata": {
-    "scrolled": true,
-    "pycharm": {
-     "name": "#%%\n"
-    }
+    "scrolled": true
    },
    "outputs": [],
    "source": [
@@ -573,11 +421,7 @@
   {
    "cell_type": "markdown",
    "id": "b8fd7827",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "This can be used by several models from the model hub using the defined name ('github_press'). First we calculate\n",
     "the number of unique converted users."
@@ -587,11 +431,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "f4f6f7e7",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# model hub: calculate conversions\n",
@@ -603,11 +443,7 @@
   {
    "cell_type": "markdown",
    "id": "6ee9995c",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "We use the earlier created `daily_users` to calculate the daily conversion rate."
    ]
@@ -616,11 +452,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "f4fa4649-1300-4647-bd67-616e95bc96d6",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# calculate conversion rate\n",
@@ -631,11 +463,7 @@
   {
    "cell_type": "markdown",
    "id": "cbc4e9a4",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "From where do users convert most?"
    ]
@@ -644,11 +472,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "88a0e85b",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "conversion_locations = modelhub.agg.unique_users(df[df.is_conversion_event], \n",
@@ -661,11 +485,7 @@
   {
    "cell_type": "markdown",
    "id": "eeb9e9d4",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "We can calculate what users did _before_ converting."
    ]
@@ -674,11 +494,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "b6762c39",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "top_features_before_conversion = modelhub.agg.top_product_features_before_conversion(df, name='github_press')\n",
@@ -688,11 +504,7 @@
   {
    "cell_type": "markdown",
    "id": "fb84157f",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "At last we want to know how much time users that converted spent on our site before they converted."
    ]
@@ -701,11 +513,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "191ead42",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# label sessions with a conversion\n",
@@ -724,11 +532,7 @@
   {
    "cell_type": "markdown",
    "id": "c4b5b4d2-d72b-4f10-9702-afe22015b74f",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "## Get the SQL for any analysis"
    ]
@@ -737,11 +541,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "3503632c-bd17-462f-a7e2-9b27a390c673",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# just one analysis as an example, this works for anything you do with Objectiv Bach\n",

--- a/notebooks/basic-user-intent.ipynb
+++ b/notebooks/basic-user-intent.ipynb
@@ -3,7 +3,11 @@
   {
    "cell_type": "markdown",
    "id": "afb5dddf",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "This is one of the Objectiv example notebooks. For more examples visit the \n",
     "[example notebooks](https://objectiv.io/docs/modeling/example-notebooks/) section of our docs. The notebooks can run with the demo data set that comes with the our [quickstart](https://objectiv.io/docs/home/quickstart-guide/), but can be used to run on your own collected data as well.\n",
@@ -14,7 +18,11 @@
   {
    "cell_type": "markdown",
    "id": "990f0ae2-48cd-4220-8960-844af284fcce",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "# Basic user intent analysis"
    ]
@@ -22,7 +30,11 @@
   {
    "cell_type": "markdown",
    "id": "fc19e049-754f-4c0e-8a5a-0ff89bdb7724",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "In this notebook, we briefly demonstrate how you can easily do basic user intent analysis on your data."
    ]
@@ -30,7 +42,11 @@
   {
    "cell_type": "markdown",
    "id": "277e303e",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Getting started"
    ]
@@ -38,7 +54,11 @@
   {
    "cell_type": "markdown",
    "id": "96aeea32",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "### Import the required packages for this notebook\n",
     "The open model hub package can be installed with `pip install objectiv-modelhub` (this installs Bach as well).  \n",
@@ -49,7 +69,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "4bd369f6",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "from modelhub import ModelHub\n",
@@ -62,7 +86,11 @@
   {
    "cell_type": "markdown",
    "id": "765624df",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "At first we have to instantiate the Objectiv DataFrame object and the model hub."
    ]
@@ -71,11 +99,15 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "da4ec1a0",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# instantiate the model hub and set the default time aggregation to daily\n",
-    "modelhub = ModelHub(time_aggregation='YYYY-MM-DD')\n",
+    "modelhub = ModelHub(time_aggregation='%Y-%m-%d')\n",
     "\n",
     "# get the Bach DataFrame with Objectiv data\n",
     "df = modelhub.get_objectiv_dataframe(start_date='2022-02-01')"
@@ -84,7 +116,11 @@
   {
    "cell_type": "markdown",
    "id": "a1b3f9b1",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "The columns 'global_contexts' and the 'location_stack' contain most of the event specific data. These columns\n",
     "are json type columns and we can extract data from it based on the keys of the json objects using `SeriesGlobalContexts` or `SeriesLocationStack` methods to extract the data."
@@ -94,7 +130,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "4e130b67",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# adding specific contexts to the data as columns\n",
@@ -105,7 +145,11 @@
   {
    "cell_type": "markdown",
    "id": "03bfa810",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Exploring root location\n",
     "The `root_location` context in the `location_stack` uniquely represents the top-level UI location of the user. As a first step of grasping user intent, this is a good starting point to see in what main areas of your product users are spending time."
@@ -115,7 +159,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "08ad4e39",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# model hub: unique users per root location\n",
@@ -126,7 +174,11 @@
   {
    "cell_type": "markdown",
    "id": "0bd73ca7-5e52-4484-b88d-a7a41d63adcb",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Exploring session duration\n",
     "The average `session_duration` model from the [open model hub](https://objectiv.io/docs/modeling/open-model-hub/) is\n",
@@ -137,7 +189,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "ec9657db-fb10-4e96-9eb0-9cb16437cade",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# model hub: duration, per root location\n",
@@ -149,7 +205,10 @@
    "cell_type": "markdown",
    "id": "6fe1a096-9221-4f9f-99b6-79747c136d66",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%% md\n"
+    }
    },
    "source": [
     "Now, we can look at the distribution of time spent. We used the Bach `quantile` operation for this. We'll use this distribution to define the different stages of user intent.  "
@@ -159,7 +218,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "1de87738",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# how is this time spent distributed?\n",
@@ -174,7 +237,11 @@
   {
    "cell_type": "markdown",
    "id": "aaa5a8f8-a7d4-4d50-b096-6af94421d802",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Defining different stages of user intent\n",
     "After exploring the `root_location` and `session_duration` (both per root location and quantiles), we can make a simple definition of different stages of user intent.\n",
@@ -196,7 +263,11 @@
   {
    "cell_type": "markdown",
    "id": "9fcd02ca-a9d4-4abe-96c9-c91ff167eb5d",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Assigning user intent\n",
     "Based on the definitions above, we can start assigning a stage of intent to each user. "
@@ -206,7 +277,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "dc42e571",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# set the root locations that we will use based on the definitions above\n",
@@ -219,7 +294,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "7fed9432",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# now we calculate the total time spent per _user_ and create a data frame from it\n",
@@ -233,7 +312,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "1a50c279",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# same as above, but for selected roots only\n",
@@ -248,7 +331,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "b00895a2",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# first, we set the Inform bucket as a catch-all, meaning users that do not fall into Explore and Implement will be defined as Inform\n",
@@ -259,7 +346,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "bb0d48e3",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# calculate buckets duration\n",
@@ -272,7 +363,11 @@
   {
    "cell_type": "markdown",
    "id": "47be4fdb-0995-4b27-bcfd-ed609eb0ca30",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "Now, we have assigned intent to each user and can for example look at the total number of users per intent bucket."
    ]
@@ -281,7 +376,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "d3537636",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# total number of users per intent bucket\n",
@@ -291,7 +390,11 @@
   {
    "cell_type": "markdown",
    "id": "aad18c25-b061-4790-9ce7-a7f633db2002",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## What's next?"
    ]
@@ -299,7 +402,11 @@
   {
    "cell_type": "markdown",
    "id": "a3c12031-e59c-4ddf-ad4e-b1239172e08e",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "The are many next possible analysis steps, for example:\n",
     "- What product features do each of the intent groups use? \n",
@@ -313,7 +420,10 @@
    "cell_type": "markdown",
    "id": "104eb315-83b7-4848-ab44-49c0f9478a66",
    "metadata": {
-    "tags": []
+    "tags": [],
+    "pycharm": {
+     "name": "#%% md\n"
+    }
    },
    "source": [
     "## Get the SQL for this user intent analysis"
@@ -323,7 +433,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e38addad-ba20-4a71-9cac-68f2dd077a25",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# get the SQL to use this analysis in for example your BI tooling\n",

--- a/notebooks/basic-user-intent.ipynb
+++ b/notebooks/basic-user-intent.ipynb
@@ -3,11 +3,7 @@
   {
    "cell_type": "markdown",
    "id": "afb5dddf",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "This is one of the Objectiv example notebooks. For more examples visit the \n",
     "[example notebooks](https://objectiv.io/docs/modeling/example-notebooks/) section of our docs. The notebooks can run with the demo data set that comes with the our [quickstart](https://objectiv.io/docs/home/quickstart-guide/), but can be used to run on your own collected data as well.\n",
@@ -18,11 +14,7 @@
   {
    "cell_type": "markdown",
    "id": "990f0ae2-48cd-4220-8960-844af284fcce",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "# Basic user intent analysis"
    ]
@@ -30,11 +22,7 @@
   {
    "cell_type": "markdown",
    "id": "fc19e049-754f-4c0e-8a5a-0ff89bdb7724",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "In this notebook, we briefly demonstrate how you can easily do basic user intent analysis on your data."
    ]
@@ -42,11 +30,7 @@
   {
    "cell_type": "markdown",
    "id": "277e303e",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "## Getting started"
    ]
@@ -54,11 +38,7 @@
   {
    "cell_type": "markdown",
    "id": "96aeea32",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "### Import the required packages for this notebook\n",
     "The open model hub package can be installed with `pip install objectiv-modelhub` (this installs Bach as well).  \n",
@@ -69,11 +49,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "4bd369f6",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from modelhub import ModelHub\n",
@@ -86,11 +62,7 @@
   {
    "cell_type": "markdown",
    "id": "765624df",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "At first we have to instantiate the Objectiv DataFrame object and the model hub."
    ]
@@ -99,11 +71,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "da4ec1a0",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# instantiate the model hub and set the default time aggregation to daily\n",
@@ -116,11 +84,7 @@
   {
    "cell_type": "markdown",
    "id": "a1b3f9b1",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "The columns 'global_contexts' and the 'location_stack' contain most of the event specific data. These columns\n",
     "are json type columns and we can extract data from it based on the keys of the json objects using `SeriesGlobalContexts` or `SeriesLocationStack` methods to extract the data."
@@ -130,11 +94,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "4e130b67",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# adding specific contexts to the data as columns\n",
@@ -145,11 +105,7 @@
   {
    "cell_type": "markdown",
    "id": "03bfa810",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "## Exploring root location\n",
     "The `root_location` context in the `location_stack` uniquely represents the top-level UI location of the user. As a first step of grasping user intent, this is a good starting point to see in what main areas of your product users are spending time."
@@ -159,11 +115,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "08ad4e39",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# model hub: unique users per root location\n",
@@ -174,11 +126,7 @@
   {
    "cell_type": "markdown",
    "id": "0bd73ca7-5e52-4484-b88d-a7a41d63adcb",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "## Exploring session duration\n",
     "The average `session_duration` model from the [open model hub](https://objectiv.io/docs/modeling/open-model-hub/) is\n",
@@ -189,11 +137,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "ec9657db-fb10-4e96-9eb0-9cb16437cade",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# model hub: duration, per root location\n",
@@ -205,10 +149,7 @@
    "cell_type": "markdown",
    "id": "6fe1a096-9221-4f9f-99b6-79747c136d66",
    "metadata": {
-    "tags": [],
-    "pycharm": {
-     "name": "#%% md\n"
-    }
+    "tags": []
    },
    "source": [
     "Now, we can look at the distribution of time spent. We used the Bach `quantile` operation for this. We'll use this distribution to define the different stages of user intent.  "
@@ -218,11 +159,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "1de87738",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# how is this time spent distributed?\n",
@@ -237,11 +174,7 @@
   {
    "cell_type": "markdown",
    "id": "aaa5a8f8-a7d4-4d50-b096-6af94421d802",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "## Defining different stages of user intent\n",
     "After exploring the `root_location` and `session_duration` (both per root location and quantiles), we can make a simple definition of different stages of user intent.\n",
@@ -263,11 +196,7 @@
   {
    "cell_type": "markdown",
    "id": "9fcd02ca-a9d4-4abe-96c9-c91ff167eb5d",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "## Assigning user intent\n",
     "Based on the definitions above, we can start assigning a stage of intent to each user. "
@@ -277,11 +206,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "dc42e571",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# set the root locations that we will use based on the definitions above\n",
@@ -294,11 +219,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "7fed9432",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# now we calculate the total time spent per _user_ and create a data frame from it\n",
@@ -312,11 +233,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "1a50c279",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# same as above, but for selected roots only\n",
@@ -331,11 +248,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "b00895a2",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# first, we set the Inform bucket as a catch-all, meaning users that do not fall into Explore and Implement will be defined as Inform\n",
@@ -346,11 +259,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "bb0d48e3",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# calculate buckets duration\n",
@@ -363,11 +272,7 @@
   {
    "cell_type": "markdown",
    "id": "47be4fdb-0995-4b27-bcfd-ed609eb0ca30",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "Now, we have assigned intent to each user and can for example look at the total number of users per intent bucket."
    ]
@@ -376,11 +281,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "d3537636",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# total number of users per intent bucket\n",
@@ -390,11 +291,7 @@
   {
    "cell_type": "markdown",
    "id": "aad18c25-b061-4790-9ce7-a7f633db2002",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "## What's next?"
    ]
@@ -402,11 +299,7 @@
   {
    "cell_type": "markdown",
    "id": "a3c12031-e59c-4ddf-ad4e-b1239172e08e",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "The are many next possible analysis steps, for example:\n",
     "- What product features do each of the intent groups use? \n",
@@ -420,10 +313,7 @@
    "cell_type": "markdown",
    "id": "104eb315-83b7-4848-ab44-49c0f9478a66",
    "metadata": {
-    "tags": [],
-    "pycharm": {
-     "name": "#%% md\n"
-    }
+    "tags": []
    },
    "source": [
     "## Get the SQL for this user intent analysis"
@@ -433,11 +323,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e38addad-ba20-4a71-9cac-68f2dd077a25",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# get the SQL to use this analysis in for example your BI tooling\n",

--- a/notebooks/feature-engineering.ipynb
+++ b/notebooks/feature-engineering.ipynb
@@ -3,7 +3,11 @@
   {
    "cell_type": "markdown",
    "id": "8d73f976",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "This is one of the Objectiv example notebooks. For more examples visit the \n",
     "[example notebooks](https://objectiv.io/docs/modeling/example-notebooks/) section of our docs. The notebooks can run with the demo data set that comes with the our [quickstart](https://objectiv.io/docs/home/quickstart-guide/), but can be used to run on your own collected data as well.\n",
@@ -14,7 +18,11 @@
   {
    "cell_type": "markdown",
    "id": "0371a170",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "This example shows how Bach can be used for feature engineering. We'll go through describing the data, finding\n",
     "outliers, transforming data and grouping and aggregating data so that a useful feature set is created that\n",
@@ -25,7 +33,11 @@
   {
    "cell_type": "markdown",
    "id": "26b3e3ad",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "### Import the required packages for this notebook\n",
     "The open model hub package can be installed with `pip install objectiv-modelhub` (this installs Bach as well).  \n",
@@ -36,7 +48,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e97ff289",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "from modelhub import ModelHub\n",
@@ -47,7 +63,11 @@
   {
    "cell_type": "markdown",
    "id": "554bcb44",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "At first we have to instantiate the Objectiv DataFrame object and the model hub."
    ]
@@ -56,11 +76,15 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "d582b77f",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# instantiate the model hub\n",
-    "modelhub = ModelHub(time_aggregation='YYYY-MM-DD')\n",
+    "modelhub = ModelHub(time_aggregation='%Y-%m-%d')\n",
     "# get the Bach DataFrame with Objectiv data\n",
     "df = modelhub.get_objectiv_dataframe(start_date='2022-02-02')"
    ]
@@ -68,7 +92,11 @@
   {
    "cell_type": "markdown",
    "id": "3c97f188",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "### describe all data"
    ]
@@ -78,7 +106,10 @@
    "execution_count": null,
    "id": "e76ac10d",
    "metadata": {
-    "scrolled": true
+    "scrolled": true,
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -88,7 +119,11 @@
   {
    "cell_type": "markdown",
    "id": "746c05af",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "We start with showing the first couple of rows from the data set and describing the entire data set."
    ]
@@ -97,7 +132,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "cce4ef5a",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "df.head()"
@@ -106,7 +145,11 @@
   {
    "cell_type": "markdown",
    "id": "ce646300",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "Columns of interest are 'user_id', this is what we will aggregate to. 'moment' contains timestamp info for the\n",
     "events. 'global_contexts' and the 'location_stack' contain most of the event specific data."
@@ -116,7 +159,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "8aa95ea4",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "df.describe(include='all').head()"
@@ -125,7 +172,11 @@
   {
    "cell_type": "markdown",
    "id": "bbffda98",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "### Creating a feature set \n",
     "We'd like to create a feature set that describes the behaviour of users in a way. We start with extracting\n",
@@ -137,7 +188,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "3b6aefac",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "df['root'] = df.location_stack.ls.get_from_context_with_type_series(type='RootLocationContext', key='id')\n",
@@ -147,7 +202,11 @@
   {
    "cell_type": "markdown",
    "id": "86e7a96b",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "`['jobs', 'docs', 'home'...]` etc is returned, the sections of the objectiv.io website."
    ]
@@ -155,7 +214,11 @@
   {
    "cell_type": "markdown",
    "id": "ec39a5b2",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "### check missing values"
    ]
@@ -164,7 +227,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "749077bb",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "df.root.isnull().value_counts().head()"
@@ -173,7 +240,11 @@
   {
    "cell_type": "markdown",
    "id": "c6a7dfd2",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "A quick check learns us that there are no missing values to worry about. Now we want a data set with\n",
     "interactions on our different sections, in particular, presses. This is an event type. We first want an\n",
@@ -184,7 +255,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "380b60b4",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "df.event_type.unique().to_numpy()"
@@ -194,7 +269,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "33ad2374",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "df[(df.event_type=='PressEvent')].root.unique().to_numpy()"
@@ -204,7 +283,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "763b738e",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "df[(df.event_type=='PressEvent')].describe(include='string').head()"
@@ -213,7 +296,11 @@
   {
    "cell_type": "markdown",
    "id": "4406a7a3",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "### Creating the variables\n",
     "We are interested in 'PressEvent'. The next code block shows that we select only press events and then group\n",
@@ -226,7 +313,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "83127b2b",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "features = df[(df.event_type=='PressEvent')].groupby(['user_id','root']).session_hit_number.count()"
@@ -236,7 +327,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "7151b993",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "features_unstacked = features.unstack()"
@@ -246,7 +341,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "78ba9cb3",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "features_unstacked.materialize().describe().head()"
@@ -256,7 +355,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "f20c9553",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "features_unstacked.head()"
@@ -265,7 +368,11 @@
   {
    "cell_type": "markdown",
    "id": "804874af",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "### Fill empty values\n",
     "Now we do have empty values, so we fill them with 0, as empty means that the user did not click in the\n",
@@ -276,7 +383,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "b13a2406",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "features_unstacked = features.unstack(fill_value=0)"
@@ -285,7 +396,11 @@
   {
    "cell_type": "markdown",
    "id": "3917a31d",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "### Describe the data set\n",
     "We use describe again to get an impression of out created per-user data set."
@@ -295,7 +410,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "3536706e",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "features_unstacked.materialize().describe().head()"
@@ -304,7 +423,11 @@
   {
    "cell_type": "markdown",
    "id": "17432bf5",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "Looking at the mean, some sections seem to be used a lot more than others. Also the max\n",
     "number of clicks seems quite different per root section. This information can be used to drop some of the\n",
@@ -314,7 +437,11 @@
   {
    "cell_type": "markdown",
    "id": "31d779c8",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "### Visualize the data"
    ]
@@ -323,7 +450,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "6b8306ad",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "figure, axis = plt.subplots(2, 4,figsize=(15,10))\n",
@@ -337,7 +468,11 @@
   {
    "cell_type": "markdown",
    "id": "518c590e",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "The histograms show that indeed the higher values seem quite anomalous for most of the root locations. This\n",
     "could be a reason to drop some of these observations or resort to scaling methods. For now we continue with\n",
@@ -347,7 +482,11 @@
   {
    "cell_type": "markdown",
    "id": "e796d882",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "### Add time feature\n",
     "Now we want to add some time feature to our data set. We add the average session length per user to the data\n",
@@ -358,7 +497,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "bced215a",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "import datetime\n",
@@ -370,7 +513,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e0d7e29b",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "features_unstacked.session_duration.describe().head()"
@@ -379,7 +526,11 @@
   {
    "cell_type": "markdown",
    "id": "2a771131",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "### Export to pandas for sklearn\n",
     "Now that we have our data set, we can use it for machine learning, using for example sklearn. To do so\n",
@@ -392,7 +543,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "1d14b11d",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "pdf = features_unstacked.to_pandas()"
@@ -402,7 +557,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "123e667a",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "pdf"

--- a/notebooks/feature-engineering.ipynb
+++ b/notebooks/feature-engineering.ipynb
@@ -3,11 +3,7 @@
   {
    "cell_type": "markdown",
    "id": "8d73f976",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "This is one of the Objectiv example notebooks. For more examples visit the \n",
     "[example notebooks](https://objectiv.io/docs/modeling/example-notebooks/) section of our docs. The notebooks can run with the demo data set that comes with the our [quickstart](https://objectiv.io/docs/home/quickstart-guide/), but can be used to run on your own collected data as well.\n",
@@ -18,11 +14,7 @@
   {
    "cell_type": "markdown",
    "id": "0371a170",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "This example shows how Bach can be used for feature engineering. We'll go through describing the data, finding\n",
     "outliers, transforming data and grouping and aggregating data so that a useful feature set is created that\n",
@@ -33,11 +25,7 @@
   {
    "cell_type": "markdown",
    "id": "26b3e3ad",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "### Import the required packages for this notebook\n",
     "The open model hub package can be installed with `pip install objectiv-modelhub` (this installs Bach as well).  \n",
@@ -48,11 +36,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e97ff289",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from modelhub import ModelHub\n",
@@ -63,11 +47,7 @@
   {
    "cell_type": "markdown",
    "id": "554bcb44",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "At first we have to instantiate the Objectiv DataFrame object and the model hub."
    ]
@@ -76,11 +56,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "d582b77f",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# instantiate the model hub\n",
@@ -92,11 +68,7 @@
   {
    "cell_type": "markdown",
    "id": "3c97f188",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "### describe all data"
    ]
@@ -106,10 +78,7 @@
    "execution_count": null,
    "id": "e76ac10d",
    "metadata": {
-    "scrolled": true,
-    "pycharm": {
-     "name": "#%%\n"
-    }
+    "scrolled": true
    },
    "outputs": [],
    "source": [
@@ -119,11 +88,7 @@
   {
    "cell_type": "markdown",
    "id": "746c05af",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "We start with showing the first couple of rows from the data set and describing the entire data set."
    ]
@@ -132,11 +97,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "cce4ef5a",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "df.head()"
@@ -145,11 +106,7 @@
   {
    "cell_type": "markdown",
    "id": "ce646300",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "Columns of interest are 'user_id', this is what we will aggregate to. 'moment' contains timestamp info for the\n",
     "events. 'global_contexts' and the 'location_stack' contain most of the event specific data."
@@ -159,11 +116,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "8aa95ea4",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "df.describe(include='all').head()"
@@ -172,11 +125,7 @@
   {
    "cell_type": "markdown",
    "id": "bbffda98",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "### Creating a feature set \n",
     "We'd like to create a feature set that describes the behaviour of users in a way. We start with extracting\n",
@@ -188,11 +137,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "3b6aefac",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "df['root'] = df.location_stack.ls.get_from_context_with_type_series(type='RootLocationContext', key='id')\n",
@@ -202,11 +147,7 @@
   {
    "cell_type": "markdown",
    "id": "86e7a96b",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "`['jobs', 'docs', 'home'...]` etc is returned, the sections of the objectiv.io website."
    ]
@@ -214,11 +155,7 @@
   {
    "cell_type": "markdown",
    "id": "ec39a5b2",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "### check missing values"
    ]
@@ -227,11 +164,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "749077bb",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "df.root.isnull().value_counts().head()"
@@ -240,11 +173,7 @@
   {
    "cell_type": "markdown",
    "id": "c6a7dfd2",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "A quick check learns us that there are no missing values to worry about. Now we want a data set with\n",
     "interactions on our different sections, in particular, presses. This is an event type. We first want an\n",
@@ -255,11 +184,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "380b60b4",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "df.event_type.unique().to_numpy()"
@@ -269,11 +194,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "33ad2374",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "df[(df.event_type=='PressEvent')].root.unique().to_numpy()"
@@ -283,11 +204,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "763b738e",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "df[(df.event_type=='PressEvent')].describe(include='string').head()"
@@ -296,11 +213,7 @@
   {
    "cell_type": "markdown",
    "id": "4406a7a3",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "### Creating the variables\n",
     "We are interested in 'PressEvent'. The next code block shows that we select only press events and then group\n",
@@ -313,11 +226,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "83127b2b",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "features = df[(df.event_type=='PressEvent')].groupby(['user_id','root']).session_hit_number.count()"
@@ -327,11 +236,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "7151b993",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "features_unstacked = features.unstack()"
@@ -341,11 +246,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "78ba9cb3",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "features_unstacked.materialize().describe().head()"
@@ -355,11 +256,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "f20c9553",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "features_unstacked.head()"
@@ -368,11 +265,7 @@
   {
    "cell_type": "markdown",
    "id": "804874af",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "### Fill empty values\n",
     "Now we do have empty values, so we fill them with 0, as empty means that the user did not click in the\n",
@@ -383,11 +276,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "b13a2406",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "features_unstacked = features.unstack(fill_value=0)"
@@ -396,11 +285,7 @@
   {
    "cell_type": "markdown",
    "id": "3917a31d",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "### Describe the data set\n",
     "We use describe again to get an impression of out created per-user data set."
@@ -410,11 +295,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "3536706e",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "features_unstacked.materialize().describe().head()"
@@ -423,11 +304,7 @@
   {
    "cell_type": "markdown",
    "id": "17432bf5",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "Looking at the mean, some sections seem to be used a lot more than others. Also the max\n",
     "number of clicks seems quite different per root section. This information can be used to drop some of the\n",
@@ -437,11 +314,7 @@
   {
    "cell_type": "markdown",
    "id": "31d779c8",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "### Visualize the data"
    ]
@@ -450,11 +323,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "6b8306ad",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "figure, axis = plt.subplots(2, 4,figsize=(15,10))\n",
@@ -468,11 +337,7 @@
   {
    "cell_type": "markdown",
    "id": "518c590e",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "The histograms show that indeed the higher values seem quite anomalous for most of the root locations. This\n",
     "could be a reason to drop some of these observations or resort to scaling methods. For now we continue with\n",
@@ -482,11 +347,7 @@
   {
    "cell_type": "markdown",
    "id": "e796d882",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "### Add time feature\n",
     "Now we want to add some time feature to our data set. We add the average session length per user to the data\n",
@@ -497,11 +358,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "bced215a",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "import datetime\n",
@@ -513,11 +370,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e0d7e29b",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "features_unstacked.session_duration.describe().head()"
@@ -526,11 +379,7 @@
   {
    "cell_type": "markdown",
    "id": "2a771131",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "### Export to pandas for sklearn\n",
     "Now that we have our data set, we can use it for machine learning, using for example sklearn. To do so\n",
@@ -543,11 +392,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "1d14b11d",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "pdf = features_unstacked.to_pandas()"
@@ -557,11 +402,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "123e667a",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "pdf"

--- a/notebooks/model-hub-demo-notebook.ipynb
+++ b/notebooks/model-hub-demo-notebook.ipynb
@@ -3,7 +3,11 @@
   {
    "cell_type": "markdown",
    "id": "a88d78f5",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "This is one of the Objectiv example notebooks. For more examples visit the \n",
     "[example notebooks](https://objectiv.io/docs/modeling/example-notebooks/) section of our docs. The notebooks can run with the demo data set that comes with the our [quickstart](https://objectiv.io/docs/home/quickstart-guide/), but can be used to run on your own collected data as well.\n",
@@ -14,7 +18,11 @@
   {
    "cell_type": "markdown",
    "id": "25b2e58e",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "# Intro\n",
     "In this notebook, we briefly demonstrate how you can use pre-built models from the [open model hub](https://objectiv.io/docs/modeling/) in conjunction with our modeling library [Bach](https://objectiv.io/docs/modeling/bach/) to quickly build model stacks to answer common product analytics questions.\n",
@@ -27,7 +35,11 @@
   {
    "cell_type": "markdown",
    "id": "baaf0d2d",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "### Import the required packages for this notebook\n",
     "The open model hub package can be installed with `pip install objectiv-modelhub` (this installs Bach as well).  \n",
@@ -38,7 +50,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e97ff289",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "from modelhub import ModelHub\n",
@@ -48,7 +64,11 @@
   {
    "cell_type": "markdown",
    "id": "e032c7c8",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "# Instantiate the model hub object\n",
     "As a first step, the model hub object is instantiated. The model hub contains collection of data models and convenience functions that can be used with Objectiv data. With `get_objectiv_dataframe()` a Bach DataFrame is created, that already has all columns and data types set correctly and as such can always be used with model hub models.\n",
@@ -63,7 +83,11 @@
   {
    "cell_type": "markdown",
    "id": "aeab3a00",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "**Note**  \n",
     "All operation and models in this notebook are run directly on entire data set in the SQL database using Bach. While the api resembles pandas, pandas is _not_ used for any the operations and calculations."
@@ -73,11 +97,15 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "d582b77f",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# instantiate the model hub\n",
-    "modelhub = ModelHub(time_aggregation='YYYY-MM-DD')\n",
+    "modelhub = ModelHub(time_aggregation='%Y-%m-%d')\n",
     "# get the Bach DataFrame with Objectiv data\n",
     "df = modelhub.get_objectiv_dataframe(start_date='2021-11-16')"
    ]
@@ -85,7 +113,11 @@
   {
    "cell_type": "markdown",
    "id": "1077acee",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "# Using the open model hub\n",
     "The open model hub is a growing collection of open-source, free to use data models that you can take,\n",
@@ -104,7 +136,11 @@
   {
    "cell_type": "markdown",
    "id": "e9f3070b",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## A simple aggregation model\n",
     "Calculating the unique users is one of the basic models in the model hub. As it is an aggregation model, it is called with `model_hub.aggregate.unique_users()`. It uses the time_aggregation that is set when the model hub was instantiated. With `.head()` we immediately query the data to show the results. `.to_pandas()` can be used to use all results as a pandas object in python. These (and following) results are sorted descending, so we show the latest data first."
@@ -114,7 +150,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "65632d2b",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "users = modelhub.aggregate.unique_users(df)\n",
@@ -124,7 +164,11 @@
   {
    "cell_type": "markdown",
    "id": "0c366433",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## Using `map` with the model hub & combining models\n",
     "This example shows how you use map to label users as a new user. This uses *time_aggregation*. As *time_aggregation* was set to 'YYYY-MM-DD' it means all hits are labeled as new for the entire day in which the user had its first session."
@@ -134,7 +178,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "10436e1e",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "df['is_new_user'] = modelhub.map.is_new_user(df)\n",
@@ -144,7 +192,11 @@
   {
    "cell_type": "markdown",
    "id": "d46cba1e",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "Or we can label conversion events. To do this we first have to define what a conversion is by setting the type of event and the location on the product at which this event was triggered with `add_conversion_event` (this is called the location stack, see [here](https://objectiv.io/docs/modeling/example-notebooks/open-taxonomy/#location_stack) for info)."
    ]
@@ -153,7 +205,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "61d9bfeb",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "modelhub.add_conversion_event(location_stack=df.location_stack.json[{'id': 'Quickstart Guide', '_type': 'LinkContext'}:],\n",
@@ -166,7 +222,11 @@
   {
    "cell_type": "markdown",
    "id": "80e05aa2",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "### Map, filter, aggregate\n",
     "As the map functions above retured a SeriesBoolean, they can be used in the model hub combined with a filter and aggregation models. We use the same aggregation model we showed earlier (`unique_users`), but now with the filter `df.conversion_events` applied. This gives the unique converted users per day."
@@ -176,7 +236,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "4493d730",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "modelhub.aggregate.unique_users(df[df.conversion_events]).head(10)"
@@ -185,7 +249,11 @@
   {
    "cell_type": "markdown",
    "id": "48dfaca9",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "Similarly, we can use other aggregation models from the model hub. In the example below, the average session duration is calculated for new users."
    ]
@@ -194,7 +262,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "65d52c00",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "duration_new_users = modelhub.aggregate.session_duration(df[df.is_new_user])\n",
@@ -204,7 +276,11 @@
   {
    "cell_type": "markdown",
    "id": "7be6e13c",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "### Combining model results\n",
     "Results from aggregation models can be used together if they share the same index type (similar to pandas). In this example the share of new users per day is calculated."
@@ -214,7 +290,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "ad6396fe",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "new_user_share = modelhub.agg.unique_users(df[df.is_new_user]) / modelhub.agg.unique_users(df)\n",
@@ -224,7 +304,11 @@
   {
    "cell_type": "markdown",
    "id": "822b577b",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "### Using multiple model hub filters"
    ]
@@ -232,7 +316,11 @@
   {
    "cell_type": "markdown",
    "id": "57f59b2c",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "The model hub's map results can be combined and reused. In this example we set two `map` model results as a column to the original DataFrame and use them both to filter the data and apply an aggregation model.\n",
     "In this example we calculate the number of users that were new in a month and also that converted twice on a day."
@@ -242,10 +330,14 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "5b7b1490",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
-    "df['is_new_user_month'] = modelhub.map.is_new_user(df, time_aggregation = 'YYYY-MM')\n",
+    "df['is_new_user_month'] = modelhub.map.is_new_user(df, time_aggregation = '%Y-%m')\n",
     "df['is_twice_converted'] = modelhub.map.conversions_in_time(df, name='quickstart_presses')==2\n",
     "modelhub.aggregate.unique_users(df[df.is_new_user_month & df.is_twice_converted]).head()"
    ]
@@ -253,7 +345,11 @@
   {
    "cell_type": "markdown",
    "id": "65575126",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## What's next?\n",
     "There are several options on how to continue working with the data or using the results otherwise, i.e. for visualization."
@@ -262,7 +358,11 @@
   {
    "cell_type": "markdown",
    "id": "297ef877",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "### 1. Export models to SQL\n",
     "As mentioned, all operations and models performed on the DataFrame are run on the SQL database. Therefore it is possible to view all objects as an SQL statement. For the `new_user_share` results that was created this looks as follows:"
@@ -272,7 +372,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "5655bb43",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# complex SQL statement alert!\n",
@@ -282,7 +386,11 @@
   {
    "cell_type": "markdown",
    "id": "c1102075",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "### 2. Export to metabase\n",
     "Aggregation model results can be exported to Metabase, to visualize and share your results. This is done for the unique new users:"
@@ -292,7 +400,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "f74099c0",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "modelhub.to_metabase(modelhub.agg.unique_users(df[df.is_new_user]), \n",
@@ -302,7 +414,11 @@
   {
    "cell_type": "markdown",
    "id": "da779d24",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "The results can be viewed here: http://localhost:3000/dashboard/1-model-hub"
    ]
@@ -310,7 +426,11 @@
   {
    "cell_type": "markdown",
    "id": "c7522e41",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "### 3. Further data crunching using the Bach Modeling Library\n",
     "All results from the model hub are in the form of Bach DataFrames or Series. This makes the model hub and Bach work seamlessly together."
@@ -320,7 +440,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "ac530557",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# label the number of time a user is converted in a session at a moment using the model hub.\n",
@@ -339,7 +463,11 @@
   {
    "cell_type": "markdown",
    "id": "15f2ab4d",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "Show the results, now the underlying query is executed."
    ]
@@ -348,7 +476,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "53d38855",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "presses_per_session.head()"
@@ -357,7 +489,11 @@
   {
    "cell_type": "markdown",
    "id": "670dde5e",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "There is another [example](https://objectiv.io/docs/modeling/bach/examples/) that demonstrates what you can do with the Bach modeling\n",
     "library, or head over to the [api reference](https://objectiv.io/docs/modeling/bach/api-reference/) for a complete overview of the possibilities."
@@ -366,7 +502,11 @@
   {
    "cell_type": "markdown",
    "id": "089230c9",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "### 4. Export DataFrame and model hub results to pandas DataFrame\n",
     "Bach DataFrames and/or model hub results can always be exported to pandas. Since Bach DataFrame operation run on the full dataset in the SQL database, it is recommended to export to pandas if data small enough; ie by aggregation or selection.  \n",
@@ -379,7 +519,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "c7e07fe5",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# presses_per_session_pd is a pandas Series\n",
@@ -390,7 +534,11 @@
   {
    "cell_type": "markdown",
    "id": "c964f0a9",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "This concludes the open model hub demo.\n",
     "\n",

--- a/notebooks/model-hub-demo-notebook.ipynb
+++ b/notebooks/model-hub-demo-notebook.ipynb
@@ -3,11 +3,7 @@
   {
    "cell_type": "markdown",
    "id": "a88d78f5",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "This is one of the Objectiv example notebooks. For more examples visit the \n",
     "[example notebooks](https://objectiv.io/docs/modeling/example-notebooks/) section of our docs. The notebooks can run with the demo data set that comes with the our [quickstart](https://objectiv.io/docs/home/quickstart-guide/), but can be used to run on your own collected data as well.\n",
@@ -18,11 +14,7 @@
   {
    "cell_type": "markdown",
    "id": "25b2e58e",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "# Intro\n",
     "In this notebook, we briefly demonstrate how you can use pre-built models from the [open model hub](https://objectiv.io/docs/modeling/) in conjunction with our modeling library [Bach](https://objectiv.io/docs/modeling/bach/) to quickly build model stacks to answer common product analytics questions.\n",
@@ -35,11 +27,7 @@
   {
    "cell_type": "markdown",
    "id": "baaf0d2d",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "### Import the required packages for this notebook\n",
     "The open model hub package can be installed with `pip install objectiv-modelhub` (this installs Bach as well).  \n",
@@ -50,11 +38,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e97ff289",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from modelhub import ModelHub\n",
@@ -64,11 +48,7 @@
   {
    "cell_type": "markdown",
    "id": "e032c7c8",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "# Instantiate the model hub object\n",
     "As a first step, the model hub object is instantiated. The model hub contains collection of data models and convenience functions that can be used with Objectiv data. With `get_objectiv_dataframe()` a Bach DataFrame is created, that already has all columns and data types set correctly and as such can always be used with model hub models.\n",
@@ -83,11 +63,7 @@
   {
    "cell_type": "markdown",
    "id": "aeab3a00",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "**Note**  \n",
     "All operation and models in this notebook are run directly on entire data set in the SQL database using Bach. While the api resembles pandas, pandas is _not_ used for any the operations and calculations."
@@ -97,11 +73,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "d582b77f",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# instantiate the model hub\n",
@@ -113,11 +85,7 @@
   {
    "cell_type": "markdown",
    "id": "1077acee",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "# Using the open model hub\n",
     "The open model hub is a growing collection of open-source, free to use data models that you can take,\n",
@@ -136,11 +104,7 @@
   {
    "cell_type": "markdown",
    "id": "e9f3070b",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "## A simple aggregation model\n",
     "Calculating the unique users is one of the basic models in the model hub. As it is an aggregation model, it is called with `model_hub.aggregate.unique_users()`. It uses the time_aggregation that is set when the model hub was instantiated. With `.head()` we immediately query the data to show the results. `.to_pandas()` can be used to use all results as a pandas object in python. These (and following) results are sorted descending, so we show the latest data first."
@@ -150,11 +114,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "65632d2b",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "users = modelhub.aggregate.unique_users(df)\n",
@@ -164,11 +124,7 @@
   {
    "cell_type": "markdown",
    "id": "0c366433",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "## Using `map` with the model hub & combining models\n",
     "This example shows how you use map to label users as a new user. This uses *time_aggregation*. As *time_aggregation* was set to 'YYYY-MM-DD' it means all hits are labeled as new for the entire day in which the user had its first session."
@@ -178,11 +134,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "10436e1e",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "df['is_new_user'] = modelhub.map.is_new_user(df)\n",
@@ -192,11 +144,7 @@
   {
    "cell_type": "markdown",
    "id": "d46cba1e",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "Or we can label conversion events. To do this we first have to define what a conversion is by setting the type of event and the location on the product at which this event was triggered with `add_conversion_event` (this is called the location stack, see [here](https://objectiv.io/docs/modeling/example-notebooks/open-taxonomy/#location_stack) for info)."
    ]
@@ -205,11 +153,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "61d9bfeb",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "modelhub.add_conversion_event(location_stack=df.location_stack.json[{'id': 'Quickstart Guide', '_type': 'LinkContext'}:],\n",
@@ -222,11 +166,7 @@
   {
    "cell_type": "markdown",
    "id": "80e05aa2",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "### Map, filter, aggregate\n",
     "As the map functions above retured a SeriesBoolean, they can be used in the model hub combined with a filter and aggregation models. We use the same aggregation model we showed earlier (`unique_users`), but now with the filter `df.conversion_events` applied. This gives the unique converted users per day."
@@ -236,11 +176,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "4493d730",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "modelhub.aggregate.unique_users(df[df.conversion_events]).head(10)"
@@ -249,11 +185,7 @@
   {
    "cell_type": "markdown",
    "id": "48dfaca9",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "Similarly, we can use other aggregation models from the model hub. In the example below, the average session duration is calculated for new users."
    ]
@@ -262,11 +194,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "65d52c00",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "duration_new_users = modelhub.aggregate.session_duration(df[df.is_new_user])\n",
@@ -276,11 +204,7 @@
   {
    "cell_type": "markdown",
    "id": "7be6e13c",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "### Combining model results\n",
     "Results from aggregation models can be used together if they share the same index type (similar to pandas). In this example the share of new users per day is calculated."
@@ -290,11 +214,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "ad6396fe",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "new_user_share = modelhub.agg.unique_users(df[df.is_new_user]) / modelhub.agg.unique_users(df)\n",
@@ -304,11 +224,7 @@
   {
    "cell_type": "markdown",
    "id": "822b577b",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "### Using multiple model hub filters"
    ]
@@ -316,11 +232,7 @@
   {
    "cell_type": "markdown",
    "id": "57f59b2c",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "The model hub's map results can be combined and reused. In this example we set two `map` model results as a column to the original DataFrame and use them both to filter the data and apply an aggregation model.\n",
     "In this example we calculate the number of users that were new in a month and also that converted twice on a day."
@@ -330,11 +242,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "5b7b1490",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "df['is_new_user_month'] = modelhub.map.is_new_user(df, time_aggregation = '%Y-%m')\n",
@@ -345,11 +253,7 @@
   {
    "cell_type": "markdown",
    "id": "65575126",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "## What's next?\n",
     "There are several options on how to continue working with the data or using the results otherwise, i.e. for visualization."
@@ -358,11 +262,7 @@
   {
    "cell_type": "markdown",
    "id": "297ef877",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "### 1. Export models to SQL\n",
     "As mentioned, all operations and models performed on the DataFrame are run on the SQL database. Therefore it is possible to view all objects as an SQL statement. For the `new_user_share` results that was created this looks as follows:"
@@ -372,11 +272,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "5655bb43",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# complex SQL statement alert!\n",
@@ -386,11 +282,7 @@
   {
    "cell_type": "markdown",
    "id": "c1102075",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "### 2. Export to metabase\n",
     "Aggregation model results can be exported to Metabase, to visualize and share your results. This is done for the unique new users:"
@@ -400,11 +292,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "f74099c0",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "modelhub.to_metabase(modelhub.agg.unique_users(df[df.is_new_user]), \n",
@@ -414,11 +302,7 @@
   {
    "cell_type": "markdown",
    "id": "da779d24",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "The results can be viewed here: http://localhost:3000/dashboard/1-model-hub"
    ]
@@ -426,11 +310,7 @@
   {
    "cell_type": "markdown",
    "id": "c7522e41",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "### 3. Further data crunching using the Bach Modeling Library\n",
     "All results from the model hub are in the form of Bach DataFrames or Series. This makes the model hub and Bach work seamlessly together."
@@ -440,11 +320,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "ac530557",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# label the number of time a user is converted in a session at a moment using the model hub.\n",
@@ -463,11 +339,7 @@
   {
    "cell_type": "markdown",
    "id": "15f2ab4d",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "Show the results, now the underlying query is executed."
    ]
@@ -476,11 +348,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "53d38855",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "presses_per_session.head()"
@@ -489,11 +357,7 @@
   {
    "cell_type": "markdown",
    "id": "670dde5e",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "There is another [example](https://objectiv.io/docs/modeling/bach/examples/) that demonstrates what you can do with the Bach modeling\n",
     "library, or head over to the [api reference](https://objectiv.io/docs/modeling/bach/api-reference/) for a complete overview of the possibilities."
@@ -502,11 +366,7 @@
   {
    "cell_type": "markdown",
    "id": "089230c9",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "### 4. Export DataFrame and model hub results to pandas DataFrame\n",
     "Bach DataFrames and/or model hub results can always be exported to pandas. Since Bach DataFrame operation run on the full dataset in the SQL database, it is recommended to export to pandas if data small enough; ie by aggregation or selection.  \n",
@@ -519,11 +379,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "c7e07fe5",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# presses_per_session_pd is a pandas Series\n",
@@ -534,11 +390,7 @@
   {
    "cell_type": "markdown",
    "id": "c964f0a9",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "This concludes the open model hub demo.\n",
     "\n",

--- a/notebooks/modelhub-logistic-regression.ipynb
+++ b/notebooks/modelhub-logistic-regression.ipynb
@@ -3,7 +3,11 @@
   {
    "cell_type": "markdown",
    "id": "6166232a",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "This is one of the Objectiv example notebooks. For more examples visit the \n",
     "[example notebooks](https://objectiv.io/docs/modeling/example-notebooks/) section of our docs. The notebooks can run with the demo data set that comes with the our [quickstart](https://objectiv.io/docs/home/quickstart-guide/), but can be used to run on your own collected data as well.\n",
@@ -14,7 +18,11 @@
   {
    "cell_type": "markdown",
    "id": "3abc9081",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "The open model hub supports logistic regression on Bach data objects. A logistic regression model can be fitted, values can be predicted and results can be tested directly on the full data set in the database. Note that for fitting the model data is extracted from the database under the hood."
    ]
@@ -22,7 +30,11 @@
   {
    "cell_type": "markdown",
    "id": "096321a3",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "### Import the required packages for this notebook\n",
     "The open model hub package can be installed with `pip install objectiv-modelhub` (this installs Bach as well).  \n",
@@ -33,7 +45,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e97ff289",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "from modelhub import ModelHub\n",
@@ -43,7 +59,11 @@
   {
    "cell_type": "markdown",
    "id": "1f896993",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "At first we have to instantiate the Objectiv DataFrame object and the model hub."
    ]
@@ -52,11 +72,15 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "d582b77f",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# instantiate the model hub\n",
-    "modelhub = ModelHub(time_aggregation='YYYY-MM-DD')\n",
+    "modelhub = ModelHub(time_aggregation='%Y-%m-%d')\n",
     "# get the Bach DataFrame with Objectiv data\n",
     "df = modelhub.get_objectiv_dataframe(start_date='2022-02-15', end_date='2022-05-16')"
    ]
@@ -64,7 +88,11 @@
   {
    "cell_type": "markdown",
    "id": "1cbc2b0d",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "### Creating a feature set"
    ]
@@ -72,7 +100,11 @@
   {
    "cell_type": "markdown",
    "id": "20c780fa",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "We create a data set that counts the number of clicks per user in each section of our website. We obtain the main sections by extracting the [root location](https://objectiv.io/docs/taxonomy/reference/location-contexts/RootLocationContext/) from the location stack. It is similar data set to the one used in the ['Bach and sklearn'](https://objectiv.io/docs/modeling/example-notebooks/machine-learning/) example. Note that this is a small and simple data set used just for demonstration purposes of the logistic regression functionality, and not so much the model results itself. \n",
     "\n",
@@ -83,7 +115,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "284d4b9f",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# extract the root location from the location stack\n",
@@ -94,7 +130,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "83127b2b",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# only look at press events and count the root locations\n",
@@ -105,7 +145,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "4225e176",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# unstack the series, to create a DataFrame with the number of clicks per root location as columns\n",
@@ -115,7 +159,11 @@
   {
    "cell_type": "markdown",
    "id": "448a54de",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "#### Sample the data\n",
     "We take a 10% sample of the full data that we will use to train the model on. This limits data processing and speeds up the fitting procedure. \n",
@@ -127,7 +175,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "1318771d",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "features_set_sample = features_unstacked.get_sample('test_lr_sample', sample_percentage=10, overwrite=True, seed=42)"
@@ -136,7 +188,11 @@
   {
    "cell_type": "markdown",
    "id": "810f5a23",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "Using a logistic regression we will predict whether a user clicked in the modeling section or not. We will predict this by the number of clicks in any of the other sections. `X` is a Bach DataFrame that contains the explanatory variables. `y` is a Bach SeriesBoolean with the labels we want to predict."
    ]
@@ -145,7 +201,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e5666a55",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "y_column = 'modeling'\n",
@@ -156,7 +216,11 @@
   {
    "cell_type": "markdown",
    "id": "37437a6f",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "Show the first lines of `X` and `y`. "
    ]
@@ -165,7 +229,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "ced14b7d",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "X.head()"
@@ -175,7 +243,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "1b3e8066",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "y.head()"
@@ -184,7 +256,11 @@
   {
    "cell_type": "markdown",
    "id": "eb151986",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "### Instantiating the logistic regression model\n",
     "We can instantiate the logistic regression model from the model hub. Since the model is based on sklearn's version of LogisticRegression, it can be instantiated with any parameters that sklearn's LogisticRegression [supports](\n",
@@ -195,7 +271,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "83e709fc",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "lr = modelhub.get_logistic_regression(fit_intercept=False)"
@@ -204,7 +284,11 @@
   {
    "cell_type": "markdown",
    "id": "309b525d",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "### Fitting the model\n",
     "The `fit` method fits a model to the passed data. This method extracts the data from the database under the hood."
@@ -214,7 +298,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "26e7953e",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "lr.fit(X, y)"
@@ -223,7 +311,11 @@
   {
    "cell_type": "markdown",
    "id": "32d1f1e2",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "### Accuracy and predicting\n",
     "All following operations are carried out directly on the database. Therefore, they can be exported to SQL statements so it can be used in for example your BI tooling."
@@ -233,7 +325,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "7d07122b",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "lr.score(X, y)"
@@ -242,7 +338,11 @@
   {
    "cell_type": "markdown",
    "id": "f123b3e2",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "The model has the same attributes as the Logistic Regression model from sklearn."
    ]
@@ -251,7 +351,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "1262bc94",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# show the coefficients of the fitted model\n",
@@ -261,7 +365,11 @@
   {
    "cell_type": "markdown",
    "id": "170dbab3",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "Create columns for the predicted values and labels in the sampled data set. Labels `True` if the probability is over .5."
    ]
@@ -270,7 +378,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "32672b17",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "features_set_sample['predicted_values'] = lr.predict_proba(X)\n",
@@ -281,7 +393,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "598a910c",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# show the sampled data set, including predictions\n",
@@ -291,7 +407,11 @@
   {
    "cell_type": "markdown",
    "id": "2f54a055",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "### Unsample and view the SQL\n",
     "The data can be unsampled and viewed as an SQL statement. `features_set_full` and the SQL statement for this DataFrame are for the full unsampled data set including the predicted values."
@@ -301,7 +421,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "072658d9",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "features_set_full = features_set_sample.get_unsampled()"
@@ -310,7 +434,11 @@
   {
    "cell_type": "markdown",
    "id": "42b3e806",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "Get the sql statement for the _full_ data set including the predicted values."
    ]
@@ -320,7 +448,10 @@
    "execution_count": null,
    "id": "352e2c05",
    "metadata": {
-    "scrolled": false
+    "scrolled": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -330,7 +461,11 @@
   {
    "cell_type": "markdown",
    "id": "23193849",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "This demonstrates the core functionality of the Logistic Regression model in the open model hub. Stay tuned for more metrics for assessing the fit of the model, as well as simplifying splitting the data into training and testing data sets."
    ]

--- a/notebooks/modelhub-logistic-regression.ipynb
+++ b/notebooks/modelhub-logistic-regression.ipynb
@@ -3,11 +3,7 @@
   {
    "cell_type": "markdown",
    "id": "6166232a",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "This is one of the Objectiv example notebooks. For more examples visit the \n",
     "[example notebooks](https://objectiv.io/docs/modeling/example-notebooks/) section of our docs. The notebooks can run with the demo data set that comes with the our [quickstart](https://objectiv.io/docs/home/quickstart-guide/), but can be used to run on your own collected data as well.\n",
@@ -18,11 +14,7 @@
   {
    "cell_type": "markdown",
    "id": "3abc9081",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "The open model hub supports logistic regression on Bach data objects. A logistic regression model can be fitted, values can be predicted and results can be tested directly on the full data set in the database. Note that for fitting the model data is extracted from the database under the hood."
    ]
@@ -30,11 +22,7 @@
   {
    "cell_type": "markdown",
    "id": "096321a3",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "### Import the required packages for this notebook\n",
     "The open model hub package can be installed with `pip install objectiv-modelhub` (this installs Bach as well).  \n",
@@ -45,11 +33,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e97ff289",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from modelhub import ModelHub\n",
@@ -59,11 +43,7 @@
   {
    "cell_type": "markdown",
    "id": "1f896993",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "At first we have to instantiate the Objectiv DataFrame object and the model hub."
    ]
@@ -72,11 +52,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "d582b77f",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# instantiate the model hub\n",
@@ -88,11 +64,7 @@
   {
    "cell_type": "markdown",
    "id": "1cbc2b0d",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "### Creating a feature set"
    ]
@@ -100,11 +72,7 @@
   {
    "cell_type": "markdown",
    "id": "20c780fa",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "We create a data set that counts the number of clicks per user in each section of our website. We obtain the main sections by extracting the [root location](https://objectiv.io/docs/taxonomy/reference/location-contexts/RootLocationContext/) from the location stack. It is similar data set to the one used in the ['Bach and sklearn'](https://objectiv.io/docs/modeling/example-notebooks/machine-learning/) example. Note that this is a small and simple data set used just for demonstration purposes of the logistic regression functionality, and not so much the model results itself. \n",
     "\n",
@@ -115,11 +83,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "284d4b9f",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# extract the root location from the location stack\n",
@@ -130,11 +94,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "83127b2b",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# only look at press events and count the root locations\n",
@@ -145,11 +105,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "4225e176",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# unstack the series, to create a DataFrame with the number of clicks per root location as columns\n",
@@ -159,11 +115,7 @@
   {
    "cell_type": "markdown",
    "id": "448a54de",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "#### Sample the data\n",
     "We take a 10% sample of the full data that we will use to train the model on. This limits data processing and speeds up the fitting procedure. \n",
@@ -175,11 +127,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "1318771d",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "features_set_sample = features_unstacked.get_sample('test_lr_sample', sample_percentage=10, overwrite=True, seed=42)"
@@ -188,11 +136,7 @@
   {
    "cell_type": "markdown",
    "id": "810f5a23",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "Using a logistic regression we will predict whether a user clicked in the modeling section or not. We will predict this by the number of clicks in any of the other sections. `X` is a Bach DataFrame that contains the explanatory variables. `y` is a Bach SeriesBoolean with the labels we want to predict."
    ]
@@ -201,11 +145,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e5666a55",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "y_column = 'modeling'\n",
@@ -216,11 +156,7 @@
   {
    "cell_type": "markdown",
    "id": "37437a6f",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "Show the first lines of `X` and `y`. "
    ]
@@ -229,11 +165,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "ced14b7d",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "X.head()"
@@ -243,11 +175,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "1b3e8066",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "y.head()"
@@ -256,11 +184,7 @@
   {
    "cell_type": "markdown",
    "id": "eb151986",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "### Instantiating the logistic regression model\n",
     "We can instantiate the logistic regression model from the model hub. Since the model is based on sklearn's version of LogisticRegression, it can be instantiated with any parameters that sklearn's LogisticRegression [supports](\n",
@@ -271,11 +195,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "83e709fc",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "lr = modelhub.get_logistic_regression(fit_intercept=False)"
@@ -284,11 +204,7 @@
   {
    "cell_type": "markdown",
    "id": "309b525d",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "### Fitting the model\n",
     "The `fit` method fits a model to the passed data. This method extracts the data from the database under the hood."
@@ -298,11 +214,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "26e7953e",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "lr.fit(X, y)"
@@ -311,11 +223,7 @@
   {
    "cell_type": "markdown",
    "id": "32d1f1e2",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "### Accuracy and predicting\n",
     "All following operations are carried out directly on the database. Therefore, they can be exported to SQL statements so it can be used in for example your BI tooling."
@@ -325,11 +233,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "7d07122b",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "lr.score(X, y)"
@@ -338,11 +242,7 @@
   {
    "cell_type": "markdown",
    "id": "f123b3e2",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "The model has the same attributes as the Logistic Regression model from sklearn."
    ]
@@ -351,11 +251,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "1262bc94",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# show the coefficients of the fitted model\n",
@@ -365,11 +261,7 @@
   {
    "cell_type": "markdown",
    "id": "170dbab3",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "Create columns for the predicted values and labels in the sampled data set. Labels `True` if the probability is over .5."
    ]
@@ -378,11 +270,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "32672b17",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "features_set_sample['predicted_values'] = lr.predict_proba(X)\n",
@@ -393,11 +281,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "598a910c",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# show the sampled data set, including predictions\n",
@@ -407,11 +291,7 @@
   {
    "cell_type": "markdown",
    "id": "2f54a055",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "### Unsample and view the SQL\n",
     "The data can be unsampled and viewed as an SQL statement. `features_set_full` and the SQL statement for this DataFrame are for the full unsampled data set including the predicted values."
@@ -421,11 +301,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "072658d9",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "features_set_full = features_set_sample.get_unsampled()"
@@ -434,11 +310,7 @@
   {
    "cell_type": "markdown",
    "id": "42b3e806",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "Get the sql statement for the _full_ data set including the predicted values."
    ]
@@ -448,10 +320,7 @@
    "execution_count": null,
    "id": "352e2c05",
    "metadata": {
-    "scrolled": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
+    "scrolled": false
    },
    "outputs": [],
    "source": [
@@ -461,11 +330,7 @@
   {
    "cell_type": "markdown",
    "id": "23193849",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "This demonstrates the core functionality of the Logistic Regression model in the open model hub. Stay tuned for more metrics for assessing the fit of the model, as well as simplifying splitting the data into training and testing data sets."
    ]

--- a/notebooks/open-taxonomy-how-to.ipynb
+++ b/notebooks/open-taxonomy-how-to.ipynb
@@ -3,11 +3,7 @@
   {
    "cell_type": "markdown",
    "id": "0dac359c",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "This is one of the Objectiv example notebooks. For more examples visit the \n",
     "[example notebooks](https://objectiv.io/docs/modeling/example-notebooks/) section of our docs. The notebooks can run with the demo data set that comes with the our [quickstart](https://objectiv.io/docs/home/quickstart-guide/), but can be used to run on your own collected data as well.\n",
@@ -18,11 +14,7 @@
   {
    "cell_type": "markdown",
    "id": "ea65ba18",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "# Intro\n",
     "This notebook demonstrates what you can do with the Objectiv Bach modeling library and a dataset that was validated against the open analytics taxonomy. The example uses real data that's stored in an SQL database and was collected with the Objectiv Tracker that's instrumented on objectiv.io.\n",
@@ -38,11 +30,7 @@
   {
    "cell_type": "markdown",
    "id": "4cab9944",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "# Contents  \n",
     "* [Instantiate-the-object](#Instantiate-the-object)\n",
@@ -57,11 +45,7 @@
   {
    "cell_type": "markdown",
    "id": "0cd96ce0",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "### Import the required packages for this notebook\n",
     "The open model hub package can be installed with `pip install objectiv-modelhub` (this installs Bach as well).  \n",
@@ -72,11 +56,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e97ff289",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "from modelhub import ModelHub"
@@ -85,11 +65,7 @@
   {
    "cell_type": "markdown",
    "id": "d1d35b5b",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "# Instantiate the object\n",
     "As a first step, the model hub object is instantiated. The model hub contains collection of data models and convenience functions that can be used with Objectiv data. With `get_objectiv_dataframe()` a Bach DataFrame is created, that already has all columns and data types set correctly and as such can always be used with model hub models. "
@@ -99,11 +75,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "05190260",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# instantiate the model hub\n",
@@ -115,11 +87,7 @@
   {
    "cell_type": "markdown",
    "id": "2a316d23",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "The data for the DataFrame is still in the database and the database is not queried before any of the data is loaded to the python environment. The methods that query the database are: \n",
     "* [`head()`](https://objectiv.io/docs/modeling/bach/api-reference/DataFrame/head/)\n",
@@ -134,11 +102,7 @@
   {
    "cell_type": "markdown",
    "id": "eac0a37f",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "## The data\n",
     "The contents of the DataFrame exist of:"
@@ -148,11 +112,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "2d187cd0",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "df.index_dtypes"
@@ -161,11 +121,7 @@
   {
    "cell_type": "markdown",
    "id": "de3272e6",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "The index contains a unique identifyer for every hit."
    ]
@@ -174,11 +130,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "4f540a20",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "df.dtypes"
@@ -187,11 +139,7 @@
   {
    "cell_type": "markdown",
    "id": "154f4898",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "* `day`: the day of the session as a date.\n",
     "* `moment`: the exact moment of the event.\n",
@@ -207,11 +155,7 @@
   {
    "cell_type": "markdown",
    "id": "283c8c6f",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "A preview of the data. We show the latest PressEvents."
    ]
@@ -220,11 +164,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a135e7e0",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "df[df.event_type == 'PressEvent'].sort_values('moment', ascending=False).head()"
@@ -233,11 +173,7 @@
   {
    "cell_type": "markdown",
    "id": "c358689e",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "## The Open Taxonomy\n",
     "Data in a DataFrame created with `get_objectiv_dataframe()` follows the principles of the [open analytics taxonomy](https://objectiv.io/docs/taxonomy/core-concepts/) and is stored as such. Therefore it adheres to the three principles of how events are structured.\n",
@@ -251,11 +187,7 @@
   {
    "cell_type": "markdown",
    "id": "0a4ca710",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "### event_type"
    ]
@@ -263,11 +195,7 @@
   {
    "cell_type": "markdown",
    "id": "f89749b5",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "The event type describes what kind of event is triggered. The goal of the open taxonomy is to label all interactive and non-interactive events in a standardized way. Together with the location stack, the event_type 'defines' what happened with or on the product."
    ]
@@ -276,11 +204,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "81de16f2",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "df[df.day == '2022-01-10'].event_type.head()"
@@ -289,11 +213,7 @@
   {
    "cell_type": "markdown",
    "id": "7882f4c0",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "### location_stack & global_contexts\n",
     "The location stack and global contexts are stored as json type data. Within the DataFrame, it is easy to access data in json data based on position or content."
@@ -302,11 +222,7 @@
   {
    "cell_type": "markdown",
    "id": "cfc4c4ac",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "**Slicing the json data**  \n",
     "With the `.json[]` syntax you can slice the array using integers. Instead of integers, dictionaries can also be passed to 'query' the json array. If the passed dictionary matches a context object in the stack, all objects of the stack starting (or ending, depending on the slice) at that object will be returned.\n",
@@ -352,11 +268,7 @@
   {
    "cell_type": "markdown",
    "id": "cf6d0e87",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "### location_stack\n",
     "The `location_stack` column in the DataFrame stores the information on the exact location where the event is triggered in the product. The example used above is the location stack of the link to the DataFrame api reference in the menu on our docs page.\n",
@@ -378,11 +290,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a74b5711",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "df[df.event_type == 'PressEvent'].location_stack.head(1)[0]"
@@ -391,11 +299,7 @@
   {
    "cell_type": "markdown",
    "id": "5ba58635",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "### global_contexts\n",
     "The `global_contexts` column in the DataFrame contain all information that is relevant to the logged event. As it is set as an `objectiv_global_context` type, specific methods can be used to access the data from the `global_contexts`. These methods can be used using the `.gc` accessor on the column. The methods are:\n",
@@ -411,10 +315,7 @@
    "execution_count": null,
    "id": "24e640ba",
    "metadata": {
-    "scrolled": true,
-    "pycharm": {
-     "name": "#%%\n"
-    }
+    "scrolled": true
    },
    "outputs": [],
    "source": [
@@ -424,11 +325,7 @@
   {
    "cell_type": "markdown",
    "id": "ca0712a1",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "# Sampling\n",
     "One of the key features to Objectiv Bach is that it runs on your full data set. There can however be situations where you want to experiment with your data, meaning you have to query the full data set often. This can become slow and/or costly. \n",
@@ -442,11 +339,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "c11a0354",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "df_sample = df.get_sample(table_name='sample_data', sample_percentage=10, overwrite=True)"
@@ -455,11 +348,7 @@
   {
    "cell_type": "markdown",
    "id": "b77755c7",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "Two new columns are created in the sample."
    ]
@@ -468,11 +357,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "af6ac7a1",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "df_sample['root_location_contexts'] = df_sample.location_stack.json[:1]\n",
@@ -483,11 +368,7 @@
   {
    "cell_type": "markdown",
    "id": "4d30f5c1",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "Using `.get_unsampled()`, the operations that are done on the sample (the creation of the two columns), are applied to the entire data set:"
    ]
@@ -496,11 +377,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e710607d",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "df_unsampled = df_sample.get_unsampled()\n",
@@ -510,11 +387,7 @@
   {
    "cell_type": "markdown",
    "id": "21d3b4e8",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "The sample can also be used for grouping and aggregating. The example below counts all hits and the unique event_types in the sample:"
    ]
@@ -523,11 +396,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "21a4f054",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "df_sample_grouped = df_sample.groupby(['application']).agg({'event_type':'nunique','session_hit_number':'count'})\n",
@@ -537,11 +406,7 @@
   {
    "cell_type": "markdown",
    "id": "ca528c2d",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "As can be seen from the counts, unsampling applies the transformation to the entire data set:"
    ]
@@ -550,11 +415,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "0aa6e731",
-   "metadata": {
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "df_unsampled_grouped = df_sample_grouped.get_unsampled()\n",
@@ -564,11 +425,7 @@
   {
    "cell_type": "markdown",
    "id": "2079ea8b",
-   "metadata": {
-    "pycharm": {
-     "name": "#%% md\n"
-    }
-   },
+   "metadata": {},
    "source": [
     "This concludes this demo.\n",
     "\n",

--- a/notebooks/open-taxonomy-how-to.ipynb
+++ b/notebooks/open-taxonomy-how-to.ipynb
@@ -3,7 +3,11 @@
   {
    "cell_type": "markdown",
    "id": "0dac359c",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "This is one of the Objectiv example notebooks. For more examples visit the \n",
     "[example notebooks](https://objectiv.io/docs/modeling/example-notebooks/) section of our docs. The notebooks can run with the demo data set that comes with the our [quickstart](https://objectiv.io/docs/home/quickstart-guide/), but can be used to run on your own collected data as well.\n",
@@ -14,7 +18,11 @@
   {
    "cell_type": "markdown",
    "id": "ea65ba18",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "# Intro\n",
     "This notebook demonstrates what you can do with the Objectiv Bach modeling library and a dataset that was validated against the open analytics taxonomy. The example uses real data that's stored in an SQL database and was collected with the Objectiv Tracker that's instrumented on objectiv.io.\n",
@@ -30,7 +38,11 @@
   {
    "cell_type": "markdown",
    "id": "4cab9944",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "# Contents  \n",
     "* [Instantiate-the-object](#Instantiate-the-object)\n",
@@ -45,7 +57,11 @@
   {
    "cell_type": "markdown",
    "id": "0cd96ce0",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "### Import the required packages for this notebook\n",
     "The open model hub package can be installed with `pip install objectiv-modelhub` (this installs Bach as well).  \n",
@@ -56,7 +72,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e97ff289",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "from modelhub import ModelHub"
@@ -65,7 +85,11 @@
   {
    "cell_type": "markdown",
    "id": "d1d35b5b",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "# Instantiate the object\n",
     "As a first step, the model hub object is instantiated. The model hub contains collection of data models and convenience functions that can be used with Objectiv data. With `get_objectiv_dataframe()` a Bach DataFrame is created, that already has all columns and data types set correctly and as such can always be used with model hub models. "
@@ -75,7 +99,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "05190260",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "# instantiate the model hub\n",
@@ -87,7 +115,11 @@
   {
    "cell_type": "markdown",
    "id": "2a316d23",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "The data for the DataFrame is still in the database and the database is not queried before any of the data is loaded to the python environment. The methods that query the database are: \n",
     "* [`head()`](https://objectiv.io/docs/modeling/bach/api-reference/DataFrame/head/)\n",
@@ -102,7 +134,11 @@
   {
    "cell_type": "markdown",
    "id": "eac0a37f",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## The data\n",
     "The contents of the DataFrame exist of:"
@@ -112,7 +148,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "2d187cd0",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "df.index_dtypes"
@@ -121,7 +161,11 @@
   {
    "cell_type": "markdown",
    "id": "de3272e6",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "The index contains a unique identifyer for every hit."
    ]
@@ -130,7 +174,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "4f540a20",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "df.dtypes"
@@ -139,7 +187,11 @@
   {
    "cell_type": "markdown",
    "id": "154f4898",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "* `day`: the day of the session as a date.\n",
     "* `moment`: the exact moment of the event.\n",
@@ -155,7 +207,11 @@
   {
    "cell_type": "markdown",
    "id": "283c8c6f",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "A preview of the data. We show the latest PressEvents."
    ]
@@ -164,7 +220,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a135e7e0",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "df[df.event_type == 'PressEvent'].sort_values('moment', ascending=False).head()"
@@ -173,7 +233,11 @@
   {
    "cell_type": "markdown",
    "id": "c358689e",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "## The Open Taxonomy\n",
     "Data in a DataFrame created with `get_objectiv_dataframe()` follows the principles of the [open analytics taxonomy](https://objectiv.io/docs/taxonomy/core-concepts/) and is stored as such. Therefore it adheres to the three principles of how events are structured.\n",
@@ -187,7 +251,11 @@
   {
    "cell_type": "markdown",
    "id": "0a4ca710",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "### event_type"
    ]
@@ -195,7 +263,11 @@
   {
    "cell_type": "markdown",
    "id": "f89749b5",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "The event type describes what kind of event is triggered. The goal of the open taxonomy is to label all interactive and non-interactive events in a standardized way. Together with the location stack, the event_type 'defines' what happened with or on the product."
    ]
@@ -204,7 +276,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "81de16f2",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "df[df.day == '2022-01-10'].event_type.head()"
@@ -213,7 +289,11 @@
   {
    "cell_type": "markdown",
    "id": "7882f4c0",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "### location_stack & global_contexts\n",
     "The location stack and global contexts are stored as json type data. Within the DataFrame, it is easy to access data in json data based on position or content."
@@ -222,7 +302,11 @@
   {
    "cell_type": "markdown",
    "id": "cfc4c4ac",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "**Slicing the json data**  \n",
     "With the `.json[]` syntax you can slice the array using integers. Instead of integers, dictionaries can also be passed to 'query' the json array. If the passed dictionary matches a context object in the stack, all objects of the stack starting (or ending, depending on the slice) at that object will be returned.\n",
@@ -268,7 +352,11 @@
   {
    "cell_type": "markdown",
    "id": "cf6d0e87",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "### location_stack\n",
     "The `location_stack` column in the DataFrame stores the information on the exact location where the event is triggered in the product. The example used above is the location stack of the link to the DataFrame api reference in the menu on our docs page.\n",
@@ -290,7 +378,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a74b5711",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "df[df.event_type == 'PressEvent'].location_stack.head(1)[0]"
@@ -299,7 +391,11 @@
   {
    "cell_type": "markdown",
    "id": "5ba58635",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "### global_contexts\n",
     "The `global_contexts` column in the DataFrame contain all information that is relevant to the logged event. As it is set as an `objectiv_global_context` type, specific methods can be used to access the data from the `global_contexts`. These methods can be used using the `.gc` accessor on the column. The methods are:\n",
@@ -315,7 +411,10 @@
    "execution_count": null,
    "id": "24e640ba",
    "metadata": {
-    "scrolled": true
+    "scrolled": true,
+    "pycharm": {
+     "name": "#%%\n"
+    }
    },
    "outputs": [],
    "source": [
@@ -325,7 +424,11 @@
   {
    "cell_type": "markdown",
    "id": "ca0712a1",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "# Sampling\n",
     "One of the key features to Objectiv Bach is that it runs on your full data set. There can however be situations where you want to experiment with your data, meaning you have to query the full data set often. This can become slow and/or costly. \n",
@@ -339,7 +442,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "c11a0354",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "df_sample = df.get_sample(table_name='sample_data', sample_percentage=10, overwrite=True)"
@@ -348,7 +455,11 @@
   {
    "cell_type": "markdown",
    "id": "b77755c7",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "Two new columns are created in the sample."
    ]
@@ -357,7 +468,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "af6ac7a1",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "df_sample['root_location_contexts'] = df_sample.location_stack.json[:1]\n",
@@ -368,7 +483,11 @@
   {
    "cell_type": "markdown",
    "id": "4d30f5c1",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "Using `.get_unsampled()`, the operations that are done on the sample (the creation of the two columns), are applied to the entire data set:"
    ]
@@ -377,7 +496,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "e710607d",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "df_unsampled = df_sample.get_unsampled()\n",
@@ -387,7 +510,11 @@
   {
    "cell_type": "markdown",
    "id": "21d3b4e8",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "The sample can also be used for grouping and aggregating. The example below counts all hits and the unique event_types in the sample:"
    ]
@@ -396,7 +523,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "21a4f054",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "df_sample_grouped = df_sample.groupby(['application']).agg({'event_type':'nunique','session_hit_number':'count'})\n",
@@ -406,7 +537,11 @@
   {
    "cell_type": "markdown",
    "id": "ca528c2d",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "As can be seen from the counts, unsampling applies the transformation to the entire data set:"
    ]
@@ -415,7 +550,11 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "0aa6e731",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "df_unsampled_grouped = df_sample_grouped.get_unsampled()\n",
@@ -425,7 +564,11 @@
   {
    "cell_type": "markdown",
    "id": "2079ea8b",
-   "metadata": {},
+   "metadata": {
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   },
    "source": [
     "This concludes this demo.\n",
     "\n",


### PR DESCRIPTION
`sql_format` is going to be deprecated, now ModelHub.time_agg uses `strftime` instead. Also changed `TIME_DEFAULT_FORMAT='YYYY-MM-DD HH24:MI:SS.MS` to `TIME_DEFAULT_FORMAT = '%Y-%m-%d %H:%M:%S.%f'`. Now, all tests in `test_model_hub_unique_sessions.py` are passing for BigQuery.

Will remove ignore of deprecation in another PR