### PR TITLE
Modelhub run tests in parallel

### DIFF
--- a/.github/workflows/modelhub_tests.yml
+++ b/.github/workflows/modelhub_tests.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Functional tests
         run: |
           cd modelhub
-          pytest tests_modelhub/functional/
+          pytest -n 4 --dist loadgroup tests_modelhub/functional/
       - name: Install BQ dependencies
         run: |
           cd modelhub
@@ -91,4 +91,4 @@ jobs:
       - name: Functional tests ALL
         run: |
           cd modelhub
-          pytest --all tests_modelhub/functional/
+          pytest --all -n 4 --dist loadgroup tests_modelhub/functional/

--- a/modelhub/Makefile
+++ b/modelhub/Makefile
@@ -3,7 +3,7 @@
 tests:
 	mypy modelhub
 	pycodestyle modelhub
-	pytest tests_modelhub
+	pytest -n 4 --dist loadgroup tests_modelhub/unit tests_modelhub/functional tests_modelhub
 
 tests-bigquery:
 # Similar to `tests`, but tests that can run against multiple databases will be run against BigQuery instead
@@ -11,7 +11,7 @@ tests-bigquery:
 # against Postgres
 	mypy modelhub
 	pycodestyle modelhub
-	pytest --big-query tests_modelhub
+	pytest --all -n 8 --dist loadgroup --big-query tests_modelhub
 
 
 tests-all:
@@ -20,4 +20,4 @@ tests-all:
 # run against Postgres
 	mypy modelhub
 	pycodestyle modelhub
-	pytest --all tests_modelhub
+	pytest --all -n 8 --dist loadgroup tests_modelhub

--- a/modelhub/pytest.ini
+++ b/modelhub/pytest.ini
@@ -7,7 +7,6 @@
 addopts =
     --strict-markers
     -W error::DeprecationWarning
-    -W ignore::DeprecationWarning:bach.series.series_datetime
 
 # markers defines our custom markers
 markers =

--- a/modelhub/requirements-dev.txt
+++ b/modelhub/requirements-dev.txt
@@ -1,6 +1,13 @@
-pytest==6.2.5
-pytest-env
 mypy==0.910
 pycodestyle==2.7.0
-types-requests
 
+# Tests runners
+pytest==6.2.5
+pytest-env
+
+# Used for multi-process testing, and communication between these processes
+pytest-xdist==2.5.0
+filelock==3.7.1
+
+# Types used by mypy
+types-requests

--- a/modelhub/tests_modelhub/data_and_utils/utils.py
+++ b/modelhub/tests_modelhub/data_and_utils/utils.py
@@ -3,7 +3,9 @@ from datetime import datetime, timezone
 from typing import Dict, Any, NamedTuple, Optional
 from uuid import UUID
 
+import bach
 from bach import DataFrame
+from sql_models.constants import DBDialect
 from sql_models.util import is_postgres, is_bigquery
 from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine
@@ -95,7 +97,14 @@ def create_engine_from_db_params(db_params: DBParams) -> Engine:
     return engine
 
 
-def setup_db(engine: Engine, table_name: str, columns: Dict[str, Any]):
+def setup_db(engine: Engine, table_name: str):
+    columns = {
+        'event_id': bach.SeriesUuid.supported_db_dtype[DBDialect.POSTGRES],
+        'day': bach.SeriesDate.supported_db_dtype[DBDialect.POSTGRES],
+        'moment': bach.SeriesTimestamp.supported_db_dtype[DBDialect.POSTGRES],
+        'cookie_id': bach.SeriesUuid.supported_db_dtype[DBDialect.POSTGRES],
+        'value': bach.SeriesJson.supported_db_dtype[DBDialect.POSTGRES],
+    }
     _prep_db_table(engine, table_name=table_name, columns=columns)
     _insert_records_in_db(engine, table_name=table_name, columns=columns)
 

--- a/modelhub/tests_modelhub/functional/conftest.py
+++ b/modelhub/tests_modelhub/functional/conftest.py
@@ -23,7 +23,9 @@ def setup_postgres_db(request: SubRequest, tmp_path_factory: TempPathFactory, wo
     When running in a scenario with multiple test processes, this will use a filelock to ensure the database
     get created only once.
     """
-    if not request.session.config.getoption("all") and not request.session.config.getoption("postgres"):
+    # use same logic as tests_modelhub.conftest.pytest_generate_tests()
+    testing_pg = not request.session.config.getoption("big_query")
+    if not testing_pg:
         return
 
     if worker_id == 'master':
@@ -47,9 +49,6 @@ def setup_postgres_db(request: SubRequest, tmp_path_factory: TempPathFactory, wo
             # We got the lock, but the file does not yet exist, so we are the first process
             _real_setup_postgres_db()
             is_done_path.write_text('done')
-            print("\n\nDB CREATED\n\n")
-        else:
-            print("\n\nDB READY\n\n")
         # else case: We got the lock, but the is_done_path file already exists, indicating we don't have to
         # do anything.
 

--- a/modelhub/tests_modelhub/functional/conftest.py
+++ b/modelhub/tests_modelhub/functional/conftest.py
@@ -1,0 +1,79 @@
+"""
+Copyright 2022 Objectiv B.V.
+### Fixtures
+There is some pytest 'magic' here that automatically fills out the db parameters for
+test functions that require an engine.
+By default such a test function will get a Postgres db parameters. But if --big-query or --all is
+specified on the commandline, then it will (also) get a BigQuery db parameters. For specific
+tests, it is possible to disable postgres or bigquery testing, see 'marks' section below.
+### Marks and Test Categorization
+A lot of functionality needs to be tested for multiple databases. The 'engine' and 'dialects' fixtures
+mentioned above help with that. Additionally we have some marks (`@pytest.mark.<type>`) to make it explicit
+which databases we expect tests to run against.
+We broadly want 5 categories of tests:
+* unit-test: These don't interact with a database
+  * unit-tests that are tested with multiple database dialects (1)
+  * unit-tests that are database-dialect independent (2)
+* functional-tests: These interact with a database
+  *  functional-tests that run against all supported databases (3)
+  *  functional-tests that run against all supported databases except Postgres (4)
+  *  functional-tests that run against all supported databases except BigQuery (5)
+1 and 3 are the default for tests. These either get 'db_params' as fixture and run against all
+databases. Category 2 are tests that test generic code that is not geared to a specific database.
+Category 4 and 5 are for functionality that we explicitly not support on some databases.
+Category 4, and 5 are the exception, these need to be marked with the `skip_postgres` or `skip_bigquery` marks.
+"""
+from pathlib import Path
+
+from filelock import FileLock
+import pytest
+from _pytest.fixtures import SubRequest
+from _pytest.tmpdir import TempPathFactory
+from sqlalchemy import create_engine
+
+from tests_modelhub.conftest import get_postgres_db_params
+from tests_modelhub.data_and_utils.utils import setup_db
+
+
+@pytest.fixture(autouse=True, scope='session')
+def setup_postgres_db(request: SubRequest, tmp_path_factory: TempPathFactory, worker_id: str) -> None:
+    """
+    Helper for creating postgres database used by all functional tests. Only created if it is required
+    to run tests against Postgres.
+    When running in a scenario with multiple test processes, this will use a filelock to ensure the database
+    get created only once.
+    """
+    if not request.session.config.getoption("all") and not request.session.config.getoption("postgres"):
+        return
+
+    if worker_id == 'master':
+        # This is the simple case: we are running with a single worker
+        _real_setup_postgres_db()
+        return
+
+    # We are running with multiple workers. Make sure only one worker calls _actually_setup_postgres_db()
+    # Use a FileLock, as advised by the pytest-xdist docs [1]
+    # [1] https://pypi.org/project/pytest-xdist/#making-session-scoped-fixtures-execute-only-once
+    # Basic idea is that we'll use a lock file to make sure only one process at a time is in the critical
+    # section. Besides setting up the database in the critical section, we'll also create a file on disk to
+    # indicate to the other processes that the database has been setup already.
+
+    root_tmp_dir = tmp_path_factory.getbasetemp().parent  # get the temp directory shared by all workers
+    is_done_path: Path = root_tmp_dir / "setup_database_is_done.txt"
+    lock_path: Path = root_tmp_dir / "setup_database.lcok"
+    lock = FileLock(str(lock_path))
+    with lock:
+        if not is_done_path.is_file():
+            # We got the lock, but the file does not yet exist, so we are the first process
+            _real_setup_postgres_db()
+            is_done_path.write_text('done')
+            print("\n\nDB CREATED\n\n")
+        else:
+            print("\n\nDB READY\n\n")
+        # else case: We got the lock, but the is_done_path file already exists, indicating we don't have to
+        # do anything.
+
+
+def _real_setup_postgres_db():
+    db_params = get_postgres_db_params()
+    setup_db(engine=create_engine(url=db_params.url), table_name=db_params.table_name)

--- a/modelhub/tests_modelhub/functional/conftest.py
+++ b/modelhub/tests_modelhub/functional/conftest.py
@@ -33,7 +33,7 @@ def setup_postgres_db(request: SubRequest, tmp_path_factory: TempPathFactory, wo
         _real_setup_postgres_db()
         return
 
-    # We are running with multiple workers. Make sure only one worker calls _actually_setup_postgres_db()
+    # We are running with multiple workers. Make sure only one worker calls _real_setup_postgres_db()
     # Use a FileLock, as advised by the pytest-xdist docs [1]
     # [1] https://pypi.org/project/pytest-xdist/#making-session-scoped-fixtures-execute-only-once
     # Basic idea is that we'll use a lock file to make sure only one process at a time is in the critical

--- a/modelhub/tests_modelhub/functional/conftest.py
+++ b/modelhub/tests_modelhub/functional/conftest.py
@@ -42,7 +42,7 @@ def setup_postgres_db(request: SubRequest, tmp_path_factory: TempPathFactory, wo
 
     root_tmp_dir = tmp_path_factory.getbasetemp().parent  # get the temp directory shared by all workers
     is_done_path: Path = root_tmp_dir / "setup_database_is_done.txt"
-    lock_path: Path = root_tmp_dir / "setup_database.lcok"
+    lock_path: Path = root_tmp_dir / "setup_database.lock"
     lock = FileLock(str(lock_path))
     with lock:
         if not is_done_path.is_file():

--- a/modelhub/tests_modelhub/functional/conftest.py
+++ b/modelhub/tests_modelhub/functional/conftest.py
@@ -43,7 +43,9 @@ def setup_postgres_db(request: SubRequest, tmp_path_factory: TempPathFactory, wo
     root_tmp_dir = tmp_path_factory.getbasetemp().parent  # get the temp directory shared by all workers
     is_done_path: Path = root_tmp_dir / "setup_database_is_done.txt"
     lock_path: Path = root_tmp_dir / "setup_database.lock"
-    lock = FileLock(str(lock_path))
+    # try to get lock, give up after 10 seconds. If other processes hasn't setup database in 10 seconds
+    # something is likely wrong. Better to fail than to wait forever.
+    lock = FileLock(str(lock_path), timeout=10)
     with lock:
         if not is_done_path.is_file():
             # We got the lock, but the file does not yet exist, so we are the first process

--- a/modelhub/tests_modelhub/functional/conftest.py
+++ b/modelhub/tests_modelhub/functional/conftest.py
@@ -43,8 +43,9 @@ def setup_postgres_db(request: SubRequest, tmp_path_factory: TempPathFactory, wo
     root_tmp_dir = tmp_path_factory.getbasetemp().parent  # get the temp directory shared by all workers
     is_done_path: Path = root_tmp_dir / "setup_database_is_done.txt"
     lock_path: Path = root_tmp_dir / "setup_database.lock"
-    # try to get lock, give up after 10 seconds. If other processes hasn't setup database in 10 seconds
-    # something is likely wrong. Better to fail than to wait forever.
+
+    # Try to get lock, but give up after 10 seconds. If another process is still busy setting up the database
+    # after 10 seconds, then something is likely wrong. Better to fail than to wait forever.
     lock = FileLock(str(lock_path), timeout=10)
     with lock:
         if not is_done_path.is_file():

--- a/modelhub/tests_modelhub/functional/conftest.py
+++ b/modelhub/tests_modelhub/functional/conftest.py
@@ -1,27 +1,7 @@
 """
 Copyright 2022 Objectiv B.V.
-### Fixtures
-There is some pytest 'magic' here that automatically fills out the db parameters for
-test functions that require an engine.
-By default such a test function will get a Postgres db parameters. But if --big-query or --all is
-specified on the commandline, then it will (also) get a BigQuery db parameters. For specific
-tests, it is possible to disable postgres or bigquery testing, see 'marks' section below.
-### Marks and Test Categorization
-A lot of functionality needs to be tested for multiple databases. The 'engine' and 'dialects' fixtures
-mentioned above help with that. Additionally we have some marks (`@pytest.mark.<type>`) to make it explicit
-which databases we expect tests to run against.
-We broadly want 5 categories of tests:
-* unit-test: These don't interact with a database
-  * unit-tests that are tested with multiple database dialects (1)
-  * unit-tests that are database-dialect independent (2)
-* functional-tests: These interact with a database
-  *  functional-tests that run against all supported databases (3)
-  *  functional-tests that run against all supported databases except Postgres (4)
-  *  functional-tests that run against all supported databases except BigQuery (5)
-1 and 3 are the default for tests. These either get 'db_params' as fixture and run against all
-databases. Category 2 are tests that test generic code that is not geared to a specific database.
-Category 4 and 5 are for functionality that we explicitly not support on some databases.
-Category 4, and 5 are the exception, these need to be marked with the `skip_postgres` or `skip_bigquery` marks.
+
+In this module we setup the database for functional tests.
 """
 from pathlib import Path
 


### PR DESCRIPTION
Changes to model hub tests:
* Make sure we only setup the database for postgres once
  *  Use a FileLock to communicate between test processes
* Moved Postgres setup code to `functional` directory so it only runs for functional tests
* Make tests run in parallel with `make` and on github


Result: Bit hard to quantify how much faster this is on Github, but.
Before: https://github.com/objectiv/objectiv-analytics/runs/6810678010?check_suite_focus=true
After: https://github.com/objectiv/objectiv-analytics/runs/6812635176?check_suite_focus=true