### PR TITLE
Bach BQ: Support `SeriesJson.__ge__` for BigQuery

### DIFF
--- a/bach/bach/series/series_json.py
+++ b/bach/bach/series/series_json.py
@@ -8,7 +8,7 @@ from typing import Dict, Union, TYPE_CHECKING, Tuple, cast, Optional, List, Any,
 from sqlalchemy.engine import Dialect
 
 from bach.series import Series
-from bach.expression import Expression
+from bach.expression import Expression, join_expressions
 from bach.series.series import WrappedPartition, ToPandasInfo
 from bach.sql_model import BachSqlModel
 from bach.types import DtypeOrAlias, StructuredDtype, AllSupportedLiteralTypes, Dtype
@@ -243,6 +243,10 @@ class SeriesJson(Series):
     def __ge__(self, other: Union['Series', AllSupportedLiteralTypes]) -> 'SeriesBoolean':
         if is_postgres(self.engine):
             return self._comparator_operation(other, "@>")
+        if is_bigquery(self.engine):
+            # there is no operator for "@>", it needs to be simulated
+            return self.json.array_contains(other)
+
         message_override = f'Operator >= is not supported for type json on database {self.engine.name}'
         raise DatabaseNotSupportedException(self.engine, message_override=message_override)
 
@@ -406,6 +410,19 @@ class JsonAccessor(Generic[TSeriesJson]):
         # So for now we have a dedicated len function for arrays.
         return self._implementation.get_array_length()
 
+    def array_contains(self, item: Union['Series', AllSupportedLiteralTypes]) -> 'SeriesBoolean':
+        """
+        Find if an object or list of objects are contained in the array.
+
+        :param item: items to be verified if it is contained by the array.
+
+        :returns: boolean series indicating if the array contains all elements.
+
+        This assumes the top-level item in the json is an array. Will result in an exception (later on) if
+        that's not the case!
+        """
+        return self._implementation.array_contains(item)
+
 
 class JsonBigQueryAccessorImpl(Generic[TSeriesJson]):
     """
@@ -524,6 +541,47 @@ class JsonBigQueryAccessorImpl(Generic[TSeriesJson]):
             .copy_override_type(SeriesInt64) \
             .copy_override(expression=expression)
 
+    def array_contains(self, item: Union['Series', AllSupportedLiteralTypes]) -> 'SeriesBoolean':
+        """ For documentation, see implementation in parent class :class:`JsonAccessor` """
+        # Implementing __ge__ for BigQuery, since @> operator is not supported, we need to
+        # simulate it by verifying if all searched items exist in the array.
+        # all items are converted into string by using json.dumps
+        # therefore be aware that if you are searching for a dict type object, the order
+        # of the keys MATTER and will only match when both compared values have the same
+        # keys and values
+
+        if not isinstance(item, list):
+            items_to_search = [item]
+        else:
+            items_to_search = item
+
+        if any(isinstance(item, Series) for item in items_to_search):
+            raise NotImplementedError('json.array_contains for Series types is not supported.')
+
+        to_search_expr = Expression.string_value(json.dumps(items_to_search))
+        # get all the searching values that exist in the array
+        search_stmt = (
+            'select searching_value '
+            f'from UNNEST(JSON_QUERY_ARRAY({{}})) as searching_value '
+            f'where searching_value in UNNEST(JSON_QUERY_ARRAY({{}}))'
+        )
+        # get the amount of contained items
+        num_found_expr = Expression.construct(
+            f'CASE WHEN {{}} THEN (select array_length(array({search_stmt}))) END',
+            self._series_object.notnull(),
+            to_search_expr,
+            self._series_object,
+        )
+        from bach.series import SeriesInt64, SeriesBoolean
+        num_found_series = (
+            self._series_object.copy_override(expression=num_found_expr)
+            .copy_override_type(SeriesInt64)
+        )
+
+        # verify if the length of contained items is the same as requested.
+        found_all = num_found_series == len(items_to_search)
+        return found_all.copy_override_type(SeriesBoolean)
+
 
 class JsonPostgresAccessorImpl(Generic[TSeriesJson]):
     """
@@ -629,3 +687,7 @@ class JsonPostgresAccessorImpl(Generic[TSeriesJson]):
         return self._series_object \
             .copy_override_type(SeriesInt64) \
             .copy_override(expression=expression)
+
+    def array_contains(self, item: Union['Series', AllSupportedLiteralTypes]) -> 'SeriesBoolean':
+        # TODO: Postgres
+        raise NotImplementedError()

--- a/bach/bach/series/series_json.py
+++ b/bach/bach/series/series_json.py
@@ -542,7 +542,7 @@ class JsonBigQueryAccessorImpl(Generic[TSeriesJson]):
             .copy_override(expression=expression)
 
     def array_contains(self, item: Union['Series', AllSupportedLiteralTypes]) -> 'SeriesBoolean':
-        """ For documentation, see implementation in parent class :class:`JsonAccessor` """
+        """ For documentation, see implementation in class :class:`JsonAccessor` """
         # Implementing __ge__ for BigQuery, since @> operator is not supported, we need to
         # simulate it by verifying if all searched items exist in the array.
         # all items are converted into string by using json.dumps

--- a/bach/tests/functional/bach/test_series_json.py
+++ b/bach/tests/functional/bach/test_series_json.py
@@ -69,10 +69,42 @@ def test_json_get_single_value(engine, dtype):
     assert a == {'a': 'b', 'c': {'a': 'c'}}
 
 
+# TODO: __le__ for BigQuery
+def test_json_compare_lists__ge__(engine, dtype):
+    bt = get_df_with_json_data(engine=engine, dtype=dtype)
+    bts = bt.list_column >= [{"c": "d"}]
+    assert_equals_data(
+        bts,
+        expected_columns=['_index_row', 'list_column'],
+        expected_data=[
+            [0, True],
+            [1, False],
+            [2, False],
+            [3, False],
+            [4, None]
+        ]
+    )
+
+    bts = bt.list_column >= ['b', 'c']
+    assert_equals_data(
+        bts,
+        expected_columns=['_index_row', 'list_column'],
+        expected_data=[
+            [0, False],
+            [1, True],
+            [2, False],
+            [3, False],
+            [4, None]
+        ]
+    )
+
+
 @pytest.mark.skip_bigquery
 def test_json_compare(engine, dtype):
     # These less-than-or-equals compares check that the left hand is contained in the right hand, on
     # Postgres. On` BigQuery we cannot support this, so we skip this function for BQ on purpose.
+    # BigQuery can only search when the top-level is an array
+    # therefore searching is a dict is a "superset" of another dict is not possible
     # TODO: maybe get rid of the Postgres support too?
     bt = get_df_with_json_data(engine=engine, dtype=dtype)
     bts = {"a": "b"} <= bt.mixed_column


### PR DESCRIPTION
Created `array_contains` in json accessor. (Still missing PG implementation https://github.com/objectiv/objectiv-analytics/issues/884). Therefore '>=' operator is now supported, still missing '<=' but not sure how yet.

 **Important**: If we want to know if a dict is contained by the array, the order of the keys matters and should match all keys and values, this is mainly because current implementation is based on string comparison (was the fastest way to implement ig). 

Also, IMHO we should limit both operators when the top-level type of the json is a list, since it's not really pythonic the current implementation for Postgres (can find if a sub path is part of the main json path). 
For example:
```
list_a = ['a', 'b', 'c']
list_b = ['b', 'c']

list_a  >= list_b  # True

dict_a = {'a': 'b', 'c': 'd'}
dict_b = {'c': 'd'}
dict_a >= dict_b # will raise a TypeError
```
Therefore, we should create a separate function for knowing if a dict contains another dict. `SeriesJson.json.json_contains_dict` maybe?