### PR TITLE
Modelhub location stack nice name prep better

### DIFF
--- a/modelhub/modelhub/series/series_objectiv.py
+++ b/modelhub/modelhub/series/series_objectiv.py
@@ -269,22 +269,18 @@ class SeriesLocationStack(SeriesJson):
                 return self._series_object.json[0].json.get_value('_type', as_str=True) + ' TODO'
             expression = Expression.construct(
                 f"""(
-                select array_to_string(
-                    array_agg(
+                select string_agg(
                         replace(
                             regexp_replace(value ->> '_type', '([a-z])([A-Z])', '\\1 \\2', 'g'),
-                        ' Context', '') || ': ' || (value ->> 'id')
-                    ),
+                        ' Context', '') || ': ' || (value ->> 'id'),
                 ' => ')
                 from jsonb_array_elements({{}}) with ordinality
                 where ordinality = jsonb_array_length({{}})) || case
                     when jsonb_array_length({{}}) > 1
-                        then ' located at ' || (select array_to_string(
-                    array_agg(
+                        then ' located at ' || (select string_agg(
                         replace(
                             regexp_replace(value ->> '_type', '([a-z])([A-Z])', '\\1 \\2', 'g'),
-                        ' Context', '') || ': ' || (value ->> 'id')
-                    ),
+                        ' Context', '') || ': ' || (value ->> 'id'),
                 ' => ')
                 from jsonb_array_elements({{}}) with ordinality
                 where ordinality < jsonb_array_length({{}})

--- a/modelhub/modelhub/series/series_objectiv.py
+++ b/modelhub/modelhub/series/series_objectiv.py
@@ -269,22 +269,29 @@ class SeriesLocationStack(SeriesJson):
                 return self._series_object.json[0].json.get_value('_type', as_str=True) + ' TODO'
             expression = Expression.construct(
                 f"""(
-                select string_agg(
-                        replace(
-                            regexp_replace(value ->> '_type', '([a-z])([A-Z])', '\\1 \\2', 'g'),
-                        ' Context', '') || ': ' || (value ->> 'id'),
-                ' => ')
-                from jsonb_array_elements({{}}) with ordinality
-                where ordinality = jsonb_array_length({{}})) || case
-                    when jsonb_array_length({{}}) > 1
-                        then ' located at ' || (select string_agg(
-                        replace(
-                            regexp_replace(value ->> '_type', '([a-z])([A-Z])', '\\1 \\2', 'g'),
-                        ' Context', '') || ': ' || (value ->> 'id'),
-                ' => ')
-                from jsonb_array_elements({{}}) with ordinality
-                where ordinality < jsonb_array_length({{}})
-                ) else '' end""",
+                    select string_agg(
+                            replace(
+                                regexp_replace(value ->> '_type', '([a-z])([A-Z])', '\\1 \\2', 'g'),
+                                ' Context',
+                                ''
+                            ) || ': ' || (value ->> 'id'),
+                            ' => ')
+                    from jsonb_array_elements({{}}) with ordinality
+                    where ordinality = jsonb_array_length({{}})
+                ) || (
+                    case when jsonb_array_length({{}}) > 1
+                         then ' located at ' || (select string_agg(
+                                replace(
+                                    regexp_replace(value ->> '_type', '([a-z])([A-Z])', '\\1 \\2', 'g'),
+                                    ' Context',
+                                    ''
+                                ) || ': ' || (value ->> 'id'),
+                                ' => ')
+                            from jsonb_array_elements({{}}) with ordinality
+                            where ordinality < jsonb_array_length({{}})
+                        )
+                        else '' end
+                )""",
                 self._series_object,
                 self._series_object,
                 self._series_object,

--- a/modelhub/tests_modelhub/data_and_utils/data_json_real.py
+++ b/modelhub/tests_modelhub/data_and_utils/data_json_real.py
@@ -14,6 +14,10 @@ TEST_DATA_JSON_REAL = [
      '[{"_type": "WebDocumentContext", "id": "#document", "url": "https://rick.objectiv.io/"}, {"_type": "SectionContext", "id": "home"}, {"_type": "SectionContext", "id": "new"}, {"_type": "SectionContext", "id": "yBwD4iYcWC4"}]'],
     [5,
      '[{"_type": "ApplicationContext", "id": "rod-web-demo"}, {"id": "http_context", "referrer": "https://rick.objectiv.io/", "user_agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:94.0) Gecko/20100101 Firefox/94.0", "remote_address": "144.144.144.144", "_type": "HttpContext"}, {"id": "f84446c6-eb76-4458-8ef4-93ade596fd5b", "cookie_id": "f84446c6-eb76-4458-8ef4-93ade596fd5b", "_type": "CookieIdContext"}]',
-     '[{"_type": "WebDocumentContext", "id": "#document", "url": "https://rick.objectiv.io/"}, {"_type": "SectionContext", "id": "home"}, {"_type": "SectionContext", "id": "new"}, {"_type": "SectionContext", "id": "eYuUAGXN0KM"}]']
+     '[{"_type": "WebDocumentContext", "id": "#document", "url": "https://rick.objectiv.io/"}, {"_type": "SectionContext", "id": "home"}, {"_type": "SectionContext", "id": "new"}, {"_type": "MediaPlayerContext", "id": "eYuUAGXN0KM"}]'],
+    [6,
+     '[{"_type": "ApplicationContext", "id": "rod-web-demo"}, {"id": "http_context", "referrer": "https://rick.objectiv.io/", "user_agent": "Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:94.0) Gecko/20100101 Firefox/94.0", "remote_address": "144.144.144.144", "_type": "HttpContext"}, {"id": "f84446c6-eb76-4458-8ef4-93ade596fd5b", "cookie_id": "f84446c6-eb76-4458-8ef4-93ade596fd5b", "_type": "CookieIdContext"}]',
+     '[{"_type": "WebDocumentContext", "id": "#document", "url": "https://rick.objectiv.io/"}]']
+
 ]
 JSON_COLUMNS_REAL = ['event_id', 'global_contexts', 'location_stack']

--- a/modelhub/tests_modelhub/functional/modelhub/test_series_objectiv.py
+++ b/modelhub/tests_modelhub/functional/modelhub/test_series_objectiv.py
@@ -18,7 +18,8 @@ def test_get_real_data(db_params: DBParams):
             [2, 2, [{'id': 'rod-web-demo', '_type': 'ApplicationContext'}, {'id': 'http_context', '_type': 'HttpContext', 'referrer': 'https://rick.objectiv.io/', 'user_agent': 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:94.0) Gecko/20100101 Firefox/94.0', 'remote_address': '144.144.144.144'}, {'id': 'f84446c6-eb76-4458-8ef4-93ade596fd5b', '_type': 'CookieIdContext', 'cookie_id': 'f84446c6-eb76-4458-8ef4-93ade596fd5b'}], [{'id': '#document', 'url': 'https://rick.objectiv.io/', '_type': 'WebDocumentContext', '_types': ['AbstractContext', 'AbstractLocationContext', 'SectionContext', 'WebDocumentContext']}, {'id': 'navigation', '_type': 'NavigationContext', '_types': ['AbstractContext', 'AbstractLocationContext', 'NavigationContext', 'SectionContext']}]],
             [3, 3, [{'id': 'rod-web-demo', '_type': 'ApplicationContext'}, {'id': 'http_context', '_type': 'HttpContext', 'referrer': 'https://rick.objectiv.io/', 'user_agent': 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:94.0) Gecko/20100101 Firefox/94.0', 'remote_address': '144.144.144.144'}, {'id': 'f84446c6-eb76-4458-8ef4-93ade596fd5b', '_type': 'CookieIdContext', 'cookie_id': 'f84446c6-eb76-4458-8ef4-93ade596fd5b'}], [{'id': '#document', 'url': 'https://rick.objectiv.io/', '_type': 'WebDocumentContext'}, {'id': 'home', '_type': 'SectionContext'}, {'id': 'new', '_type': 'SectionContext'}, {'id': 'BeyEGebJ1l4', '_type': 'SectionContext'}]],
             [4, 4, [{'id': 'rod-web-demo', '_type': 'ApplicationContext'}, {'id': 'http_context', '_type': 'HttpContext', 'referrer': 'https://rick.objectiv.io/', 'user_agent': 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:94.0) Gecko/20100101 Firefox/94.0', 'remote_address': '144.144.144.144'}, {'id': 'f84446c6-eb76-4458-8ef4-93ade596fd5b', '_type': 'CookieIdContext', 'cookie_id': 'f84446c6-eb76-4458-8ef4-93ade596fd5b'}], [{'id': '#document', 'url': 'https://rick.objectiv.io/', '_type': 'WebDocumentContext'}, {'id': 'home', '_type': 'SectionContext'}, {'id': 'new', '_type': 'SectionContext'}, {'id': 'yBwD4iYcWC4', '_type': 'SectionContext'}]],
-            [5, 5, [{'id': 'rod-web-demo', '_type': 'ApplicationContext'}, {'id': 'http_context', '_type': 'HttpContext', 'referrer': 'https://rick.objectiv.io/', 'user_agent': 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:94.0) Gecko/20100101 Firefox/94.0', 'remote_address': '144.144.144.144'}, {'id': 'f84446c6-eb76-4458-8ef4-93ade596fd5b', '_type': 'CookieIdContext', 'cookie_id': 'f84446c6-eb76-4458-8ef4-93ade596fd5b'}], [{'id': '#document', 'url': 'https://rick.objectiv.io/', '_type': 'WebDocumentContext'}, {'id': 'home', '_type': 'SectionContext'}, {'id': 'new', '_type': 'SectionContext'}, {'id': 'eYuUAGXN0KM', '_type': 'SectionContext'}]]
+            [5, 5, [{'id': 'rod-web-demo', '_type': 'ApplicationContext'}, {'id': 'http_context', '_type': 'HttpContext', 'referrer': 'https://rick.objectiv.io/', 'user_agent': 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:94.0) Gecko/20100101 Firefox/94.0', 'remote_address': '144.144.144.144'}, {'id': 'f84446c6-eb76-4458-8ef4-93ade596fd5b', '_type': 'CookieIdContext', 'cookie_id': 'f84446c6-eb76-4458-8ef4-93ade596fd5b'}], [{'id': '#document', 'url': 'https://rick.objectiv.io/', '_type': 'WebDocumentContext'}, {'id': 'home', '_type': 'SectionContext'}, {'id': 'new', '_type': 'SectionContext'}, {'id': 'eYuUAGXN0KM', '_type': 'MediaPlayerContext'}]],
+            [6, 6, [{'id': 'rod-web-demo', '_type': 'ApplicationContext'}, {'id': 'http_context', '_type': 'HttpContext', 'referrer': 'https://rick.objectiv.io/', 'user_agent': 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:94.0) Gecko/20100101 Firefox/94.0', 'remote_address': '144.144.144.144'}, {'id': 'f84446c6-eb76-4458-8ef4-93ade596fd5b', '_type': 'CookieIdContext', 'cookie_id': 'f84446c6-eb76-4458-8ef4-93ade596fd5b'}], [{'id': '#document', 'url': 'https://rick.objectiv.io/', '_type': 'WebDocumentContext'}]]
         ]
     )
 
@@ -36,7 +37,8 @@ def test_objectiv_stack_type(db_params):
             [2, 'f84446c6-eb76-4458-8ef4-93ade596fd5b'],
             [3, 'f84446c6-eb76-4458-8ef4-93ade596fd5b'],
             [4, 'f84446c6-eb76-4458-8ef4-93ade596fd5b'],
-            [5, 'f84446c6-eb76-4458-8ef4-93ade596fd5b']
+            [5, 'f84446c6-eb76-4458-8ef4-93ade596fd5b'],
+            [6, 'f84446c6-eb76-4458-8ef4-93ade596fd5b']
         ]
     )
 
@@ -54,7 +56,8 @@ def test_objectiv_stack_type2(db_params):
             [2, 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:94.0) Gecko/20100101 Firefox/94.0'],
             [3, 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:94.0) Gecko/20100101 Firefox/94.0'],
             [4, 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:94.0) Gecko/20100101 Firefox/94.0'],
-            [5, 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:94.0) Gecko/20100101 Firefox/94.0']
+            [5, 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:94.0) Gecko/20100101 Firefox/94.0'],
+            [6, 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:94.0) Gecko/20100101 Firefox/94.0']
         ]
     )
 
@@ -72,7 +75,8 @@ def test_objectiv_stack_type3(db_params):
             [2, [{'id': 'navigation', '_type': 'NavigationContext', '_types': ['AbstractContext', 'AbstractLocationContext', 'NavigationContext', 'SectionContext']}]],
             [3, []],
             [4, []],
-            [5, []]
+            [5, []],
+            [6, []]
         ],
         use_to_pandas=True,
     )
@@ -92,7 +96,8 @@ def test_objectiv_stack_type4(db_params):
             [2, [{'id': '#document', '_type': 'WebDocumentContext'}, {'id': 'navigation', '_type': 'NavigationContext'}]],
             [3, [{'id': '#document', '_type': 'WebDocumentContext'}, {'id': 'home', '_type': 'SectionContext'}, {'id': 'new', '_type': 'SectionContext'}, {'id': 'BeyEGebJ1l4', '_type': 'SectionContext'}]],
             [4, [{'id': '#document', '_type': 'WebDocumentContext'}, {'id': 'home', '_type': 'SectionContext'}, {'id': 'new', '_type': 'SectionContext'}, {'id': 'yBwD4iYcWC4', '_type': 'SectionContext'}]],
-            [5, [{'id': '#document', '_type': 'WebDocumentContext'}, {'id': 'home', '_type': 'SectionContext'}, {'id': 'new', '_type': 'SectionContext'}, {'id': 'eYuUAGXN0KM', '_type': 'SectionContext'}]]
+            [5, [{'id': '#document', '_type': 'WebDocumentContext'}, {'id': 'home', '_type': 'SectionContext'}, {'id': 'new', '_type': 'SectionContext'}, {'id': 'eYuUAGXN0KM', '_type': 'MediaPlayerContext'}]],
+            [6, [{'id': '#document', '_type': 'WebDocumentContext'}]]
         ]
 
     )
@@ -112,6 +117,7 @@ def test_objectiv_stack_type5(db_params):
             [2, 'Navigation: navigation located at Web Document: #document'],
             [3, 'Section: BeyEGebJ1l4 located at Web Document: #document => Section: home => Section: new'],
             [4, 'Section: yBwD4iYcWC4 located at Web Document: #document => Section: home => Section: new'],
-            [5, 'Section: eYuUAGXN0KM located at Web Document: #document => Section: home => Section: new']
+            [5, 'Media Player: eYuUAGXN0KM located at Web Document: #document => Section: home => Section: new'],
+            [6, 'Web Document: #document']
         ]
     )


### PR DESCRIPTION
**Probably easiest to review per commit**

Changes:
1. Made test data more interesting for `nice_name`. a652ac9d2a6fc4130d05c2fdb73e44cec0101bd0
2. Replace `array_to_string(array_agg())` with `string_agg()` fbb11e0cc9ad6bd2e75b58387f0e0944481d7d84
3. Reformat Postgres Sql Query for `nice_name`. This was not strictly needed, but I needed to read what was happening, and found this a bit easier to read. 45e2baef301c52e565ed1f602e9f595a2f7d047c

NOTE that all tests pass after the first commit. So the code changes in the second and third commit can be reviewed independently from the test changes. The changes to the tests merely add more tests, they don't mask any defects :)