### PR TITLE
Bach fix for `.json[negative index]` and other small improvements

### DIFF
--- a/bach/bach/series/series_json.py
+++ b/bach/bach/series/series_json.py
@@ -532,14 +532,13 @@ class JsonBigQueryAccessorImpl(Generic[TSeriesJson]):
         """
         if key < 0:
             # BigQuery doesn't (yet) natively support this, so we emulate this by reversing the array
-            key = -key - 1
-            array_expr = Expression.construct(
-                "'[' || ARRAY_TO_STRING(ARRAY_REVERSE(JSON_QUERY_ARRAY({})), ', ') || ']'",
+            key = abs(key)
+            expression = Expression.construct(
+                f'ARRAY_REVERSE(JSON_QUERY_ARRAY({{}}))[SAFE_ORDINAL({key})]',
                 self._series_object
             )
         else:
-            array_expr = self._series_object.expression
-        expression = Expression.construct(f'''JSON_QUERY({{}}, '$[{key}]')''', array_expr)
+            expression = Expression.construct(f'''JSON_QUERY({{}}, '$[{key}]')''', self._series_object)
         return self._series_object.copy_override(expression=expression)
 
     def get_dict_item(self, key: str) -> 'TSeriesJson':

--- a/bach/bach/series/series_json.py
+++ b/bach/bach/series/series_json.py
@@ -524,7 +524,12 @@ class JsonBigQueryAccessorImpl(Generic[TSeriesJson]):
         return Expression.construct(fmt, slicing_mask, self._series_object)
 
     def get_array_item(self, key: int) -> 'TSeriesJson':
-        """ For documentation, see implementation in parent class :class:`JsonAccessor` """
+        """
+        Returns an item from the json array.
+        The key is treated as a 0-based index. If negative this will count from the end of the array (one
+            based). If the index does not exist this will render None/NULL.
+        This assumes the top-level item in the json is an array
+        """
         if key < 0:
             # BigQuery doesn't (yet) natively support this, so we emulate this by reversing the array
             key = -key - 1
@@ -700,7 +705,12 @@ class JsonPostgresAccessorImpl(Generic[TSeriesJson]):
             )
 
     def get_array_item(self, key: int) -> 'TSeriesJson':
-        """ For documentation, see implementation in parent class :class:`JsonAccessor` """
+        """
+        Returns an item from the json array.
+        The key is treated as a 0-based index. If negative this will count from the end of the array (one
+            based). If the index does not exist this will render None/NULL.
+        This assumes the top-level item in the json is an array
+        """
         return self._series_object \
             .copy_override(expression=Expression.construct(f'{{}}->{key}', self._series_object))
 

--- a/bach/tests/functional/bach/test_series_json.py
+++ b/bach/tests/functional/bach/test_series_json.py
@@ -137,19 +137,21 @@ def test_json_getitem(engine, dtype):
     bt = get_df_with_json_data(engine=engine, dtype=dtype)
     bt = bt[['mixed_column']]
     bt['sel_0'] = bt.mixed_column.json[0]
-    bt['sel_min2'] = bt.mixed_column.json[-2]
+    bt['sel_min2'] = bt.mixed_column.json[-3]
+    bt['sel_min5'] = bt.mixed_column.json[-5]  # -5 doesn't exist
     bt['sel_a'] = bt.mixed_column.json["a"]
     bt = bt.drop(columns=['mixed_column'])
+    print(bt.view_sql())
     assert_equals_data(
         bt,
         use_to_pandas=True,
-        expected_columns=['_index_row', 'sel_0', 'sel_min2', 'sel_a'],
+        expected_columns=['_index_row', 'sel_0', 'sel_min2', 'sel_min5', 'sel_a'],
         expected_data=[
-            [0, None, None, "b"],
-            [1, "a", "c", None],
-            [2, None, None, "b"],
-            [3, {"_type": "WebDocumentContext", "id": "#document"}, {"_type": "SectionContext", "id": "top-10"}, None],
-            [4, None, None, None]
+            [0, None, None, None, "b"],
+            [1, "a", "b", None, None],
+            [2, None, None, None, "b"],
+            [3, {"_type": "WebDocumentContext", "id": "#document"}, {"_type": "SectionContext", "id": "home"}, None, None],
+            [4, None, None, None, None]
         ]
     )
 

--- a/bach/tests/functional/bach/test_series_json.py
+++ b/bach/tests/functional/bach/test_series_json.py
@@ -134,45 +134,22 @@ def test_json_compare(engine, dtype):
 
 
 def test_json_getitem(engine, dtype):
-    # TODO: make this a one-query test
     bt = get_df_with_json_data(engine=engine, dtype=dtype)
-    bts = bt.mixed_column.json[0]
+    bt = bt[['mixed_column']]
+    bt['sel_0'] = bt.mixed_column.json[0]
+    bt['sel_min2'] = bt.mixed_column.json[-2]
+    bt['sel_a'] = bt.mixed_column.json["a"]
+    bt = bt.drop(columns=['mixed_column'])
     assert_equals_data(
-        bts,
+        bt,
         use_to_pandas=True,
-        expected_columns=['_index_row', 'mixed_column'],
+        expected_columns=['_index_row', 'sel_0', 'sel_min2', 'sel_a'],
         expected_data=[
-            [0, None],
-            [1, "a"],
-            [2, None],
-            [3, {"_type": "WebDocumentContext", "id": "#document"}],
-            [4, None]
-        ]
-    )
-    bts = bt.mixed_column.json[-2]
-    assert_equals_data(
-        bts,
-        use_to_pandas=True,
-        expected_columns=['_index_row', 'mixed_column'],
-        expected_data=[
-            [0, None],
-            [1, "c"],
-            [2, None],
-            [3, {"_type": "SectionContext", "id": "top-10"}],
-            [4, None]
-        ]
-    )
-    bts = bt.mixed_column.json["a"]
-    assert_equals_data(
-        bts,
-        use_to_pandas=True,
-        expected_columns=['_index_row', 'mixed_column'],
-        expected_data=[
-            [0, "b"],
-            [1, None],
-            [2, "b"],
-            [3, None],
-            [4, None]
+            [0, None, None, "b"],
+            [1, "a", "c", None],
+            [2, None, None, "b"],
+            [3, {"_type": "WebDocumentContext", "id": "#document"}, {"_type": "SectionContext", "id": "top-10"}, None],
+            [4, None, None, None]
         ]
     )
 

--- a/bach/tests/functional/bach/test_series_json.py
+++ b/bach/tests/functional/bach/test_series_json.py
@@ -137,15 +137,14 @@ def test_json_getitem(engine, dtype):
     bt = get_df_with_json_data(engine=engine, dtype=dtype)
     bt = bt[['mixed_column']]
     bt['get_0'] = bt.mixed_column.json[0]
-    bt['get_min2'] = bt.mixed_column.json[-3]
+    bt['get_min3'] = bt.mixed_column.json[-3]
     bt['get_min5'] = bt.mixed_column.json[-5]  # -5 doesn't exist, we expect to get `None`
     bt['get_a'] = bt.mixed_column.json["a"]
     bt = bt.drop(columns=['mixed_column'])
-    print(bt.view_sql())
     assert_equals_data(
         bt,
         use_to_pandas=True,
-        expected_columns=['_index_row', 'get_0', 'get_min2', 'get_min5', 'get_a'],
+        expected_columns=['_index_row', 'get_0', 'get_min3', 'get_min5', 'get_a'],
         expected_data=[
             [0, None, None, None, "b"],
             [1, "a", "b", None, None],

--- a/bach/tests/functional/bach/test_series_json.py
+++ b/bach/tests/functional/bach/test_series_json.py
@@ -136,16 +136,16 @@ def test_json_compare(engine, dtype):
 def test_json_getitem(engine, dtype):
     bt = get_df_with_json_data(engine=engine, dtype=dtype)
     bt = bt[['mixed_column']]
-    bt['sel_0'] = bt.mixed_column.json[0]
-    bt['sel_min2'] = bt.mixed_column.json[-3]
-    bt['sel_min5'] = bt.mixed_column.json[-5]  # -5 doesn't exist
-    bt['sel_a'] = bt.mixed_column.json["a"]
+    bt['get_0'] = bt.mixed_column.json[0]
+    bt['get_min2'] = bt.mixed_column.json[-3]
+    bt['get_min5'] = bt.mixed_column.json[-5]  # -5 doesn't exist, we expect to get `None`
+    bt['get_a'] = bt.mixed_column.json["a"]
     bt = bt.drop(columns=['mixed_column'])
     print(bt.view_sql())
     assert_equals_data(
         bt,
         use_to_pandas=True,
-        expected_columns=['_index_row', 'sel_0', 'sel_min2', 'sel_min5', 'sel_a'],
+        expected_columns=['_index_row', 'get_0', 'get_min2', 'get_min5', 'get_a'],
         expected_data=[
             [0, None, None, None, "b"],
             [1, "a", "b", None, None],

--- a/bach/tests/functional/bach/test_series_json.py
+++ b/bach/tests/functional/bach/test_series_json.py
@@ -138,19 +138,25 @@ def test_json_getitem(engine, dtype):
     bt = bt[['mixed_column']]
     bt['get_0'] = bt.mixed_column.json[0]
     bt['get_min3'] = bt.mixed_column.json[-3]
+    bt['get_min4'] = bt.mixed_column.json[-4]  # Should be the same as json[0] for row 0 and 4
     bt['get_min5'] = bt.mixed_column.json[-5]  # -5 doesn't exist, we expect to get `None`
     bt['get_a'] = bt.mixed_column.json["a"]
     bt = bt.drop(columns=['mixed_column'])
     assert_equals_data(
         bt,
         use_to_pandas=True,
-        expected_columns=['_index_row', 'get_0', 'get_min3', 'get_min5', 'get_a'],
+        expected_columns=['_index_row', 'get_0', 'get_min3', 'get_min4', 'get_min5', 'get_a'],
         expected_data=[
-            [0, None, None, None, "b"],
-            [1, "a", "b", None, None],
-            [2, None, None, None, "b"],
-            [3, {"_type": "WebDocumentContext", "id": "#document"}, {"_type": "SectionContext", "id": "home"}, None, None],
-            [4, None, None, None, None]
+            [0, None, None, None, None, "b"],
+            [1, "a", "b", "a", None, None],
+            [2, None, None, None, None, "b"],
+            [3,
+             {"_type": "WebDocumentContext", "id": "#document"},
+             {"_type": "SectionContext", "id": "home"},
+             {"_type": "WebDocumentContext", "id": "#document"},
+             None,
+             None],
+            [4, None, None, None, None, None]
         ]
     )
 


### PR DESCRIPTION
Changes:
* Bugfix: previously `.json[-5]` would give an error on BigQuery if `-5` was not a valid index. Whereas on Postgres, and with positive indexes it gives `NULL`. Now with non-existing negative indexes it also gives NULL
* Slightly changed implementation for negative indexes: reverse the array instead of using array-length to calculate positive index. This way the json-series is only referenced once in the expression instead of twice, which is an improvement if the expression is non-trivial.
* Optimized test: single query vs three queries previously


Of course changing both the tests and the implementation in a single PR is not a best practice. But I figured since I only changed one of the implementations (Postgres is unchanged) and the change is small, it would be easier to have a in single PR.

