### PR TITLE
Run modelhub tests on github against BigQuery too

### DIFF
--- a/.github/workflows/bach-tests.yml
+++ b/.github/workflows/bach-tests.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Unit tests postgres
         run: |
           cd bach
-          pytest -n 4 --dist loadgroup --postgres tests/unit
+          pytest --postgres tests/unit
       - name: Functional tests postgres
         run: |
           cd bach
@@ -87,7 +87,7 @@ jobs:
       - name: Unit tests ALL
         run: |
           cd bach
-          pytest -n 4 --dist loadgroup --all tests/unit
+          pytest --all tests/unit
       - name: Functional tests ALL
         run: |
           cd bach

--- a/.github/workflows/modelhub_tests.yml
+++ b/.github/workflows/modelhub_tests.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Install BQ dependencies
         run: |
           cd modelhub
-          # We don't an equivalent requirement-bigquery.txt in modelhub, as the requirements should be the
+          # We don't have an equivalent requirement-bigquery.txt in modelhub, as the requirements should be the
           # same as for Bach
           pip install -r ../bach/requirements-bigquery.txt
       - name: Setup GCP Credentials

--- a/.github/workflows/modelhub_tests.yml
+++ b/.github/workflows/modelhub_tests.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           # This path is specific to Ubuntu
           path: ~/.cache/pip
-          key: pip-${{ matrix.python-version }}-${{ hashFiles('modelhub/requirements.txt', 'modelhub/requirements-dev.txt') }}
+          key: pip-${{ matrix.python-version }}-${{ hashFiles('modelhub/requirements.txt', 'modelhub/requirements-dev.txt', 'bach/requirements-bigquery.txt') }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/modelhub_tests.yml
+++ b/.github/workflows/modelhub_tests.yml
@@ -35,6 +35,9 @@ jobs:
     env:
       # tell tests to use the above defined postgres service
       OBJ_DB_PG_TEST_URL: 'postgresql://objectiv:no_password_set@localhost:5432/objectiv'
+      GCP_SERVICE_ACCOUNT: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+      # Just the path to a temp file, the actual secret is fully contained in the env var above.
+      OBJ_DB_BQ_CREDENTIALS_PATH: './sa.json'
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -66,8 +69,26 @@ jobs:
       - name: Unit tests
         run: |
           cd modelhub
-          pytest tests_modelhub/unit/  -W error::DeprecationWarning
+          pytest tests_modelhub/unit/
       - name: Functional tests
         run: |
           cd modelhub
-          pytest tests_modelhub/functional/  -W error::DeprecationWarning -W ignore::DeprecationWarning:bach.series.series_datetime
+          pytest tests_modelhub/functional/
+      - name: Install BQ dependencies
+        run: |
+          cd modelhub
+          # We don't an equivalent requirement-bigquery.txt in modelhub, as the requirements should be the
+          # same as for Bach
+          pip install -r ../bach/requirements-bigquery.txt
+      - name: Setup GCP Credentials
+        run: |
+          cd modelhub
+          echo $GCP_SERVICE_ACCOUNT > $OBJ_DB_BQ_CREDENTIALS_PATH
+      - name: Unit tests ALL
+        run: |
+          cd modelhub
+          pytest --all tests_modelhub/unit/
+      - name: Functional tests ALL
+        run: |
+          cd modelhub
+          pytest --all tests_modelhub/functional/

--- a/modelhub/tests_modelhub/conftest.py
+++ b/modelhub/tests_modelhub/conftest.py
@@ -34,6 +34,15 @@ from sql_models.constants import DBDialect
 from sqlalchemy import create_engine
 from tests_modelhub.data_and_utils.utils import setup_db, DBParams
 
+
+DB_PG_TEST_URL = os.environ.get('OBJ_DB_PG_TEST_URL', 'postgresql://objectiv:@localhost:5432/objectiv')
+DB_BQ_TEST_URL = os.environ.get('OBJ_DB_BQ_TEST_URL', 'bigquery://objectiv-snowplow-test-2/modelhub_test')
+DB_BQ_CREDENTIALS_PATH = os.environ.get(
+    'OBJ_DB_BQ_CREDENTIALS_PATH',
+    os.path.dirname(os.path.dirname(os.path.realpath(__file__))) + '/.secrets/bach-big-query-testing.json'
+)
+
+
 MARK_SKIP_POSTGRES = 'skip_postgres'
 MARK_SKIP_BIGQUERY = 'skip_bigquery'
 
@@ -100,7 +109,7 @@ def pytest_generate_tests(metafunc: Metafunc):
 
 def _get_postgres_db_params() -> DBParams:
     return DBParams(
-        url=os.environ.get('OBJ_DB_PG_TEST_URL', 'postgresql://objectiv:@localhost:5432/objectiv'),
+        url=DB_PG_TEST_URL,
         credentials=None,
         table_name='objectiv_data',
     )
@@ -108,10 +117,7 @@ def _get_postgres_db_params() -> DBParams:
 
 def _get_bigquery_db_params() -> DBParams:
     return DBParams(
-        url=os.environ.get('OBJ_DB_BQ_TEST_URL', 'bigquery://objectiv-snowplow-test-2/modelhub_test'),
-        credentials=os.environ.get(
-            'OBJ_DB_BQ_CREDENTIALS_PATH',
-            os.path.dirname(os.path.dirname(os.path.realpath(__file__))) + '/.secrets/bach-big-query-testing.json'
-        ),
+        url=DB_BQ_TEST_URL,
+        credentials=DB_BQ_CREDENTIALS_PATH,
         table_name='events',
     )


### PR DESCRIPTION
With this change we run the modelhub tests against BigQuery too.

In a follow-up PR (https://github.com/objectiv/objectiv-analytics/pull/865, not done) I'll make the tests run in parallel.