### PR TITLE
[ModelHub: BQ] Support BigQuery in Aggregate.session_duration

### DIFF
--- a/modelhub/modelhub/aggregate.py
+++ b/modelhub/modelhub/aggregate.py
@@ -142,10 +142,10 @@ class Aggregate:
 
         gdata = self._check_groupby(data=data, groupby=new_groupby)
         session_duration = gdata.aggregate({'moment': ['min', 'max']})
-        session_duration['session_duration'] = session_duration['moment_max']-session_duration['moment_min']
+        session_duration['session_duration'] = session_duration['moment_max'] - session_duration['moment_min']
 
         if exclude_bounces:
-            session_duration = session_duration[(session_duration['session_duration'] > '0')]
+            session_duration = session_duration[(session_duration['session_duration'].dt.total_seconds > 0)]
 
         if method not in ['sum', 'mean']:
             raise ValueError("only 'sum and 'mean' are supported for `method`")

--- a/modelhub/tests_modelhub/functional/modelhub/test_model_hub_logistic_regression.py
+++ b/modelhub/tests_modelhub/functional/modelhub/test_model_hub_logistic_regression.py
@@ -9,6 +9,7 @@ import pytest
 from tests.functional.bach.test_data_and_utils import get_df_with_test_data
 from tests_modelhub.functional.modelhub.logistic_regression_test_utils import TestLR
 from tests_modelhub.data_and_utils.utils import create_engine_from_db_params
+pytestmark = [pytest.mark.skip_bigquery]  # TODO: BigQuery
 
 
 def test_fitted_model(db_params):

--- a/modelhub/tests_modelhub/functional/modelhub/test_model_hub_session_duration.py
+++ b/modelhub/tests_modelhub/functional/modelhub/test_model_hub_session_duration.py
@@ -3,11 +3,9 @@ Copyright 2021 Objectiv B.V.
 """
 
 # Any import from modelhub initializes all the types, do not remove
-import pandas
 from sql_models.util import is_bigquery
 
 from modelhub import __version__
-import pytest
 from tests_modelhub.data_and_utils.utils import get_objectiv_dataframe_test
 from tests.functional.bach.test_data_and_utils import assert_equals_data
 import datetime
@@ -22,18 +20,37 @@ def test_defaults(db_params):
     assert len(s.to_numpy()) == 0
 
 
-@pytest.mark.parametrize("exclude_bounces,expected_data", [
-    (True, [[pandas.Timedelta(microseconds=2667)]]),
-    (False, [[pandas.Timedelta(microseconds=1143)]])
-])
-def test_no_grouping(db_params, exclude_bounces, expected_data):
+def test_no_grouping_excluded_bounces(db_params):
     # not grouping to anything
     df, modelhub = get_objectiv_dataframe_test(db_params)
-    s = modelhub.aggregate.session_duration(df, groupby=None, exclude_bounces=exclude_bounces)
+    s = modelhub.aggregate.session_duration(df, groupby=None, exclude_bounces=True)
+    expected_data = [[datetime.timedelta(microseconds=2667)]]
+    if is_bigquery(df.engine):
+        # BQ does not rounds nanoprecision, just truncates it
+        expected_data = [[datetime.timedelta(microseconds=2666)]]
+
     assert_equals_data(
         s,
         expected_columns=['session_duration'],
         expected_data=expected_data,
+        use_to_pandas=True,
+    )
+
+
+def test_no_grouping_without_excluded_bounces(db_params):
+    # not grouping to anything
+    df, modelhub = get_objectiv_dataframe_test(db_params)
+    s = modelhub.aggregate.session_duration(df, groupby=None, exclude_bounces=False)
+    expected_data = [[datetime.timedelta(microseconds=1143)]]
+    if is_bigquery(df.engine):
+        # BQ does not rounds nanoprecision, just truncates it
+        expected_data = [[datetime.timedelta(microseconds=1142)]]
+
+    assert_equals_data(
+        s,
+        expected_columns=['session_duration'],
+        expected_data=expected_data,
+        use_to_pandas=True,
     )
 
 
@@ -49,8 +66,10 @@ def test_time_aggregation_in_df(db_params):
             ['2021-11-29', datetime.timedelta(microseconds=1000)],
             ['2021-11-30', datetime.timedelta(microseconds=4000)],
             ['2021-12-01', datetime.timedelta(microseconds=3000)]
-        ]
+        ],
+        use_to_pandas=True,
     )
+
 
 def test_overriding_time_aggregation_in(db_params):
     # overriding time_aggregation
@@ -60,8 +79,11 @@ def test_overriding_time_aggregation_in(db_params):
     assert_equals_data(
         bts,
         expected_columns=['time_aggregation', 'session_duration'],
-        expected_data=[['2021-11', datetime.timedelta(microseconds=2500)],
-            ['2021-12', datetime.timedelta(microseconds=3000)]]
+        expected_data=[
+            ['2021-11', datetime.timedelta(microseconds=2500)],
+            ['2021-12', datetime.timedelta(microseconds=3000)]
+        ],
+        use_to_pandas=True,
     )
 
     bts = modelhub.aggregate.session_duration(df, groupby=modelhub.time_agg(df, '%Y-%m'), method='sum')
@@ -69,20 +91,30 @@ def test_overriding_time_aggregation_in(db_params):
     assert_equals_data(
         bts,
         expected_columns=['time_aggregation', 'session_duration'],
-        expected_data=[['2021-11', datetime.timedelta(microseconds=5000)],
-            ['2021-12', datetime.timedelta(microseconds=3000)]]
+        expected_data=[
+            ['2021-11', datetime.timedelta(microseconds=5000)],
+            ['2021-12', datetime.timedelta(microseconds=3000)],
+        ],
+        use_to_pandas=True,
     )
+
 
 def test_groupby(db_params):
     # group by other columns
     df, modelhub = get_objectiv_dataframe_test(db_params, time_aggregation='%Y-%m-%d')
     s = modelhub.aggregate.session_duration(df, groupby='event_type')
+    expected_session_duration = datetime.timedelta(microseconds=2667)
+    if is_bigquery(df.engine):
+        # BQ does not rounds nanoprecision, just truncates it
+        expected_session_duration = datetime.timedelta(microseconds=2666)
 
     assert_equals_data(
         s,
         expected_columns=['event_type', 'session_duration'],
-        expected_data=[['ClickEvent', datetime.timedelta(microseconds=2667)]]
+        expected_data=[['ClickEvent', expected_session_duration]],
+        use_to_pandas=True,
     )
+
 
 def test_groupby_incl_time_agg(db_params):
     # group by other columns (as series), including time_agg
@@ -96,5 +128,6 @@ def test_groupby_incl_time_agg(db_params):
             ['2021-11', 1, datetime.timedelta(microseconds=1000)],
             ['2021-11', 3, datetime.timedelta(microseconds=4000)],
             ['2021-12', 4, datetime.timedelta(microseconds=3000)]
-        ]
+        ],
+        use_to_pandas=True,
     )

--- a/modelhub/tests_modelhub/functional/modelhub/test_model_hub_session_duration.py
+++ b/modelhub/tests_modelhub/functional/modelhub/test_model_hub_session_duration.py
@@ -3,12 +3,14 @@ Copyright 2021 Objectiv B.V.
 """
 
 # Any import from modelhub initializes all the types, do not remove
+import pandas
+from sql_models.util import is_bigquery
+
 from modelhub import __version__
 import pytest
 from tests_modelhub.data_and_utils.utils import get_objectiv_dataframe_test
 from tests.functional.bach.test_data_and_utils import assert_equals_data
 import datetime
-pytestmark = [pytest.mark.skip_bigquery]  # TODO: BigQuery
 
 
 def test_defaults(db_params):
@@ -19,20 +21,21 @@ def test_defaults(db_params):
     # with standard time_aggregation, all sessions are bounces
     assert len(s.to_numpy()) == 0
 
+
 @pytest.mark.parametrize("exclude_bounces,expected_data", [
-    (True, [[datetime.timedelta(microseconds=2667)]]),
-    (False, [[datetime.timedelta(microseconds=1143)]])
+    (True, [[pandas.Timedelta(microseconds=2667)]]),
+    (False, [[pandas.Timedelta(microseconds=1143)]])
 ])
 def test_no_grouping(db_params, exclude_bounces, expected_data):
     # not grouping to anything
     df, modelhub = get_objectiv_dataframe_test(db_params)
     s = modelhub.aggregate.session_duration(df, groupby=None, exclude_bounces=exclude_bounces)
-
     assert_equals_data(
         s,
         expected_columns=['session_duration'],
-        expected_data=expected_data
+        expected_data=expected_data,
     )
+
 
 def test_time_aggregation_in_df(db_params):
     # using time_aggregation (and default groupby: mh.time_agg(df, ))


### PR DESCRIPTION
Just changed the condition used in `session_duration` method, comparing an interval with a string is not supported in BigQuery. So use `dt.total_seconds` instead.


**Nano-precision Problem**

While I was changing test, I got into a weird problem with intervals containing nano-precision. For example, since modelhub can aggregate session durations by `avg` aggregation function, it is possible to generate something like this:
`0-0 0 00:00:00.123456789`. The main problem is if user tries to convert this into a Timestamp or do `dt.total_seconds`. 
Bach will generate the following expression: `UNIX_MICROS(CAST('1970-01-01' AS TIMESTAMP) + interval_column)` <- this will raise an error when executing a query, since BQ Timestamps support till microseconds precision. I'm still not sure how this can be solved, there's no way to date format an interval, and other idea is extracting each date part from interval and rebuild it (already tried justifying it but does not work)

Here for test:

```sql
with `example_session_duration_nano` as (
  select * from 
    UNNEST([STRUCT<`_index__session_id` INT64, `session_duration` INTERVAL> 
    (2, cast("""P0DT0H0M0S""" as INTERVAL)),
    (4, cast("""P0DT0H0M0.003S""" as INTERVAL)),
    (1, cast("""P0DT0H0M0.001S""" as INTERVAL)),
    (3, cast("""P0DT0H0M0.004S""" as INTERVAL)),
    (5, cast("""P0DT0H0M0S""" as INTERVAL)),
    (6, cast("""P0DT0H0M0S""" as INTERVAL)),
    (7, cast("""P0DT0H0M0S""" as INTERVAL))
  ])
)
select 
avg(`session_duration`) as `average_session_duration`,
CAST('1970-01-01' AS TIMESTAMP) + avg(`session_duration`)  # raises exception: Operation results in TIMESTAMP with nanoseconds precision
from `example_session_duration_nano` 
 
 
```