### PR TITLE
Modelhub bq locationstack

### DIFF
--- a/modelhub/modelhub/modelhub.py
+++ b/modelhub/modelhub/modelhub.py
@@ -14,6 +14,7 @@ from modelhub.map import Map
 from modelhub.models.logistic_regression import LogisticRegression
 from modelhub.series.series_objectiv import MetaBase
 from sql_models.constants import NotSet
+from sql_models.util import is_bigquery
 
 if TYPE_CHECKING:
     from modelhub.series import SeriesLocationStack
@@ -100,7 +101,7 @@ class ModelHub:
     def get_objectiv_dataframe(
         self,
         db_url: str = None,
-        table_name: str = 'data',
+        table_name: str = None,
         start_date: str = None,
         end_date: str = None,
         *,
@@ -116,7 +117,8 @@ class ModelHub:
         :param db_url: the url that indicate database dialect and connection arguments. If not given, env DSN
             is used to create one. If that's not there, the default of
             'postgresql://objectiv:@localhost:5432/objectiv' will be used.
-        :param table_name: the name of the sql table where the data is stored.
+        :param table_name: the name of the sql table where the data is stored. Will default to 'events' for
+            bigquery and 'data' for other engines.
         :param start_date: first date for which data is loaded to the DataFrame. If None, data is loaded from
             the first date in the sql table. Format as 'YYYY-MM-DD'.
         :param end_date: last date for which data is loaded to the DataFrame. If None, data is loaded up to
@@ -129,6 +131,11 @@ class ModelHub:
         """
         engine = self._get_db_engine(db_url=db_url, bq_credentials_path=bq_credentials_path)
         from modelhub.stack import get_sessionized_data
+        if table_name is None:
+            if is_bigquery(engine):
+                table_name = 'events'
+            else:
+                table_name = 'data'
 
         data = get_sessionized_data(
             engine=engine,

--- a/modelhub/modelhub/series/series_objectiv.py
+++ b/modelhub/modelhub/series/series_objectiv.py
@@ -252,13 +252,16 @@ class SeriesLocationStack(SeriesJson):
             return series
 
         @property
-        def nice_name(self) -> 'SeriesJson':
+        def nice_name(self) -> 'SeriesString':
             """
             .. _ls_nice_name:
 
             Returns a nice name for the location stack. This is a human readable name for the data in the
             feature stack.
             """
+            if is_bigquery(self._series_object.engine):
+                # TODO: This is temporary, just so that we have something
+                return self._series_object.json[0].json.get_value('_type', as_str=True) + ' TODO'
             expression = Expression.construct(
                 f"""(
                 select array_to_string(

--- a/modelhub/modelhub/series/series_objectiv.py
+++ b/modelhub/modelhub/series/series_objectiv.py
@@ -4,19 +4,26 @@ Copyright 2021 Objectiv B.V.
 import json
 import os
 
+from typing import List, Generic, TypeVar
 # added for metabase export
 import requests
 
-from bach import DataFrame
+from bach import DataFrame, Series, SeriesString, SeriesJson
 from bach.expression import Expression, quote_string, quote_identifier
-from bach.series import Series
-from bach.series import SeriesJson
 from bach.series.series_json import JsonAccessor
 from bach.types import register_dtype
 from sql_models.util import is_postgres, DatabaseNotSupportedException, is_bigquery
 
 
-class ObjectivStack(JsonAccessor):
+TSeriesJson = TypeVar('TSeriesJson', bound='SeriesJson')
+
+
+class ObjectivStack(JsonAccessor, Generic[TSeriesJson]):
+    """
+    Specialized JsonAccessor that has functions to work on SeriesJsons whose data consists of an array
+    of objects.
+    """
+
     def get_from_context_with_type_series(self, type: str, key: str, dtype='string'):
         """
         .. _get_from_context_with_type_series:
@@ -62,6 +69,67 @@ class ObjectivStack(JsonAccessor):
         as_str = dtype == 'string'
         value_series = ctx_series.json.get_value(key=key, as_str=as_str)
         return value_series.copy_override_dtype(dtype)
+
+    def filter_keys_of_dicts(self, keys: List[str]) -> 'TSeriesJson':
+        """
+        Return a new Series, that consists of the same top level array, but with all the sub-dictionaries
+        having only their original fields if that field is listed in the keys parameter.
+        """
+        engine = self._series_object.engine
+        if is_postgres(engine):
+            return self._pg_filter_keys_of_dicts(keys)
+        if is_bigquery(engine):
+            return self._bigquery_filter_keys_of_dicts(keys)
+        raise DatabaseNotSupportedException(engine)
+
+    def _pg_filter_keys_of_dicts(self, keys: List[str]) -> 'TSeriesJson':
+        jsonb_build_object_str = [f"{quote_string(self._series_object.engine, key)}" for key in keys]
+        expression_str = f'''(
+            select jsonb_agg((
+                select json_object_agg(items.key, items.value)
+                from jsonb_each(objects.value) as items
+                where items.key in ({", ".join(jsonb_build_object_str)})))
+            from jsonb_array_elements({{}}) as objects)
+        '''
+        expression = Expression.construct(
+            expression_str,
+            self._series_object
+        )
+        return self._series_object.copy_override(expression=expression)
+
+    def _bigquery_filter_keys_of_dicts(self, keys: List[str]) -> 'TSeriesJson':
+        json_object_str_expressions = []
+        # We build a string that rebuilds the json object, with only the fields in keys.
+        # unfortunately BigQuery has no way (yet) to turn a struct into a json string, so we have to do raw
+        # string building to get a json.
+        for i, key in enumerate(keys):
+            if '"' in key:
+                raise ValueError(f'key values containing double quotes are not supported. key: {key}')
+            key_expr = Expression.construct('{}', Expression.string_value(json.dumps(key)))
+            colon_expr = Expression.string_value(': ')
+            val_expr = Expression.construct('''JSON_QUERY(item, '$."{}"')''', Expression.raw(key))
+            comma_expr = Expression.string_value(', ')
+            json_object_str_expressions.append(key_expr)
+            json_object_str_expressions.append(colon_expr)
+            json_object_str_expressions.append(val_expr)
+            if i < (len(keys) - 1):
+                json_object_str_expressions.append(comma_expr)
+        json_object_key_values_expr = Expression.construct(
+            ', '.join('{}' for _ in json_object_str_expressions),
+            *json_object_str_expressions
+        )
+        # Here we build the json object as a string by concatenating all earlier key-value and comma
+        # expressions.
+        json_object_expr = Expression.construct(
+            '''select concat('{', {}, '}') from unnest(json_query_array({}, '$')) as item''',
+            json_object_key_values_expr,
+            self._series_object,
+        )
+        json_str_expression = Expression.construct(
+            "'[' || ARRAY_TO_STRING(ARRAY({}), ', ') || ']'",
+            json_object_expr
+        )
+        return self._series_object.copy_override(expression=json_str_expression)
 
 
 @register_dtype(value_types=[], override_registered_types=True)
@@ -171,7 +239,7 @@ class SeriesLocationStack(SeriesJson):
             return self[{'_type': 'NavigationContext'}: None]
 
         @property
-        def feature_stack(self):
+        def feature_stack(self) -> 'SeriesLocationStack':
             """
             .. _ls_feature_stack:
 
@@ -179,24 +247,11 @@ class SeriesLocationStack(SeriesJson):
             and a `id` key.
             """
             keys = ['_type', 'id']
-            jsonb_build_object_str = [f"{quote_string(self._series_object.engine, key)}" for key in keys]
-            expression_str = f'''(
-                select jsonb_agg((
-                    select json_object_agg(items.key, items.value)
-                    from jsonb_each(objects.value) as items
-                    where items.key in ({", ".join(jsonb_build_object_str)})))
-                from jsonb_array_elements({{}}) as objects)
-            '''
-            expression = Expression.construct(
-                expression_str,
-                self._series_object
-            )
-            return self._series_object\
-                .copy_override_dtype('objectiv_location_stack')\
-                .copy_override(expression=expression)
+            series = self.filter_keys_of_dicts(keys=keys)
+            return series
 
         @property
-        def nice_name(self):
+        def nice_name(self) -> 'SeriesJson':
             """
             .. _ls_nice_name:
 
@@ -231,7 +286,7 @@ class SeriesLocationStack(SeriesJson):
                 self._series_object,
                 self._series_object
             )
-            return self._series_object.copy_override_dtype('string').copy_override(expression=expression)
+            return self._series_object.copy_override_type(SeriesString).copy_override(expression=expression)
 
     @property
     def objectiv(self):

--- a/modelhub/modelhub/series/series_objectiv.py
+++ b/modelhub/modelhub/series/series_objectiv.py
@@ -99,9 +99,10 @@ class ObjectivStack(JsonAccessor, Generic[TSeriesJson]):
 
     def _bigquery_filter_keys_of_dicts(self, keys: List[str]) -> 'TSeriesJson':
         json_object_str_expressions = []
-        # We build a string that rebuilds the json object, with only the fields in keys.
-        # unfortunately BigQuery has no way (yet) to turn a struct into a json string, so we have to do raw
-        # string building to get a json.
+        # We unnest the json-array, and then for every json object in the array we build a copy of that
+        # json object, but with only the keys that are listed in the `keys` variable.
+        # Unfortunately BigQuery has no way (yet) to turn a struct into a json string, so we have to do raw
+        # string building to get json objects.
         for i, key in enumerate(keys):
             if '"' in key:
                 raise ValueError(f'key values containing double quotes are not supported. key: {key}')

--- a/modelhub/tests_modelhub/functional/modelhub/test_series_objectiv.py
+++ b/modelhub/tests_modelhub/functional/modelhub/test_series_objectiv.py
@@ -78,7 +78,6 @@ def test_objectiv_stack_type3(db_params):
     )
 
 
-@pytest.mark.skip_bigquery  # TODO: BigQuery
 def test_objectiv_stack_type4(db_params):
     bt = get_df_with_json_data_real(db_params)
 
@@ -86,6 +85,7 @@ def test_objectiv_stack_type4(db_params):
     bts = bt.b.location_stack.feature_stack
     assert_equals_data(
         bts,
+        use_to_pandas=True,
         expected_columns=['_index_event_id', 'b'],
         expected_data=[
             [1, [{'id': '#document', '_type': 'WebDocumentContext'}, {'id': 'home', '_type': 'SectionContext'}, {'id': 'yep', '_type': 'SectionContext'}, {'id': 'cc91EfoBh8A', '_type': 'SectionContext'}]],

--- a/notebooks/model-hub-demo-notebook.ipynb
+++ b/notebooks/model-hub-demo-notebook.ipynb
@@ -416,7 +416,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.10"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Changes:
1. Make `Locationstack.feature_stack` work on BigQuery
2. Temporary work around for `LocationStack.nice_name`. Actual implementation will follow in later PR
3. Use 'events' as default table when running on BigQuery.

Results
With these changes a few of the steps in the `basic-product-analytics.ipynb` notebook work. To test that out simply add something like this to the top of that file:
```python
import os
os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = 'even_the_path_is_a_secret/objectiv-production--bigquery-read-only.json'
os.environ['DSN'] = 'bigquery://objectiv-production/snowplow'
```