### PR TITLE
ModelHub BQ: json series globalcontext

### DIFF
--- a/bach/bach/series/series_json.py
+++ b/bach/bach/series/series_json.py
@@ -360,14 +360,14 @@ class JsonAccessor(Generic[TSeriesJson]):
 
         If key is an integer, then this returns an item from the json array.
         The key is treated as a 0-based index. If negative this will count from the end of the array (one
-            based). The index MUST exist in the array.
+            based). If the index does not exists this will render None/NULL.
         This assumes the top-level item in the json is an array
 
         If key is a slice, then this returns a slice from the json array.
         This assumes the top-level item in the json is an array
 
         If key is a string, then this returns an item from the json object. The item belonging to the given
-            key is returned.
+            key is returned, or None/NULL if not found.
         This assumes the top-level item in the json is an object
         """
         # TODO: leverage instance_dtype information here, if we have that

--- a/bach/bach/series/series_json.py
+++ b/bach/bach/series/series_json.py
@@ -154,11 +154,7 @@ class SeriesJson(Series):
             :members:
 
         """
-        if is_postgres(self.engine):
-            return JsonPostgresAccessor(series_object=self)
-        if is_bigquery(self.engine):
-            return JsonBigQueryAccessor(series_object=self)
-        raise DatabaseNotSupportedException(self.engine)
+        return JsonAccessor(series_object=self)
 
     @property
     def elements(self):
@@ -314,7 +310,7 @@ class SeriesJsonPostgres(SeriesJson):
         """
         json_series = self.astype('json')
         assert isinstance(json_series, SeriesJson)  # help mypy
-        return JsonPostgresAccessor(series_object=json_series)
+        return json_series.json
 
     def materialize(
             self,
@@ -336,70 +332,56 @@ TSeriesJson = TypeVar('TSeriesJson', bound='SeriesJson')
 
 class JsonAccessor(Generic[TSeriesJson]):
     """
-    Abstract class with accessor methods to JSON type data.
-
-    Database specific subclasses implement the abstract functions.
+    Class with accessor methods to JSON type data.
     """
+
+    # We have different implementations for different databases. This class is a facade, that will call the
+    # actual implementing class based on the used database engine.
+    # Having this facade (instead of having subclasses per engine) makes it possible to have classes inherit
+    # from this class.
+
     def __init__(self, series_object: 'TSeriesJson'):
         self._series_object = series_object
 
+        # _implementation implements the actual functionality.
+        engine = self._series_object.engine
+        self._implementation: Union[JsonPostgresAccessorImpl, JsonBigQueryAccessorImpl]
+        if is_postgres(engine):
+            self._implementation = JsonPostgresAccessorImpl(series_object)
+        elif is_bigquery(engine):
+            self._implementation = JsonBigQueryAccessorImpl(series_object)
+        else:
+            raise DatabaseNotSupportedException(engine)
+
     def __getitem__(self, key: Union[str, int, slice]) -> 'TSeriesJson':
         """
-        Slice the JSON data in pythonic ways
+        Get item(s) from the JSON data in pythonic ways.
+        The way item(s) are looked up depends on the type of key.
+
+        If key is an integer, then this returns an item from the json array.
+        The key is treated as a 0-based index. If negative this will count from the end of the array (one
+            based). The index MUST exist in the array.
+        This assumes the top-level item in the json is an array
+
+        If key is a slice, the this returns a slice from the json array.
+        This assumes the top-level item in the json is an array
+
+        If key is a string, then this returns an item from the json object. The item belonging to the given
+            key is returned.
+        This assumes the top-level item in the json is an object
         """
         # TODO: leverage instance_dtype information here, if we have that
         if isinstance(key, int):
-            return self._get_array_item(key)
+            return self._implementation.get_array_item(key)
 
         elif isinstance(key, str):
-            return self._get_dict_item(key)
+            return self._implementation.get_dict_item(key)
 
         elif isinstance(key, slice):
-            return self._get_array_slice(key)
+            return self._implementation.get_array_slice(key)
 
         raise TypeError('Key should either be a string, integer, or slice.')
 
-    @abstractmethod
-    def _get_array_slice(self, key: slice) -> 'TSeriesJson':
-        """
-        Get items from toplevel array.
-
-        This assumes the top-level item in the json is an array. Will result in an exception (later on) if
-        that's not the case!
-
-        :param key: array-slice.
-        :returns: series with the selected values.
-        """
-        raise NotImplementedError()
-
-    @abstractmethod
-    def _get_array_item(self, key: int) -> 'TSeriesJson':
-        """
-        Get item from toplevel array.
-
-        This assumes the top-level item in the json is an array. Will result in an exception (later on) if
-        that's not the case!
-
-        :param key: the 0-based index. If negative this will count from the end of the array (1 based). The
-            index MUST exist in the array
-        :returns: series with the selected value.
-        """
-        raise NotImplementedError()
-
-    @abstractmethod
-    def _get_dict_item(self, key: str) -> 'TSeriesJson':
-        """
-        Get item from toplevel object by key.
-
-        This assumes the top-level item in the json is an object. Will result in an exception (later on) if
-        that's not the case!
-
-        :param key: the key to return the values for.
-        :returns: series with the selected value.
-        """
-        raise NotImplementedError()
-
-    @abstractmethod
     def get_value(self, key: str, as_str: bool = False) -> Union['SeriesString', 'TSeriesJson']:
         """
         Get item from toplevel object by key.
@@ -408,9 +390,8 @@ class JsonAccessor(Generic[TSeriesJson]):
         :param as_str: if True, it returns a string Series, json otherwise.
         :returns: series with the selected object value.
         """
-        raise NotImplementedError()
+        return self._implementation.get_value(key=key, as_str=as_str)
 
-    @abstractmethod
     def get_array_length(self) -> 'SeriesInt64':
         """
         Get the length of the toplevel array.
@@ -421,15 +402,18 @@ class JsonAccessor(Generic[TSeriesJson]):
         # Implementing a more generic __len__() function is not trivial as a json object can be (among
         # others) an array, a dict, or a string, all of which should be supported by a generic __len__().
         # So for now we have a dedicated len function for arrays.
-        raise NotImplementedError()
+        return self._implementation.get_array_length()
 
 
-class JsonBigQueryAccessor(JsonAccessor, Generic[TSeriesJson]):
+class JsonBigQueryAccessorImpl(Generic[TSeriesJson]):
     """
-    BigQuery specific implementation of JsonAccessor.
+    BigQuery specific implementation of JsonAccessor functions.
     """
 
-    def _get_array_slice(self, key: slice) -> 'TSeriesJson':
+    def __init__(self, series_object: 'TSeriesJson'):
+        self._series_object = series_object
+
+    def get_array_slice(self, key: slice) -> 'TSeriesJson':
         """ See implementation in parent class :class:`JsonAccessor` """
         if key.step:
             raise NotImplementedError('slice steps not supported')
@@ -479,7 +463,7 @@ class JsonBigQueryAccessor(JsonAccessor, Generic[TSeriesJson]):
             array_len = self.get_array_length()
             return Expression.construct(f'({{}} {value})', array_len)
 
-    def _get_array_item(self, key: int) -> 'TSeriesJson':
+    def get_array_item(self, key: int) -> 'TSeriesJson':
         """ For documentation, see implementation in parent class :class:`JsonAccessor` """
         if key >= 0:
             expression = Expression.construct(f'''JSON_QUERY({{}}, '$[{key}]')''', self._series_object)
@@ -491,7 +475,7 @@ class JsonBigQueryAccessor(JsonAccessor, Generic[TSeriesJson]):
         expression = Expression.construct('JSON_QUERY_ARRAY({})[{}]', self._series_object, expr_offset)
         return self._series_object.copy_override(expression=expression)
 
-    def _get_dict_item(self, key: str) -> 'TSeriesJson':
+    def get_dict_item(self, key: str) -> 'TSeriesJson':
         """ For documentation, see implementation in parent class :class:`JsonAccessor` """
         return cast('TSeriesJson', self.get_value(key=key, as_str=False))
 
@@ -533,10 +517,13 @@ class JsonBigQueryAccessor(JsonAccessor, Generic[TSeriesJson]):
             .copy_override(expression=expression)
 
 
-class JsonPostgresAccessor(JsonAccessor, Generic[TSeriesJson]):
+class JsonPostgresAccessorImpl(Generic[TSeriesJson]):
     """
-    Postgres specific implementation of JsonAccessor.
+    Postgres specific implementation of JsonAccessor functions.
     """
+
+    def __init__(self, series_object: 'TSeriesJson'):
+        self._series_object = series_object
 
     def _find_in_json_list(self, key: Union[str, Dict[str, str]]):
         if isinstance(key, (dict, str)):
@@ -548,7 +535,7 @@ class JsonPostgresAccessor(JsonAccessor, Generic[TSeriesJson]):
         else:
             raise TypeError(f'key should be int or slice, actual type: {type(key)}')
 
-    def _get_array_slice(self, key: slice) -> 'TSeriesJson':
+    def get_array_slice(self, key: slice) -> 'TSeriesJson':
         """ See implementation in parent class :class:`JsonAccessor` """
         expression_references = 0
         if key.step:
@@ -600,12 +587,12 @@ class JsonPostgresAccessor(JsonAccessor, Generic[TSeriesJson]):
                 )
             )
 
-    def _get_array_item(self, key: int) -> 'TSeriesJson':
+    def get_array_item(self, key: int) -> 'TSeriesJson':
         """ For documentation, see implementation in parent class :class:`JsonAccessor` """
         return self._series_object \
             .copy_override(expression=Expression.construct(f'{{}}->{key}', self._series_object))
 
-    def _get_dict_item(self, key: str) -> 'TSeriesJson':
+    def get_dict_item(self, key: str) -> 'TSeriesJson':
         """ For documentation, see implementation in parent class :class:`JsonAccessor` """
         return cast('TSeriesJson', self.get_value(key=key, as_str=False))
 

--- a/bach/bach/series/series_json.py
+++ b/bach/bach/series/series_json.py
@@ -363,7 +363,7 @@ class JsonAccessor(Generic[TSeriesJson]):
             based). The index MUST exist in the array.
         This assumes the top-level item in the json is an array
 
-        If key is a slice, the this returns a slice from the json array.
+        If key is a slice, then this returns a slice from the json array.
         This assumes the top-level item in the json is an array
 
         If key is a string, then this returns an item from the json object. The item belonging to the given
@@ -387,7 +387,9 @@ class JsonAccessor(Generic[TSeriesJson]):
         Get item from toplevel object by key.
 
         :param key: the key to return the values for.
-        :param as_str: if True, it returns a string Series, json otherwise.
+        :param as_str: if True, it returns a string Series, json otherwise. Particular useful if the returned
+            value is in fact a string. In json the string will be represented as a quoted string, if this
+            field is set to true, the returned SeriesString will not have additional quotes.
         :returns: series with the selected object value.
         """
         return self._implementation.get_value(key=key, as_str=as_str)

--- a/bach/tests/unit/bach/test_series_json.py
+++ b/bach/tests/unit/bach/test_series_json.py
@@ -3,7 +3,7 @@ Copyright 2022 Objectiv B.V.
 """
 import pytest
 
-from bach.series.series_json import JsonBigQueryAccessor
+from bach.series.series_json import JsonBigQueryAccessorImpl
 from tests.unit.bach.util import get_fake_df
 
 
@@ -18,7 +18,7 @@ def test_bq_get_slice_partial_expr(dialect):
         data_names=['a'],
         dtype='json'
     )
-    jbqa = JsonBigQueryAccessor(df.a)
+    jbqa = JsonBigQueryAccessorImpl(df.a)
     assert jbqa._get_slice_partial_expr(None, True).to_sql(dialect) == '0'
     assert jbqa._get_slice_partial_expr(None, False).to_sql(dialect) == '9223372036854775807'
     assert jbqa._get_slice_partial_expr(5, False).to_sql(dialect) == '5'

--- a/modelhub/modelhub/series/series_objectiv.py
+++ b/modelhub/modelhub/series/series_objectiv.py
@@ -11,11 +11,12 @@ from bach import DataFrame
 from bach.expression import Expression, quote_string, quote_identifier
 from bach.series import Series
 from bach.series import SeriesJson
-from bach.series.series_json import JsonPostgresAccessor
+from bach.series.series_json import JsonAccessor
 from bach.types import register_dtype
+from sql_models.util import is_postgres, DatabaseNotSupportedException
 
 
-class ObjectivStack(JsonPostgresAccessor):
+class ObjectivStack(JsonAccessor):
     def get_from_context_with_type_series(self, type: str, key: str, dtype='string'):
         """
         .. _get_from_context_with_type_series:
@@ -27,6 +28,12 @@ class ObjectivStack(JsonPostgresAccessor):
         :param dtype: the dtype of the series to return.
         :returns: a series of type `dtype`
         """
+        dialect = self._series_object.engine.dialect
+        if is_postgres(dialect):
+            return self._postgres_get_from_context_with_type_series(type, key, dtype)
+        raise DatabaseNotSupportedException(dialect)
+
+    def _postgres_get_from_context_with_type_series(self, type: str, key: str, dtype='string'):
         dialect = self._series_object.engine.dialect
         expression_str = f'''
         jsonb_path_query_first({{}},

--- a/modelhub/modelhub/series/series_objectiv.py
+++ b/modelhub/modelhub/series/series_objectiv.py
@@ -13,7 +13,7 @@ from bach.series import Series
 from bach.series import SeriesJson
 from bach.series.series_json import JsonAccessor
 from bach.types import register_dtype
-from sql_models.util import is_postgres, DatabaseNotSupportedException
+from sql_models.util import is_postgres, DatabaseNotSupportedException, is_bigquery
 
 
 class ObjectivStack(JsonAccessor):
@@ -31,6 +31,8 @@ class ObjectivStack(JsonAccessor):
         dialect = self._series_object.engine.dialect
         if is_postgres(dialect):
             return self._postgres_get_from_context_with_type_series(type, key, dtype)
+        if is_bigquery(dialect):
+            return self._bigquery_get_from_context_with_type_series(type, key, dtype)
         raise DatabaseNotSupportedException(dialect)
 
     def _postgres_get_from_context_with_type_series(self, type: str, key: str, dtype='string'):
@@ -45,6 +47,21 @@ class ObjectivStack(JsonAccessor):
             Expression.string_value(key)
         )
         return self._series_object.copy_override_dtype(dtype).copy_override(expression=expression)
+
+    def _bigquery_get_from_context_with_type_series(self, type: str, key: str, dtype='string'):
+        select_ctx_expression = Expression.construct(
+            '''(
+              select first_value(ctx) over (order by pos)
+              from unnest(json_query_array({}, '$')) as ctx with offset as pos
+              where json_value(ctx, '$."_type"') = {}
+            )''',
+            self._series_object,
+            Expression.string_value(type)
+        )
+        ctx_series = self._series_object.copy_override(expression=select_ctx_expression)
+        as_str = dtype == 'string'
+        value_series = ctx_series.json.get_value(key=key, as_str=as_str)
+        return value_series.copy_override_dtype(dtype)
 
 
 @register_dtype(value_types=[], override_registered_types=True)

--- a/modelhub/tests_modelhub/functional/modelhub/test_series_objectiv.py
+++ b/modelhub/tests_modelhub/functional/modelhub/test_series_objectiv.py
@@ -23,7 +23,6 @@ def test_get_real_data(db_params: DBParams):
     )
 
 
-@pytest.mark.skip_bigquery  # TODO: BigQuery
 def test_objectiv_stack_type(db_params):
     bt = get_df_with_json_data_real(db_params)
 
@@ -42,7 +41,6 @@ def test_objectiv_stack_type(db_params):
     )
 
 
-@pytest.mark.skip_bigquery  # TODO: BigQuery
 def test_objectiv_stack_type2(db_params):
     bt = get_df_with_json_data_real(db_params)
 


### PR DESCRIPTION
## Changes
### Change 1: series_json code hierarchy
Changed code hierarchy in series_json.py, again:
* `JsonAccessor` no longer has subclasses for each database.
* `JsonAccessor` forwards calls to either `JsonPostgresAccessorImpl` or `JsonBigQueryAccessorImpl` depending on the engine

This change was needed because in modelhub we extend from `JsonAccessor`. If `JsonAccessor` already has subclasses per engine that means we would need a lot of classes and duplication. With this change the inheritance in modelhub stays unchanged.

### Change 2
Made the `ObjectivStack` in modelhub work with BigQuery.

More changes are still needed to enable all functionality in modelhub, but this is a first small step.