### PR TITLE
Optimize notebook analytics

### DIFF
--- a/modelhub/modelhub/aggregate.py
+++ b/modelhub/modelhub/aggregate.py
@@ -260,7 +260,7 @@ class Aggregate:
 
         data.materialize(inplace=True)
         # label hits where at that point in time, there are 0 conversions in the session
-        data['zero_conversions_at_moment'] = data['conversions_in_time'] == 0
+        data['zero_conversions_at_moment'] = data['__conversions_in_time'] == 0
 
         # filter on above created labels
         converted_users = data[(data.converted_users & data.zero_conversions_at_moment)]

--- a/modelhub/modelhub/map.py
+++ b/modelhub/modelhub/map.py
@@ -136,7 +136,7 @@ class Map:
         """
         data.materialize(inplace=True)
         window = data.groupby(partition).window(end_boundary=WindowFrameBoundary.FOLLOWING)
-        data['__converted'] = window['conversions_in_time'].max()
+        data['__converted'] = window['__conversions_in_time'].max()
 
     def conversions_counter(self,
                             data: bach.DataFrame,

--- a/modelhub/modelhub/map.py
+++ b/modelhub/modelhub/map.py
@@ -233,7 +233,7 @@ class Map:
         sort_by = ['session_id', 'session_hit_number']
 
         window = data.sort_values(sort_by, ascending=False).groupby(partition).window()
-        max_number_of_conversions = data['conversions_in_time'].max(window)
+        max_number_of_conversions = data['__conversions_in_time'].max(window)
         data['__is_converted'] = True
         data.loc[max_number_of_conversions == 0, '__is_converted'] = False
 
@@ -242,7 +242,7 @@ class Map:
         window = data.sort_values(sort_by, ascending=False).groupby(partition).window()
 
         # number all rows except where __is_converted is NULL and _conversions == 0
-        pch_mask = (data['__is_converted']) & (data['conversions_in_time'] == 0)
+        pch_mask = (data['__is_converted']) & (data['__conversions_in_time'] == 0)
         data['__pre_conversion_hit_number'] = 1
         data.loc[~pch_mask, '__pre_conversion_hit_number'] = None
         pre_conversion_hit_number = (

--- a/modelhub/modelhub/map.py
+++ b/modelhub/modelhub/map.py
@@ -293,11 +293,10 @@ class Map:
 
         data['__hit_before_conversion'] = (data['__conversions_in_time'] == 0) & (data['__converted'] >= 1)
 
-
     def hit_before_conversion(self,
-                                  data: bach.DataFrame,
-                                  name: str,
-                                  partition: str = 'session_id') -> bach.SeriesInt64:
+                              data: bach.DataFrame,
+                              name: str,
+                              partition: str = 'session_id') -> bach.Series:
 
         self._mh._check_data_is_objectiv_data(data)
         data = data.copy()

--- a/modelhub/modelhub/map.py
+++ b/modelhub/modelhub/map.py
@@ -278,3 +278,34 @@ class Map:
 
         return data['__pre_conversion_hit_number'].copy_override(
             name='pre_conversion_hit_number').materialize().copy_override_type(bach.SeriesInt64)
+
+    def _hit_before_conversion(self,
+                               data):
+        """
+        requires
+            `_is_conversion_event`
+            `_conversions_in_time`
+            `_conversions_counter`
+
+        creates
+            `__hit_before_conversion`
+        """
+
+        data['__hit_before_conversion'] = (data['__conversions_in_time'] == 0) & (data['__converted'] >= 1)
+
+
+    def hit_before_conversion(self,
+                                  data: bach.DataFrame,
+                                  name: str,
+                                  partition: str = 'session_id') -> bach.SeriesInt64:
+
+        self._mh._check_data_is_objectiv_data(data)
+        data = data.copy()
+
+        self._is_conversion_event(data, name)
+        self._conversions_in_time(data, partition=partition)
+        self._conversions_counter(data, partition=partition)
+
+        self._hit_before_conversion(data)
+
+        return data['__hit_before_conversion'].copy_override(name='hit_before_conversion')

--- a/modelhub/modelhub/map.py
+++ b/modelhub/modelhub/map.py
@@ -85,17 +85,11 @@ class Map:
         is_new_user_series = is_new_user_series.copy_override_type(bach.SeriesBoolean)
         return is_new_user_series.copy_override(name='is_new_user').materialize()
 
-    def is_conversion_event(self, data: bach.DataFrame, name: str) -> bach.SeriesBoolean:
+    def _is_conversion_event(self, data: bach.DataFrame, name: str):
         """
-        Labels a hit True if it is a conversion event, all other hits are labeled False.
-
-        :param data: :py:class:`bach.DataFrame` to apply the method on.
-        :param name: the name of the conversion to label as set in
-            :py:attr:`ModelHub.conversion_events`.
-        :returns: :py:class:`bach.SeriesBoolean` with the same index as ``data``.
+        creates
+            `__conversion`
         """
-
-        self._mh._check_data_is_objectiv_data(data)
 
         if name not in self._mh._conversion_events:
             raise KeyError(f"Key {name} is not labeled as a conversion")
@@ -108,7 +102,41 @@ class Map:
             series = conversion_stack.json.get_array_length() > 0
         else:
             series = ((conversion_stack.json.get_array_length() > 0) & (data.event_type == conversion_event))
-        return series.copy_override(name='is_conversion_event')
+
+        data['__conversion'] = series
+
+    def is_conversion_event(self, data: bach.DataFrame, name: str) -> bach.Series:
+        """
+        Labels a hit True if it is a conversion event, all other hits are labeled False.
+
+        :param data: :py:class:`bach.DataFrame` to apply the method on.
+        :param name: the name of the conversion to label as set in
+            :py:attr:`ModelHub.conversion_events`.
+        :returns: :py:class:`bach.SeriesBoolean` with the same index as ``data``.
+        """
+
+        self._mh._check_data_is_objectiv_data(data)
+        data = data.copy()
+
+        self._is_conversion_event(data, name=name)
+
+        return data['__conversion'].copy_override(name='is_conversion_event')
+
+    def _conversions_counter(self,
+                             data: bach.DataFrame,
+                             partition: str):
+
+        """
+        requires
+            `_is_conversion_event`
+            `_conversions_in_time`
+
+        creates
+            `__converted`
+        """
+        data.materialize(inplace=True)
+        window = data.groupby(partition).window(end_boundary=WindowFrameBoundary.FOLLOWING)
+        data['__converted'] = window['conversions_in_time'].max()
 
     def conversions_counter(self,
                             data: bach.DataFrame,
@@ -126,20 +154,42 @@ class Map:
         """
 
         self._mh._check_data_is_objectiv_data(data)
+        data = data.copy()
 
-        data['__conversions'] = self._mh.map.conversions_in_time(data, name=name)
+        self._is_conversion_event(data, name)
+        self._conversions_in_time(data, partition=partition)
+        self._conversions_counter(data, partition=partition)
 
-        window = data.groupby(partition).window(end_boundary=WindowFrameBoundary.FOLLOWING)
-        converted = window['__conversions'].max()
-        data = data.drop(columns=['__conversions'])
-
-        new_series = converted.copy_override(name='converted',
-                                             index=data.index).materialize()
-
-        return new_series
+        return data['__converted'].copy_override(name='converted',
+                                                 index=data.index)
 
     def conversion_count(self, *args, **kwargs):
         raise NotImplementedError('function is renamed please use `conversions_in_time`')
+
+    def _conversions_in_time(self,
+                             data: bach.DataFrame,
+                             partition: str):
+        """
+        requires
+            `_is_conversion_event`
+
+        creates
+            `__conversion_counter`
+            `conversions_in_time`
+        """
+
+        data['__conversion_counter'] = 0
+        data.loc[data['__conversion'], '__conversion_counter'] = 1
+
+        # make the query more clean, just require these series
+        if is_bigquery(data.engine):
+            # group by materializes for BQ, window will make reference to column
+            data.materialize(node_name='conversion_counter_bq', inplace=True)
+
+        window = data.sort_values([partition, 'moment']).groupby(partition).window()
+        data['conversions_in_time'] = (
+            data['__conversion_counter'].copy_override_type(bach.SeriesInt64).sum(window)
+        )
 
     def conversions_in_time(self,
                             data: bach.DataFrame,
@@ -158,23 +208,47 @@ class Map:
         """
 
         self._mh._check_data_is_objectiv_data(data)
-
         data = data.copy()
-        data['__conversion'] = self._mh.map.is_conversion_event(data, name)
-        data['__conversion_counter'] = 0
-        data.loc[data['__conversion'], '__conversion_counter'] = 1
 
-        # make the query more clean, just require these series
-        data = data[[partition, 'moment', '__conversion_counter']]
-        if is_bigquery(data.engine):
-            # group by materializes for BQ, window will make reference to column
-            data = data.materialize(node_name='conversion_counter_bq')
+        self._is_conversion_event(data, name)
+        self._conversions_in_time(data=data, partition=partition)
 
-        window = data.sort_values([partition, 'moment']).groupby(partition).window()
-        data['conversions_in_time'] = (
-            data['__conversion_counter'].copy_override_type(bach.SeriesInt64).sum(window)
-        )
         return data.conversions_in_time.materialize(node_name='conversions_in_time')
+
+    def _pre_conversion_hit_number(self,
+                                   data: bach.DataFrame,
+                                   partition: str):
+        """
+        requires in `data`
+            `_is_conversion_event`
+            `_conversions_in_time`
+
+        creates
+
+
+        """
+
+        # sort all windows by session id and hit number
+        sort_by = ['session_id', 'session_hit_number']
+
+        window = data.sort_values(sort_by, ascending=False).groupby(partition).window()
+        max_number_of_conversions = data['conversions_in_time'].max(window)
+        data['__is_converted'] = True
+        data.loc[max_number_of_conversions == 0, '__is_converted'] = False
+
+        data.materialize(inplace=True)
+
+        window = data.sort_values(sort_by, ascending=False).groupby(partition).window()
+
+        # number all rows except where __is_converted is NULL and _conversions == 0
+        pch_mask = (data['__is_converted']) & (data['conversions_in_time'] == 0)
+        data['pre_conversion_hit_number'] = 1
+        data.loc[~pch_mask, 'pre_conversion_hit_number'] = None
+        pre_conversion_hit_number = (
+            data['pre_conversion_hit_number']
+            .astype('int64').copy_override_type(bach.SeriesInt64)  # None is parsed as string
+        )
+        data['__pre_conversion_hit_number'] = pre_conversion_hit_number.sum(window)
 
     def pre_conversion_hit_number(self,
                                   data: bach.DataFrame,
@@ -194,33 +268,11 @@ class Map:
         """
 
         self._mh._check_data_is_objectiv_data(data)
-
         data = data.copy()
-        data['__conversions'] = self._mh.map.conversions_in_time(data, name=name)
 
-        # make the query more clean, just require these series
-        required_series = [partition, 'session_id', 'session_hit_number', '__conversions']
-        data = data[required_series]
+        self._is_conversion_event(data, name)
+        self._conversions_in_time(data, partition=partition)
+        data.materialize(inplace=True)
+        self._pre_conversion_hit_number(data, partition=partition)
 
-        # sort all windows by session id and hit number
-        sort_by = ['session_id', 'session_hit_number']
-
-        window = data.sort_values(sort_by, ascending=False).groupby(partition).window()
-        max_number_of_conversions = data['__conversions'].max(window)
-        data['__is_converted'] = True
-        data.loc[max_number_of_conversions == 0, '__is_converted'] = False
-
-        pre_conversion_hits = data.materialize()
-
-        window = pre_conversion_hits.sort_values(sort_by, ascending=False).groupby(partition).window()
-
-        # number all rows except where __is_converted is NULL and _conversions == 0
-        pch_mask = (pre_conversion_hits['__is_converted']) & (pre_conversion_hits['__conversions'] == 0)
-        pre_conversion_hits['pre_conversion_hit_number'] = 1
-        pre_conversion_hits.loc[~pch_mask, 'pre_conversion_hit_number'] = None
-        pre_conversion_hit_number = (
-            pre_conversion_hits['pre_conversion_hit_number']
-            .astype('int64').copy_override_type(bach.SeriesInt64)  # None is parsed as string
-        )
-        pre_conversion_hit_number = pre_conversion_hit_number.sum(window)
-        return pre_conversion_hit_number.materialize().copy_override_type(bach.SeriesInt64)
+        return data['__pre_conversion_hit_number'].materialize().copy_override_type(bach.SeriesInt64)

--- a/modelhub/modelhub/map.py
+++ b/modelhub/modelhub/map.py
@@ -194,7 +194,7 @@ class Map:
     def conversions_in_time(self,
                             data: bach.DataFrame,
                             name: str,
-                            partition: str = 'session_id') -> bach.SeriesInt64:
+                            partition: str = 'session_id') -> bach.Series:
         """
         Counts the number of time a user is converted at a moment in time given a partition (ie 'session_id'
         or 'user_id').

--- a/notebooks/basic-product-analytics.ipynb
+++ b/notebooks/basic-product-analytics.ipynb
@@ -126,16 +126,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# adding specific contexts to the data as columns\n",
+    "# add 'application' and 'root_location' as columns, so that we can use it for grouping etc later\n",
     "df['application'] = df.global_contexts.gc.application\n",
-    "df['feature_nice_name'] = df.location_stack.ls.nice_name\n",
-    "df['root_location'] = df.location_stack.ls.get_from_context_with_type_series(type='RootLocationContext', key='id')\n",
-    "df['referrer'] = df.global_contexts.gc.get_from_context_with_type_series(type='HttpContext', key='referrer')\n",
-    "df['utm_source'] = df.global_contexts.gc.get_from_context_with_type_series(type='MarketingContext', key='source')\n",
-    "df['utm_medium'] = df.global_contexts.gc.get_from_context_with_type_series(type='MarketingContext', key='medium')\n",
-    "df['utm_campaign'] = df.global_contexts.gc.get_from_context_with_type_series(type='MarketingContext', key='campaign')\n",
-    "df['utm_content'] = df.global_contexts.gc.get_from_context_with_type_series(type='MarketingContext', key='content')\n",
-    "df['utm_term'] = df.global_contexts.gc.get_from_context_with_type_series(type='MarketingContext', key='term')"
+    "df['root_location'] = df.location_stack.ls.get_from_context_with_type_series(type='RootLocationContext', key='id')"
    ]
   },
   {
@@ -322,8 +315,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# select only user actions, so stack_event_types must be a superset of ['InteractiveEvent']\n",
-    "interactive_events = df[df.stack_event_types >= ['InteractiveEvent']]\n",
+    "# select only user actions, so stack_event_types must contain 'InteractiveEvent'\n",
+    "interactive_events = df[df.stack_event_types.json.array_contains('InteractiveEvent')]\n",
+    "# get the readable name from the location stack\n",
+    "interactive_events['feature_nice_name'] = interactive_events.location_stack.ls.nice_name\n",
     "\n",
     "top_interactions = modelhub.agg.unique_users(interactive_events, groupby=['application','root_location','feature_nice_name', 'event_type'])\n",
     "top_interactions = top_interactions.reset_index()"
@@ -362,10 +357,44 @@
   },
   {
    "cell_type": "markdown",
+   "id": "31b3686c",
+   "metadata": {},
+   "source": [
+    "## Aqcuisition"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6422c6bb",
+   "metadata": {},
+   "source": [
+    "We create a copy of the original df, as to not clutter our original df with columns that are only required for acquisition analysis. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9d3d151a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df_acquisition = df.copy()\n",
+    "# extract referrer and marketing contexts from the global contexts\n",
+    "df_acquisition['referrer'] = df_acquisition.global_contexts.gc.get_from_context_with_type_series(type='HttpContext', key='referrer')\n",
+    "df_acquisition['utm_source'] = df_acquisition.global_contexts.gc.get_from_context_with_type_series(type='MarketingContext', key='source')\n",
+    "df_acquisition['utm_medium'] = df_acquisition.global_contexts.gc.get_from_context_with_type_series(type='MarketingContext', key='medium')\n",
+    "df_acquisition['utm_campaign'] = df_acquisition.global_contexts.gc.get_from_context_with_type_series(type='MarketingContext', key='campaign')\n",
+    "df_acquisition['utm_content'] = df_acquisition.global_contexts.gc.get_from_context_with_type_series(type='MarketingContext', key='content')\n",
+    "df_acquisition['utm_term'] = df_acquisition.global_contexts.gc.get_from_context_with_type_series(type='MarketingContext', key='term')\n",
+    "df_acquisition['feature_nice_name'] = df_acquisition.location_stack.ls.nice_name"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "eb7374f3",
    "metadata": {},
    "source": [
-    "## User origin"
+    "### User origin"
    ]
   },
   {
@@ -376,7 +405,7 @@
    "outputs": [],
    "source": [
     "# users by referrer\n",
-    "modelhub.agg.unique_users(df, groupby='referrer').sort_values(ascending=False).head()"
+    "modelhub.agg.unique_users(df_acquisition, groupby='referrer').sort_values(ascending=False).head()"
    ]
   },
   {
@@ -384,7 +413,7 @@
    "id": "f0bdf159",
    "metadata": {},
    "source": [
-    "## Marketing\n",
+    "### Marketing\n",
     "Calculate the number of users per campaign."
    ]
   },
@@ -396,7 +425,7 @@
    "outputs": [],
    "source": [
     "# users by marketing campaign\n",
-    "campaign_users = modelhub.agg.unique_users(df, groupby=['utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term'])\n",
+    "campaign_users = modelhub.agg.unique_users(df_acquisition, groupby=['utm_source', 'utm_medium', 'utm_campaign', 'utm_content', 'utm_term'])\n",
     "campaign_users = campaign_users.reset_index().dropna(axis=0, how='any', subset='utm_source')\n",
     "\n",
     "campaign_users.sort_values('utm_source', ascending=True).head()"
@@ -407,8 +436,7 @@
    "id": "59bb032a",
    "metadata": {},
    "source": [
-    "Look at top used features by campaign, using the previously created interactive_events to focus just on user\n",
-    "interactions."
+    "Look at top used features by campaign for only user interactions."
    ]
   },
   {
@@ -419,7 +447,12 @@
    "outputs": [],
    "source": [
     "# users by feature per campaign source & term\n",
-    "users_feature_campaign = modelhub.agg.unique_users(interactive_events, groupby=['utm_source', 'utm_term', 'feature_nice_name', 'event_type'])\n",
+    "users_feature_campaign = modelhub.agg.unique_users(df_acquisition[\n",
+    "    df_acquisition.stack_event_types.json.array_contains('InteractiveEvent')], \n",
+    "                                                   groupby=['utm_source', \n",
+    "                                                            'utm_term', \n",
+    "                                                            'feature_nice_name', \n",
+    "                                                            'event_type'])\n",
     "users_feature_campaign = users_feature_campaign.reset_index().dropna(axis=0, how='any', subset='utm_source')\n",
     "\n",
     "users_feature_campaign.sort_values(['utm_source', 'utm_term', 'unique_users'], ascending=[True, True, False]).head()"
@@ -510,8 +543,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "conversion_locations = modelhub.agg.unique_users(df[df.is_conversion_event], \n",
-    "                                                 groupby=['application', 'feature_nice_name', 'event_type'])\n",
+    "df_conversions = df[df.is_conversion_event]\n",
+    "conversion_locations = modelhub.agg.unique_users(df_conversions, \n",
+    "                                                 groupby=['application', df_conversions.location_stack.ls.nice_name, 'event_type'])\n",
     "\n",
     "# calling .to_frame() for nicer formatting\n",
     "conversion_locations.sort_values(ascending=False).to_frame().head()"

--- a/notebooks/basic-product-analytics.ipynb
+++ b/notebooks/basic-product-analytics.ipynb
@@ -585,14 +585,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# label sessions with a conversion\n",
-    "df['converted_users'] = modelhub.map.conversions_counter(df, name='github_press') >= 1\n",
-    "\n",
-    "# label hits where at that point in time, there are 0 conversions in the session\n",
-    "df['zero_conversions_at_moment'] = modelhub.map.conversions_in_time(df, 'github_press') == 0\n",
+    "# label hit before conversion (only true if there is a conversion in the session later)\n",
+    "df['hit_before_conversion'] = modelhub.map.hit_before_conversion(df, name='github_press')\n",
     "\n",
     "# filter on above created labels\n",
-    "converted_users = df[(df.converted_users & df.zero_conversions_at_moment)]\n",
+    "converted_users = df[df['hit_before_conversion']]\n",
     "\n",
     "# how much time do users spend before they convert?\n",
     "modelhub.aggregate.session_duration(converted_users, groupby=None).to_frame().head()"


### PR DESCRIPTION
this simplifies the resulting queries from the product analytics notebook
also adds a helper function that limits the number of joins from one of the old operations in the notebook

todo

- [ ] make internal methods in current pr into proper public functions
- [ ] add docstrings
- [ ] add better return types for model hub map functions
- [ ] update the example page following the notebook
