### PR TITLE
Make plugin lists extendible, instead of replaceable, in all Trackers

### DIFF
--- a/tracker/core/tracker/src/TrackerTransportRetryAttempt.ts
+++ b/tracker/core/tracker/src/TrackerTransportRetryAttempt.ts
@@ -118,7 +118,10 @@ export class TrackerTransportRetryAttempt implements TrackerTransportRetryAttemp
       })
       .catch((error) => {
         if (globalThis.objectiv) {
-          globalThis.objectiv.TrackerConsole.groupCollapsed(`%c｢objectiv:TrackerTransportRetryAttempt｣ Failed`, 'color:red');
+          globalThis.objectiv.TrackerConsole.groupCollapsed(
+            `%c｢objectiv:TrackerTransportRetryAttempt｣ Failed`,
+            'color:red'
+          );
           globalThis.objectiv.TrackerConsole.log(`Error:`);
           globalThis.objectiv.TrackerConsole.log(error);
           globalThis.objectiv.TrackerConsole.log(`Events:`);
@@ -150,7 +153,10 @@ export class TrackerTransportRetryAttempt implements TrackerTransportRetryAttemp
     this.attemptCount++;
 
     if (globalThis.objectiv) {
-      globalThis.objectiv.TrackerConsole.groupCollapsed(`%c｢objectiv:TrackerTransportRetryAttempt｣ Retrying`, 'color:orange');
+      globalThis.objectiv.TrackerConsole.groupCollapsed(
+        `%c｢objectiv:TrackerTransportRetryAttempt｣ Retrying`,
+        'color:orange'
+      );
       globalThis.objectiv.TrackerConsole.log(`Attempt Count: ${this.attemptCount}`);
       globalThis.objectiv.TrackerConsole.log(`Waited: ${nextTimeoutMs}`);
       globalThis.objectiv.TrackerConsole.log(`Error:`);

--- a/tracker/trackers/angular/src/AngularTracker.ts
+++ b/tracker/trackers/angular/src/AngularTracker.ts
@@ -5,6 +5,7 @@
 import {
   BrowserTrackerConfig,
   ContextsConfig,
+  isPluginsArray,
   makeBrowserTrackerDefaultPluginsList,
   makeBrowserTrackerDefaultQueue,
   makeBrowserTrackerDefaultTransport,
@@ -46,11 +47,10 @@ export class AngularTracker extends Tracker {
     }
 
     // Configure to use provided `plugins` or automatically create a Plugins instance with some sensible web defaults
-    if (!config.plugins) {
-      config = {
-        ...config,
-        plugins: makeBrowserTrackerDefaultPluginsList(config),
-      };
+    if (isPluginsArray(trackerConfig.plugins) || trackerConfig.plugins === undefined) {
+      config.plugins = [...makeBrowserTrackerDefaultPluginsList(trackerConfig), ...(trackerConfig.plugins ?? [])];
+    } else {
+      config.plugins = trackerConfig.plugins;
     }
 
     // Initialize core Tracker

--- a/tracker/trackers/browser/src/BrowserTracker.ts
+++ b/tracker/trackers/browser/src/BrowserTracker.ts
@@ -2,7 +2,7 @@
  * Copyright 2021-2022 Objectiv B.V.
  */
 
-import { ContextsConfig, Tracker, TrackerConfig, TrackerPlatform } from '@objectiv/tracker-core';
+import { ContextsConfig, isPluginsArray, Tracker, TrackerConfig, TrackerPlatform } from '@objectiv/tracker-core';
 import { makeBrowserTrackerDefaultPluginsList } from './common/factories/makeBrowserTrackerDefaultPluginsList';
 import { makeBrowserTrackerDefaultQueue } from './common/factories/makeBrowserTrackerDefaultQueue';
 import { makeBrowserTrackerDefaultTransport } from './common/factories/makeBrowserTrackerDefaultTransport';
@@ -73,11 +73,10 @@ export class BrowserTracker extends Tracker {
     }
 
     // Configure to use provided `plugins` or automatically create a Plugins instance with some sensible web defaults
-    if (!config.plugins) {
-      config = {
-        ...config,
-        plugins: makeBrowserTrackerDefaultPluginsList(config),
-      };
+    if (isPluginsArray(trackerConfig.plugins) || trackerConfig.plugins === undefined) {
+      config.plugins = [...makeBrowserTrackerDefaultPluginsList(trackerConfig), ...(trackerConfig.plugins ?? [])];
+    } else {
+      config.plugins = trackerConfig.plugins;
     }
 
     // Initialize core Tracker

--- a/tracker/trackers/browser/tests/BrowserTracker.test.ts
+++ b/tracker/trackers/browser/tests/BrowserTracker.test.ts
@@ -2,10 +2,12 @@
  * Copyright 2021-2022 Objectiv B.V.
  */
 
+import { RootLocationContextFromURLPlugin } from '@objectiv/plugin-root-location-context-from-url';
 import { MockConsoleImplementation } from '@objectiv/testing-tools';
 import {
   GlobalContextName,
   TrackerEvent,
+  TrackerPlugins,
   TrackerQueue,
   TrackerQueueMemoryStore,
   TrackerTransportRetry,
@@ -138,6 +140,47 @@ describe('BrowserTracker', () => {
       expect(testTracker).toBeInstanceOf(BrowserTracker);
       expect(testTracker.plugins?.plugins).toEqual([
         expect.objectContaining({ pluginName: 'OpenTaxonomyValidationPlugin' }),
+      ]);
+    });
+
+    it('should allow customizing a plugin, without affecting the existing ones', () => {
+      const testTracker = new BrowserTracker({
+        applicationId: 'app-id',
+        endpoint: 'localhost',
+        plugins: [
+          new RootLocationContextFromURLPlugin({
+            idFactoryFunction: () => 'test',
+          }),
+        ],
+      });
+      expect(testTracker).toBeInstanceOf(BrowserTracker);
+      expect(testTracker.plugins?.plugins).toEqual([
+        expect.objectContaining({ pluginName: 'OpenTaxonomyValidationPlugin' }),
+        expect.objectContaining({ pluginName: 'ApplicationContextPlugin' }),
+        expect.objectContaining({ pluginName: 'HttpContextPlugin' }),
+        expect.objectContaining({ pluginName: 'PathContextFromURLPlugin' }),
+        expect.objectContaining({ pluginName: 'RootLocationContextFromURLPlugin' }),
+      ]);
+    });
+
+    it('should allow customizing the plugin set', () => {
+      const testTracker = new BrowserTracker({
+        applicationId: 'app-id',
+        endpoint: 'localhost',
+      });
+      const trackerClone = new BrowserTracker({
+        applicationId: 'app-id',
+        endpoint: 'localhost',
+        plugins: new TrackerPlugins({ tracker: testTracker, plugins: testTracker.plugins.plugins }),
+      });
+
+      expect(trackerClone).toBeInstanceOf(BrowserTracker);
+      expect(trackerClone.plugins?.plugins).toEqual([
+        expect.objectContaining({ pluginName: 'OpenTaxonomyValidationPlugin' }),
+        expect.objectContaining({ pluginName: 'ApplicationContextPlugin' }),
+        expect.objectContaining({ pluginName: 'HttpContextPlugin' }),
+        expect.objectContaining({ pluginName: 'PathContextFromURLPlugin' }),
+        expect.objectContaining({ pluginName: 'RootLocationContextFromURLPlugin' }),
       ]);
     });
   });

--- a/tracker/trackers/browser/tests/getElementLocationStack.test.ts
+++ b/tracker/trackers/browser/tests/getElementLocationStack.test.ts
@@ -61,7 +61,7 @@ describe('getElementLocationStack', () => {
     const applicationId = 'app';
     const endpoint = 'http://test';
     const plugins: TrackerPluginInterface[] = [new PathContextFromURLPlugin()];
-    const tracker = new BrowserTracker({ applicationId, endpoint, plugins });
+    const tracker = new BrowserTracker({ applicationId, endpoint, plugins, trackRootLocationContextFromURL: false });
 
     const expectedPathsByElement: [TaggableElement, string][] = [
       [mainSection, 'Content:main'],
@@ -87,7 +87,13 @@ describe('getElementLocationStack', () => {
     const endpoint = 'http://test';
     const location_stack: LocationStack = [makeContentContext({ id: 'root' })];
     const plugins: TrackerPluginInterface[] = [new PathContextFromURLPlugin()];
-    const tracker = new BrowserTracker({ applicationId, endpoint, plugins, location_stack });
+    const tracker = new BrowserTracker({
+      applicationId,
+      endpoint,
+      plugins,
+      location_stack,
+      trackRootLocationContextFromURL: false,
+    });
 
     const expectedPathsByElement: [TaggableElement, string][] = [
       [mainSection, 'Content:root / Content:main'],

--- a/tracker/trackers/react-native/src/ReactNativeTracker.ts
+++ b/tracker/trackers/react-native/src/ReactNativeTracker.ts
@@ -2,7 +2,7 @@
  * Copyright 2021-2022 Objectiv B.V.
  */
 
-import { ContextsConfig, Tracker, TrackerConfig, TrackerPlatform } from '@objectiv/tracker-core';
+import { ContextsConfig, isPluginsArray, Tracker, TrackerConfig, TrackerPlatform } from '@objectiv/tracker-core';
 import { makeReactNativeTrackerDefaultPluginsList } from './common/factories/makeReactNativeTrackerDefaultPluginsList';
 import { makeReactNativeTrackerDefaultQueue } from './common/factories/makeReactNativeTrackerDefaultQueue';
 import { makeReactNativeTrackerDefaultTransport } from './common/factories/makeReactNativeTrackerDefaultTransport';
@@ -73,11 +73,10 @@ export class ReactNativeTracker extends Tracker {
     }
 
     // Configure to use provided `plugins` or automatically create a Plugins instance with some sensible web defaults
-    if (!config.plugins) {
-      config = {
-        ...config,
-        plugins: makeReactNativeTrackerDefaultPluginsList(),
-      };
+    if (isPluginsArray(trackerConfig.plugins) || trackerConfig.plugins === undefined) {
+      config.plugins = [...makeReactNativeTrackerDefaultPluginsList(), ...(trackerConfig.plugins ?? [])];
+    } else {
+      config.plugins = trackerConfig.plugins;
     }
 
     // Initialize Core Tracker

--- a/tracker/trackers/react/src/ReactTracker.ts
+++ b/tracker/trackers/react/src/ReactTracker.ts
@@ -2,7 +2,7 @@
  * Copyright 2021-2022 Objectiv B.V.
  */
 
-import { ContextsConfig, Tracker, TrackerConfig, TrackerPlatform } from '@objectiv/tracker-core';
+import { ContextsConfig, isPluginsArray, Tracker, TrackerConfig, TrackerPlatform } from '@objectiv/tracker-core';
 import { makeReactTrackerDefaultPluginsList } from './common/factories/makeReactTrackerDefaultPluginsList';
 import { makeReactTrackerDefaultQueue } from './common/factories/makeReactTrackerDefaultQueue';
 import { makeReactTrackerDefaultTransport } from './common/factories/makeReactTrackerDefaultTransport';
@@ -96,11 +96,10 @@ export class ReactTracker extends Tracker {
     }
 
     // Configure to use provided `plugins` or automatically create a Plugins instance with some sensible web defaults
-    if (!config.plugins) {
-      config = {
-        ...config,
-        plugins: makeReactTrackerDefaultPluginsList(config),
-      };
+    if (isPluginsArray(trackerConfig.plugins) || trackerConfig.plugins === undefined) {
+      config.plugins = [...makeReactTrackerDefaultPluginsList(trackerConfig), ...(trackerConfig.plugins ?? [])];
+    } else {
+      config.plugins = trackerConfig.plugins;
     }
 
     // Initialize Core Tracker


### PR DESCRIPTION
Our documentation illustrates how to reconfigure Root Locations with an example that actually does not match how plugins can be configured in all Trackers: https://objectiv.io/docs/tracking/react/how-to-guides/configuring-root-locations#specifying-a-customized-plugin

---

For example, suppose the original plugin list of React Tracker is 

```
[
   ApplicationContextPlugin, 
   OpenTaxonomyValidationPlugin, 
   HttpContextPlugin, 
   PathContextFromURLPlugin, 
   RootLocationContextFromURLPlugin
]
```

With the previous version of the code, if developers specified a custom `RootLocationContextFromURLPlugin` by setting the trackers plugins like described in the docs:
```
const tracker = new ReactTracker({
  applicationId: 'app-id',
  endpoint: 'https://collector.app.dev',
  plugins: [
    new RootLocationContextFromURLPlugin({
      idFactoryFunction: customIdFactoryFunction
    })    
  ]
});
```

That would produce a final list of plugins equal to 
```
[
  RootLocationContextFromURLPlugin
]
````

This is not what we want.  

With the new changes, instead the given `RootLocationContextFromURLPlugin` will simply replace the existing one.
