### PR TITLE
Bach BQ: Remove hack from DataFrame.quantile

### DIFF
--- a/bach/bach/operations/describe.py
+++ b/bach/bach/operations/describe.py
@@ -236,7 +236,4 @@ class DescribeOperation:
             )
         )
 
-        if is_bigquery(percentile_df.engine):
-            # BigQuery returns quantile per row, need to apply distinct
-            percentile_df = percentile_df.materialize(node_name='describe_quantile', distinct=True)
         return percentile_df

--- a/bach/tests/functional/bach/test_df.py
+++ b/bach/tests/functional/bach/test_df.py
@@ -132,8 +132,7 @@ def test_round(engine):
         pd.testing.assert_frame_equal(expected2, result2, check_names=False)
 
 
-def test_quantile(pg_engine) -> None:
-    engine = pg_engine  # TODO: BigQuery
+def test_quantile(engine) -> None:
     pdf = pd.DataFrame(
         data={
             'a': [1, 2, 3, 4, 5, 6, np.nan, 7.],


### PR DESCRIPTION
We no longer need the hack for adding the quantile label since the function is no longer generating complex merge subqueries anymore. Tho we do need to add a materialization for BigQuery because it will return duplicated quantiles