### PR TITLE
Make session_gap_seconds a more prominent and required setting

### DIFF
--- a/modelhub/modelhub/modelhub.py
+++ b/modelhub/modelhub/modelhub.py
@@ -135,6 +135,7 @@ class ModelHub:
             start_date=start_date,
             end_date=end_date,
             table_name=table_name,
+            session_gap_seconds=1800,
         )
 
         # sessionized data returns both series as bach.SeriesJson.

--- a/modelhub/modelhub/modelhub.py
+++ b/modelhub/modelhub/modelhub.py
@@ -22,6 +22,7 @@ GroupByType = Union[List[Union[str, bach.Series]], str, bach.Series, NotSet]
 ConversionEventDefinitionType = Tuple[Optional['SeriesLocationStack'], Optional[str]]
 
 TIME_DEFAULT_FORMAT = '%Y-%m-%d %H:%M:%S.%f'
+SESSION_GAP_DEFAULT_SECONDS = 1800
 
 
 class ModelHub:
@@ -135,7 +136,7 @@ class ModelHub:
             start_date=start_date,
             end_date=end_date,
             table_name=table_name,
-            session_gap_seconds=1800,
+            session_gap_seconds=SESSION_GAP_DEFAULT_SECONDS,
         )
 
         # sessionized data returns both series as bach.SeriesJson.

--- a/modelhub/modelhub/stack/sessionized_data.py
+++ b/modelhub/modelhub/stack/sessionized_data.py
@@ -40,7 +40,12 @@ class SessionizedDataPipeline(BaseDataPipeline):
         - all context and sessionized series defined in ObjectivSupportedColumns
         - correct dtypes for both context and sessionized series
     """
-    def _get_pipeline_result(self, session_gap_seconds=180, **kwargs) -> bach.DataFrame:
+
+    def __init__(self, engine: Engine, table_name: str, session_gap_seconds: int):
+        super().__init__(engine, table_name)
+        self.session_gap_seconds = session_gap_seconds
+
+    def _get_pipeline_result(self, **kwargs) -> bach.DataFrame:
         # initial data is the result from ExtractedContextsPipeline
         context_df = get_extracted_contexts_df(
             engine=self._engine, table_name=self._table_name, set_index=False, **kwargs,
@@ -62,7 +67,7 @@ class SessionizedDataPipeline(BaseDataPipeline):
 
         # calculate series that are needed for the final result
         sessionized_df = self._calculate_base_session_series(
-            context_df, session_gap_seconds=session_gap_seconds,
+            context_df, session_gap_seconds=self.session_gap_seconds,
         )
 
         # adds required objectiv session series
@@ -108,7 +113,7 @@ class SessionizedDataPipeline(BaseDataPipeline):
         """
         sessionized_df = df.copy()
 
-        is_session_start_series = self._calculate_session_start(sessionized_df, session_gap_seconds)
+        is_session_start_series = self._calculate_session_start(sessionized_df, self.session_gap_seconds)
         sessionized_df[is_session_start_series.name] = is_session_start_series
         # materialize since rest of series are dependant and it uses a window function
         sessionized_df = sessionized_df.materialize(node_name='session_starts')
@@ -256,16 +261,19 @@ class SessionizedDataPipeline(BaseDataPipeline):
         ).copy_override_type(bach.SeriesInt64)
 
 
-def get_sessionized_data(engine: Engine, table_name: str, set_index: bool = True, **kwargs) -> bach.DataFrame:
+def get_sessionized_data(engine: Engine, table_name: str, session_gap_seconds: int,
+                         set_index: bool = True, **kwargs) -> bach.DataFrame:
     """
     Gets context and sessionized data from pipeline.
     :param engine: db connection
     :param table_name: table from where to extract data
     :param set_index: set index series for final dataframe
+    :param session_gap_seconds: the session gap in seconds
 
     returns a bach DataFrame
     """
-    pipeline = SessionizedDataPipeline(engine=engine, table_name=table_name)
+    pipeline = SessionizedDataPipeline(engine=engine, table_name=table_name,
+                                       session_gap_seconds=session_gap_seconds)
     result = pipeline(**kwargs)
     if set_index:
         indexes = list(ObjectivSupportedColumns.get_index_columns())

--- a/modelhub/tests_modelhub/functional/modelhub/test_stack_sessionized_data.py
+++ b/modelhub/tests_modelhub/functional/modelhub/test_stack_sessionized_data.py
@@ -197,7 +197,7 @@ def test_calculate_base_session_series(db_params) -> None:
 
     tz_info = datetime.timezone.utc if is_bigquery(engine) else None
 
-    result = pipeline._calculate_base_session_series(context_df, _SESSION_GAP_SECONDS)
+    result = pipeline._calculate_base_session_series(context_df)
     assert_equals_data(
         result,
         expected_columns=[

--- a/modelhub/tests_modelhub/functional/modelhub/test_stack_sessionized_data.py
+++ b/modelhub/tests_modelhub/functional/modelhub/test_stack_sessionized_data.py
@@ -57,7 +57,8 @@ _FAKE_SESSIONIZED_DATA = [
 
 def _get_sessionized_data_pipeline(db_params) -> SessionizedDataPipeline:
     engine = create_engine_from_db_params(db_params)
-    return SessionizedDataPipeline(engine=engine, table_name=db_params.table_name)
+    return SessionizedDataPipeline(engine=engine, table_name=db_params.table_name,
+                                   session_gap_seconds=_SESSION_GAP_SECONDS)
 
 
 def test_get_pipeline_result(db_params, monkeypatch) -> None:
@@ -82,7 +83,7 @@ def test_get_pipeline_result(db_params, monkeypatch) -> None:
         lambda *args, **kwargs: context_df,
     )
 
-    result = pipeline._get_pipeline_result()
+    result = pipeline._get_pipeline_result(session_gap_seconds=_SESSION_GAP_SECONDS)
 
     assert_equals_data(
         result,
@@ -255,7 +256,8 @@ def test_calculate_objectiv_session_series(db_params) -> None:
 def test_get_sessionized_data_df(db_params) -> None:
     engine = create_engine_from_db_params(db_params)
 
-    result = get_sessionized_data(engine=engine, table_name=db_params.table_name)
+    result = get_sessionized_data(engine=engine, table_name=db_params.table_name,
+                                  session_gap_seconds=_SESSION_GAP_SECONDS)
     result = result.sort_index()
 
     expected = get_expected_context_pandas_df(engine)
@@ -264,6 +266,7 @@ def test_get_sessionized_data_df(db_params) -> None:
     expected = expected.set_index('event_id')
     pd.testing.assert_frame_equal(expected, result.to_pandas())
 
-    result = get_sessionized_data(engine=engine, table_name=db_params.table_name, set_index=False)
+    result = get_sessionized_data(engine=engine, table_name=db_params.table_name,
+                                  session_gap_seconds=_SESSION_GAP_SECONDS, set_index=False)
     assert 'event_id' not in result.index
     assert 'event_id' in result.data

--- a/modelhub/tests_modelhub/unit/modelhub/test_stack_sessionized_data.py
+++ b/modelhub/tests_modelhub/unit/modelhub/test_stack_sessionized_data.py
@@ -25,7 +25,7 @@ def patch_extracted_contexts_validations(monkeypatch):
 def test_convert_dtypes(db_params) -> None:
     engine = create_engine_from_db_params(db_params)
 
-    pipeline = SessionizedDataPipeline(engine, db_params.table_name)
+    pipeline = SessionizedDataPipeline(engine, db_params.table_name, session_gap_seconds=1)
 
     pdf = pd.DataFrame({'session_id': ['1'], 'session_hit_number': ['2']})
     df = bach.DataFrame.from_pandas(


### PR DESCRIPTION
- remove the default in the pipeline
- Add a default value of 1800s back to modelhub