### PR TITLE
Bach unittest, convert tests to multi-database

### DIFF
--- a/bach/tests/functional/bach/test_data_and_utils.py
+++ b/bach/tests/functional/bach/test_data_and_utils.py
@@ -185,13 +185,6 @@ def get_df_with_food_data(engine: Engine) -> DataFrame:
     raise ValueError(f'engine of type {engine.name} is not supported.')
 
 
-def get_bt_with_food_data() -> DataFrame:
-    """
-    DEPRECATED: Use get_df_with_food_data()
-    """
-    return get_bt(TEST_DATA_FOOD, FOOD_COLUMNS, True)
-
-
 def get_df_with_railway_data(engine: Engine) -> DataFrame:
     if is_postgres(engine):
         return get_bt(TEST_DATA_RAILWAYS, RAILWAYS_COLUMNS, True)

--- a/bach/tests/functional/bach/test_df_scale.py
+++ b/bach/tests/functional/bach/test_df_scale.py
@@ -1,13 +1,14 @@
 from sklearn.preprocessing import StandardScaler, MinMaxScaler
 
-from tests.functional.bach.test_data_and_utils import get_bt_with_test_data, assert_equals_data
+from tests.functional.bach.test_data_and_utils import get_df_with_test_data, assert_equals_data, \
+    get_bt_with_test_data
 import numpy as np
 
 
-def test_standard_scale() -> None:
+def test_standard_scale(engine) -> None:
     numerical_cols = ['skating_order', 'inhabitants', 'founding']
     all_cols = ['city'] + numerical_cols
-    bt = get_bt_with_test_data(full_data_set=True)[all_cols]
+    bt = get_df_with_test_data(engine, full_data_set=True)[all_cols]
 
     pdf = bt.to_pandas()
 

--- a/bach/tests/functional/bach/test_df_setitem.py
+++ b/bach/tests/functional/bach/test_df_setitem.py
@@ -3,9 +3,11 @@ Copyright 2021 Objectiv B.V.
 """
 import datetime
 from typing import Type, Any, List
-import pytest
 
+import pandas
+import pytest
 import numpy as np
+from pandas.core.indexes.numeric import Int64Index
 
 from bach import SeriesInt64, SeriesString, SeriesFloat64, SeriesDate, SeriesTimestamp, \
     SeriesTime, SeriesTimedelta, Series, SeriesJson, SeriesBoolean
@@ -456,8 +458,11 @@ def test_set_pandas_series_different_shape(engine):
 
 def test_set_pandas_series_different_shape_and_name(engine):
     bt = get_df_with_test_data(engine)
-    bt2 = get_df_with_railway_data(engine)  # has more rows and different name index
-    pandas_series = bt2['town'].to_pandas()
+    # Create a series with more rows and a differently named index.
+    pandas_series = pandas.Series(
+        data=['Drylts', 'It Hearrenfean', 'It Hearrenfean', 'Ljouwert', 'Ljouwert', 'Snits', 'Snits'],
+        index=Int64Index([1, 2, 3, 4, 5, 6, 7], dtype='int64', name='_index_station_id')
+    )
     bt['the_town'] = pandas_series
     assert_postgres_type(bt['the_town'], 'text', SeriesString)
     assert_equals_data(

--- a/bach/tests/functional/bach/test_df_setitem.py
+++ b/bach/tests/functional/bach/test_df_setitem.py
@@ -157,37 +157,36 @@ def test_set_series_column(engine):
     )
     assert bt.duplicated_column == bt['duplicated_column']
 
-    spaced_col_name = 'spaces in column'
-    if is_bigquery(engine):
-        # BigQuery doesn't support spaces in column names. So we don't test that functionality on that engine
-        spaced_col_name = 'spaces_in_column'
-    bt[spaced_col_name] = bt['founding']
-    assert_equals_data(
-        bt,
-        expected_columns=[
-            '_index_skating_order',  # index
-            'skating_order', 'city', 'municipality', 'inhabitants', 'founding', 'duplicated_column', spaced_col_name
-        ],
-        expected_data=[
-            [1, 1, 'Ljouwert', 'Leeuwarden', 93485, 1285, 1285, 1285],
-            [2, 2, 'Snits', 'Súdwest-Fryslân', 33520, 1456, 1456, 1456],
-            [3, 3, 'Drylts', 'Súdwest-Fryslân', 3055, 1268, 1268, 1268],
-        ]
-    )
-
     filtered_bt = bt[bt['city'] == 'Ljouwert']
     filtered_bt['town'] = filtered_bt['city']
     assert_equals_data(
         filtered_bt,
         expected_columns=[
             '_index_skating_order',  # index
-            'skating_order', 'city', 'municipality', 'inhabitants', 'founding', 'duplicated_column', spaced_col_name, 'town'
+            'skating_order', 'city', 'municipality', 'inhabitants', 'founding', 'duplicated_column', 'town'
         ],
         expected_data=[
-            [1, 1, 'Ljouwert', 'Leeuwarden', 93485, 1285, 1285, 1285, 'Ljouwert']
+            [1, 1, 'Ljouwert', 'Leeuwarden', 93485, 1285, 1285, 'Ljouwert']
         ]
     )
     assert filtered_bt.town == filtered_bt['town']
+
+@pytest.mark.skip_bigquery("Bigquery doesn't support spaces in column names")
+def test_set_series_column_name_with_spaces(engine):
+    bt = get_df_with_test_data(engine)
+    bt['spaces in column'] = bt['founding']
+    assert_equals_data(
+        bt,
+        expected_columns=[
+            '_index_skating_order',  # index
+            'skating_order', 'city', 'municipality', 'inhabitants', 'founding', 'spaces in column'
+        ],
+        expected_data=[
+            [1, 1, 'Ljouwert', 'Leeuwarden', 93485, 1285, 1285],
+            [2, 2, 'Snits', 'Súdwest-Fryslân', 33520, 1456, 1456],
+            [3, 3, 'Drylts', 'Súdwest-Fryslân', 3055, 1268, 1268],
+        ]
+    )
 
 
 def test_set_multiple(engine):

--- a/bach/tests/functional/bach/test_df_sort_index.py
+++ b/bach/tests/functional/bach/test_df_sort_index.py
@@ -1,7 +1,7 @@
 import pytest
 
 from tests.functional.bach.test_data_and_utils import assert_equals_data, \
-    get_bt_with_railway_data, get_df_with_test_data, get_df_with_railway_data
+    get_df_with_test_data, get_df_with_railway_data
 
 
 def test_sort_index_basic(engine):

--- a/bach/tests/functional/bach/test_df_stack.py
+++ b/bach/tests/functional/bach/test_df_stack.py
@@ -1,11 +1,10 @@
 import pandas as pd
-import pytest
 
-from tests.functional.bach.test_data_and_utils import get_bt_with_test_data, assert_equals_data
+from tests.functional.bach.test_data_and_utils import assert_equals_data, get_df_with_test_data
 
 
-def test_stack() -> None:
-    bt = get_bt_with_test_data(full_data_set=True)[['city', 'municipality', 'inhabitants']]
+def test_stack(engine) -> None:
+    bt = get_df_with_test_data(engine, full_data_set=True)[['city', 'municipality', 'inhabitants']]
     bt = bt.groupby(['municipality', 'city'])['inhabitants'].sum()
 
     unstacked_bt = bt.unstack()
@@ -63,8 +62,8 @@ def test_stack() -> None:
     )
 
 
-def test_stack_diff_types() -> None:
-    bt = get_bt_with_test_data(full_data_set=False)[['city', 'inhabitants']]
+def test_stack_diff_types(engine) -> None:
+    bt = get_df_with_test_data(engine, full_data_set=False)[['city', 'inhabitants']]
     pbt = bt.to_pandas()
 
     result = bt.stack().sort_index()

--- a/bach/tests/functional/bach/test_df_unstack.py
+++ b/bach/tests/functional/bach/test_df_unstack.py
@@ -1,6 +1,7 @@
 import pytest
 
-from tests.functional.bach.test_data_and_utils import get_bt_with_test_data, assert_equals_data
+from tests.functional.bach.test_data_and_utils import get_bt_with_test_data, assert_equals_data, \
+    get_df_with_test_data
 
 
 def test_basic_unstack() -> None:
@@ -81,8 +82,8 @@ def test_unstack_level() -> None:
         bt.unstack(level='random')
 
 
-def test_df_unstack_w_none():
-    bt = get_bt_with_test_data(full_data_set=True)
+def test_df_unstack_w_none(engine):
+    bt = get_df_with_test_data(engine, full_data_set=True)
     bt['municipality_none'] = bt[bt.skating_order < 10].municipality
     stacked_bt = bt.groupby(['city', 'municipality_none']).inhabitants.sum()
 

--- a/bach/tests/functional/bach/test_df_variables.py
+++ b/bach/tests/functional/bach/test_df_variables.py
@@ -7,7 +7,7 @@ from bach.dataframe import DtypeNamePair, DefinedVariable, DataFrame
 from sql_models.model import CustomSqlModelBuilder
 from sql_models.util import is_bigquery, is_postgres
 from tests.functional.bach.test_data_and_utils import get_df_with_test_data, assert_equals_data, \
-    get_df_with_food_data, get_bt_with_test_data
+    get_df_with_food_data
 
 
 def test_variable_happy_path(engine):
@@ -247,8 +247,8 @@ def test_get_all_variable_usage(engine):
     ]
 
 
-def test_variable_escaping():
-    df = get_bt_with_test_data()[['city']]
+def test_variable_escaping(engine):
+    df = get_df_with_test_data(engine)[['city']]
     df = df[df['city'] == 'Ljouwert']
 
     weird_value = ' %(test)s %%  ? {test} {{test2}} {{{test3}}} {{}"test"{}\'test\'\'"'

--- a/bach/tests/functional/bach/test_injection_escaping.py
+++ b/bach/tests/functional/bach/test_injection_escaping.py
@@ -6,12 +6,12 @@ The test below are to prevent regressions in the escaping logic.
 We use(d) format() in multiple places, which means `{` and `}` need to be escaped at times.
 The pandas.read_sql_query() function that uses '%' for placeholders, which means all `%` need to be escaped.
 """
-from tests.functional.bach.test_data_and_utils import get_bt_with_test_data, assert_equals_data
+from tests.functional.bach.test_data_and_utils import get_df_with_test_data, assert_equals_data
 
 
-def test_format_injection_simple():
+def test_format_injection_simple(engine):
     # We use(d) format() in multiple places, this test is to prevent regressions in correct escaping
-    bt1 = get_bt_with_test_data()[['city']]
+    bt1 = get_df_with_test_data(engine)[['city']]
     bt1['city'] = bt1['city'] + ' {{test}}'
     assert_equals_data(
         bt1,
@@ -25,8 +25,8 @@ def test_format_injection_simple():
     )
 
 
-def test_format_injection_more():
-    bt2 = get_bt_with_test_data()[['city']]
+def test_format_injection_more(engine):
+    bt2 = get_df_with_test_data(engine)[['city']]
     bt2['city'] = bt2['city'] + ' {test} {{test2}} {{{test3}}} {{}{}'
     assert_equals_data(
         bt2,
@@ -40,11 +40,11 @@ def test_format_injection_more():
     )
 
 
-def test_format_injection_merge():
+def test_format_injection_merge(engine):
     # We use(d) format() in multiple places, this test is to prevent regressions in correct escaping
-    bt1 = get_bt_with_test_data()[['city']]
+    bt1 = get_df_with_test_data(engine)[['city']]
     bt1['city'] = bt1['city'] + ' {{test}}'
-    bt2 = get_bt_with_test_data()[['city']]
+    bt2 = get_df_with_test_data(engine)[['city']]
     bt2['city'] = bt2['city'] + ' {test} {{test2}} {{{test3}}} {{}{}'
     bt = bt1.merge(bt2, on='_index_skating_order')
     assert_equals_data(
@@ -59,9 +59,9 @@ def test_format_injection_merge():
     )
 
 
-def test_percentage_injection():
+def test_percentage_injection(engine):
     # We use(d) format() in multiple places, this test is to prevent regressions in correct escaping
-    bt = get_bt_with_test_data()[['city']]
+    bt = get_df_with_test_data(engine)[['city']]
     bt['city'] = bt['city'] + ' %(test)s %%  ?'
     print(bt.engine)
     assert_equals_data(

--- a/bach/tests/functional/bach/test_series.py
+++ b/bach/tests/functional/bach/test_series.py
@@ -10,7 +10,7 @@ from bach.expression import Expression
 from sql_models.util import is_postgres, is_bigquery
 from tests.functional.bach.test_data_and_utils import (
     get_df_with_test_data, assert_equals_data, df_to_list,
-    get_df_with_railway_data, get_df_with_food_data, get_bt_with_test_data, get_bt_with_food_data
+    get_df_with_railway_data, get_df_with_food_data, get_bt_with_test_data
 )
 
 
@@ -730,9 +730,9 @@ def test__set_item_with_merge_different_dtypes() -> None:
         bt['inhabitants'] + bt2['inhabitants']
 
 
-def test__set_item_with_merge_w_group_shared_name() -> None:
-    bt = get_bt_with_test_data(full_data_set=True)
-    mt = get_bt_with_food_data()
+def test__set_item_with_merge_w_group_shared_name(engine) -> None:
+    bt = get_df_with_test_data(engine, full_data_set=True)
+    mt = get_df_with_food_data(engine)
     mt['inhabitants'] = mt.skating_order
 
     max_bt_inh = bt.groupby('skating_order').inhabitants.max()

--- a/bach/tests/functional/bach/test_series_boolean.py
+++ b/bach/tests/functional/bach/test_series_boolean.py
@@ -1,7 +1,6 @@
 import numpy
 
-from tests.functional.bach.test_data_and_utils import get_bt_with_test_data, assert_equals_data, \
-    get_df_with_test_data
+from tests.functional.bach.test_data_and_utils import assert_equals_data, get_df_with_test_data
 
 
 def test_from_const(engine):

--- a/bach/tests/functional/bach/test_series_float.py
+++ b/bach/tests/functional/bach/test_series_float.py
@@ -6,7 +6,7 @@ import math
 from unittest.mock import ANY
 
 from bach import SeriesFloat64
-from tests.functional.bach.test_data_and_utils import get_bt_with_test_data, assert_equals_data
+from tests.functional.bach.test_data_and_utils import assert_equals_data, get_df_with_test_data
 from tests.functional.bach.test_series_numeric import helper_test_simple_arithmetic
 
 
@@ -19,7 +19,7 @@ def test_from_value(engine):
     f = float('-infinity')
     g = None
 
-    bt = get_bt_with_test_data()[['city']]
+    bt = get_df_with_test_data(engine)[['city']]
     bt['a'] = a
     bt['b'] = b
     bt['c'] = c

--- a/bach/tests/functional/bach/test_series_int.py
+++ b/bach/tests/functional/bach/test_series_int.py
@@ -2,8 +2,8 @@
 Copyright 2021 Objectiv B.V.
 """
 from bach import Series, SeriesInt64
-from tests.functional.bach.test_data_and_utils import get_bt_with_test_data, assert_equals_data, \
-    assert_postgres_type, get_df_with_test_data
+from tests.functional.bach.test_data_and_utils import assert_equals_data, assert_postgres_type,\
+    get_df_with_test_data
 from tests.functional.bach.test_series_numeric import helper_test_simple_arithmetic
 
 

--- a/bach/tests/functional/bach/test_series_numeric.py
+++ b/bach/tests/functional/bach/test_series_numeric.py
@@ -9,9 +9,7 @@ from sqlalchemy.engine import Engine
 
 from bach import DataFrame
 from sql_models.util import is_postgres, is_bigquery
-from tests.functional.bach.test_data_and_utils import (
-    assert_equals_data, get_df_with_test_data, get_bt_with_test_data
-)
+from tests.functional.bach.test_data_and_utils import assert_equals_data, get_df_with_test_data
 
 
 def helper_test_simple_arithmetic(engine: Engine, a: Union[int, float], b: Union[int, float]):
@@ -300,8 +298,8 @@ def test_series_qcut(engine) -> None:
             np.testing.assert_almost_equal(exp.right, float(res.right), decimal=2)
 
 
-def test_series_scale() -> None:
-    inhabitants = get_bt_with_test_data(full_data_set=True)['inhabitants']
+def test_series_scale(engine) -> None:
+    inhabitants = get_df_with_test_data(engine, full_data_set=True)['inhabitants']
     result = inhabitants.scale()
 
     inhbt_values = inhabitants.to_numpy()
@@ -330,8 +328,8 @@ def test_series_scale() -> None:
     )
 
 
-def test_series_minmax_scale() -> None:
-    inhabitants = get_bt_with_test_data(full_data_set=True)['inhabitants']
+def test_series_minmax_scale(engine) -> None:
+    inhabitants = get_df_with_test_data(engine, full_data_set=True)['inhabitants']
     result = inhabitants.minmax_scale()
 
     min_inh = 700

--- a/bach/tests/functional/bach/test_series_string.py
+++ b/bach/tests/functional/bach/test_series_string.py
@@ -4,8 +4,7 @@ Copyright 2021 Objectiv B.V.
 import pandas as pd
 
 from bach import Series, SeriesString, DataFrame
-from tests.functional.bach.test_data_and_utils import get_bt_with_test_data, assert_equals_data, \
-    get_df_with_test_data
+from tests.functional.bach.test_data_and_utils import assert_equals_data, get_df_with_test_data
 
 
 def test_from_value(engine):

--- a/bach/tests/functional/bach/test_series_timedelta.py
+++ b/bach/tests/functional/bach/test_series_timedelta.py
@@ -8,7 +8,7 @@ import pandas as pd
 
 from bach import DataFrame
 from tests.functional.bach.test_data_and_utils import assert_equals_data, \
-    get_bt_with_test_data, get_df_with_test_data, get_df_with_food_data
+    get_df_with_test_data, get_df_with_food_data
 from tests.functional.bach.test_series_timestamp import types_plus_min
 
 


### PR DESCRIPTION
Changes to bach functional tests:
* Replaced calls to `get_bt_with_test_data()` with calls to `get_df_with_test_data()`, where possible.
* Replaced calls to `get_bt_with_railway_data()` with calls to `get_df_with_railway_data()` ,where possible.
* Got rid of `get_bt_with_food_data()` and replaced calls to it with calls to `get_df_with_food_data()`.