### PR TITLE
New hooks for React 18 Reusable State in StrictMode

### DIFF
--- a/tracker/core/react/src/common/providers/ObjectivProvider.tsx
+++ b/tracker/core/react/src/common/providers/ObjectivProvider.tsx
@@ -4,7 +4,7 @@
 
 import React, { ReactNode, useContext } from 'react';
 import { trackApplicationLoadedEvent } from '../../eventTrackers/trackApplicationLoadedEvent';
-import { useOnMount } from '../../hooks/useOnMount';
+import { useOnMountOnce } from '../../hooks/useOnMountOnce';
 import { ObjectivProviderContext } from './ObjectivProviderContext';
 import { TrackerProviderContext } from './TrackerProviderContext';
 import { TrackingContext } from './TrackingContext';
@@ -31,7 +31,7 @@ export type ObjectivProviderProps = TrackerProviderContext & {
   /**
    * ObjectivProvider children can also be a function (render props).
    */
-  children: ReactNode | ((parameters: TrackingContext) => void);
+  children: ReactNode | ((parameters: TrackingContext) => ReactNode);
 
   /**
    * Optional. A partial ObjectivProviderOptions object to override the default options.
@@ -53,7 +53,7 @@ export const ObjectivProvider = ({ children, tracker, options }: ObjectivProvide
     `);
   }
 
-  useOnMount(() => {
+  useOnMountOnce(() => {
     if (trackApplicationLoaded) {
       trackApplicationLoadedEvent({ tracker });
     }

--- a/tracker/core/react/src/hooks/useOnMountOnce.ts
+++ b/tracker/core/react/src/hooks/useOnMountOnce.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2021-2022 Objectiv B.V.
+ */
+
+import { EffectCallback, useEffect, useRef } from 'react';
+
+/**
+ * A side effect that runs once on mount. Uses a ref instead of deps for compatibility with React 18.
+ */
+export const useOnMountOnce = (effect: EffectCallback) => {
+  const didRun = useRef(false);
+
+  useEffect(() => {
+    if (!didRun.current) {
+      didRun.current = true;
+
+      effect();
+    }
+  }, []);
+};

--- a/tracker/core/react/src/hooks/useOnUnmountOnce.ts
+++ b/tracker/core/react/src/hooks/useOnUnmountOnce.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021-2022 Objectiv B.V.
+ */
+
+import { useEffect, useRef } from 'react';
+import { EffectDestructor } from '../types';
+
+/**
+ * A side effect that runs only once on unmount. Uses a ref instead of deps for compatibility with React 18.
+ */
+export const useOnUnmountOnce = (destructor: EffectDestructor) => {
+  const didRun = useRef(false);
+  const latestDestructorRef = useRef<Function | undefined>(destructor);
+
+  latestDestructorRef.current = destructor;
+
+  useEffect(
+    () => () => {
+      if (!didRun.current && latestDestructorRef.current) {
+        didRun.current = true;
+
+        latestDestructorRef.current();
+      }
+    },
+    []
+  );
+};

--- a/tracker/core/react/src/hooks/useTrackOnMountOnce.ts
+++ b/tracker/core/react/src/hooks/useTrackOnMountOnce.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021-2022 Objectiv B.V.
+ */
+
+import { TrackerEventConfig } from '@objectiv/tracker-core';
+import { TrackEventParameters } from '../types';
+import { useTracker } from './consumers/useTracker';
+import { useOnMountOnce } from './useOnMountOnce';
+
+/**
+ * The parameters of useTrackOnMount
+ */
+export type TrackOnMountOnceHookParameters = Partial<TrackEventParameters> & {
+  /**
+   * The Event to track
+   */
+  event: TrackerEventConfig;
+};
+
+/**
+ * A side effect that triggers the given TrackerEvent once on mount.
+ * Uses a ref instead of deps for compatibility with React 18.
+ */
+export const useTrackOnMountOnce = (parameters: TrackOnMountOnceHookParameters) => {
+  const { event, tracker = useTracker(), options } = parameters;
+
+  return useOnMountOnce(() => {
+    tracker.trackEvent(event, options);
+  });
+};

--- a/tracker/core/react/src/hooks/useTrackOnUnmountOnce.ts
+++ b/tracker/core/react/src/hooks/useTrackOnUnmountOnce.ts
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021-2022 Objectiv B.V.
+ */
+
+import { TrackerEventConfig } from '@objectiv/tracker-core';
+import { TrackEventParameters } from '../types';
+import { useTracker } from './consumers/useTracker';
+import { useOnUnmount } from './useOnUnmount';
+
+/**
+ * The parameters of useTrackOnUnmount
+ */
+export type TrackOnUnmountOnceHookParameters = Partial<TrackEventParameters> & {
+  /**
+   * The Event to track
+   */
+  event: TrackerEventConfig;
+};
+
+/**
+ * A side effect that triggers the given TrackerEvent once on unmount.
+ * Uses a ref instead of deps for compatibility with React 18.
+ */
+export const useTrackOnUnmountOnce = (parameters: TrackOnUnmountOnceHookParameters) => {
+  const { event, tracker = useTracker(), options } = parameters;
+
+  return useOnUnmount(() => {
+    tracker.trackEvent(event, options);
+  });
+};

--- a/tracker/core/react/src/index.ts
+++ b/tracker/core/react/src/index.ts
@@ -53,12 +53,16 @@ export * from './hooks/eventTrackers/useVisibilityTracker';
 
 export * from './hooks/useOnChange';
 export * from './hooks/useOnMount';
+export * from './hooks/useOnMountOnce';
 export * from './hooks/useOnToggle';
 export * from './hooks/useOnUnmount';
+export * from './hooks/useOnUnmountOnce';
 export * from './hooks/useTrackOnChange';
 export * from './hooks/useTrackOnMount';
+export * from './hooks/useTrackOnMountOnce';
 export * from './hooks/useTrackOnToggle';
 export * from './hooks/useTrackOnUnmount';
+export * from './hooks/useTrackOnUnmountOnce';
 
 export * from './locationWrappers/ContentContextWrapper';
 export * from './locationWrappers/ExpandableContextWrapper';

--- a/tracker/core/react/tests/ObjectivProvider.test.tsx
+++ b/tracker/core/react/tests/ObjectivProvider.test.tsx
@@ -161,6 +161,21 @@ describe('ObjectivProvider', () => {
     );
   });
 
+  it('should track an ApplicationLoadedEvent once', () => {
+    const tracker = new Tracker({ applicationId: 'app-id' });
+    jest.spyOn(tracker, 'trackEvent');
+
+    const { rerender } = render(<ObjectivProvider tracker={tracker}>app</ObjectivProvider>);
+    rerender(<ObjectivProvider tracker={tracker}>app</ObjectivProvider>);
+
+    expect(tracker.trackEvent).toHaveBeenCalledTimes(1);
+    expect(tracker.trackEvent).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining(makeApplicationLoadedEvent()),
+      undefined
+    );
+  });
+
   it('should not track ApplicationLoadedEvent', () => {
     const tracker = new Tracker({ applicationId: 'app-id' });
     jest.spyOn(tracker, 'trackEvent');

--- a/tracker/core/react/tests/useOnMountOnce.test.ts
+++ b/tracker/core/react/tests/useOnMountOnce.test.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2021-2022 Objectiv B.V.
+ */
+
+import { renderHook } from '@testing-library/react-hooks';
+import { useOnMountOnce } from '../src';
+
+describe('useOnMountOnce', () => {
+  const mockEffectCallback = jest.fn();
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should execute once on mount', () => {
+    renderHook(() => useOnMountOnce(mockEffectCallback));
+
+    expect(mockEffectCallback).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not execute on unmount', () => {
+    const { unmount } = renderHook(() => useOnMountOnce(mockEffectCallback));
+
+    expect(mockEffectCallback).toHaveBeenCalledTimes(1);
+
+    unmount();
+
+    expect(mockEffectCallback).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not execute on rerender', () => {
+    const { rerender } = renderHook(() => useOnMountOnce(mockEffectCallback));
+
+    expect(mockEffectCallback).toHaveBeenCalledTimes(1);
+
+    rerender();
+    rerender();
+    rerender();
+
+    expect(mockEffectCallback).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tracker/core/react/tests/useOnUnmountOnce.test.ts
+++ b/tracker/core/react/tests/useOnUnmountOnce.test.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2021-2022 Objectiv B.V.
+ */
+
+import { renderHook } from '@testing-library/react-hooks';
+import { useOnUnmountOnce } from '../src';
+
+describe('useOnUnmountOnce', () => {
+  const mockEffectCallback = jest.fn();
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should not execute on mount', () => {
+    renderHook((effectCallback) => useOnUnmountOnce(effectCallback), { initialProps: mockEffectCallback });
+
+    expect(mockEffectCallback).not.toHaveBeenCalled();
+  });
+
+  it('should not execute on rerender', () => {
+    const { rerender } = renderHook((effectCallback) => useOnUnmountOnce(effectCallback), {
+      initialProps: mockEffectCallback,
+    });
+
+    expect(mockEffectCallback).not.toHaveBeenCalled();
+
+    rerender();
+    rerender();
+    rerender();
+
+    expect(mockEffectCallback).not.toHaveBeenCalled();
+  });
+
+  it('should execute on unmount', () => {
+    const { unmount } = renderHook((effectCallback) => useOnUnmountOnce(effectCallback), {
+      initialProps: mockEffectCallback,
+    });
+
+    expect(mockEffectCallback).not.toHaveBeenCalled();
+
+    unmount();
+
+    expect(mockEffectCallback).toHaveBeenCalledTimes(1);
+  });
+
+  it('should execute the latest version of the effect callback', () => {
+    const mockEffectCallback2 = jest.fn();
+    const mockEffectCallback3 = jest.fn();
+    const mockEffectCallback4 = jest.fn();
+    const { rerender, unmount } = renderHook((effectCallback) => useOnUnmountOnce(effectCallback), {
+      initialProps: mockEffectCallback,
+    });
+
+    rerender(mockEffectCallback2);
+    rerender(mockEffectCallback3);
+    rerender(mockEffectCallback4);
+    unmount();
+
+    expect(mockEffectCallback).not.toHaveBeenCalled();
+    expect(mockEffectCallback2).not.toHaveBeenCalled();
+    expect(mockEffectCallback3).not.toHaveBeenCalled();
+    expect(mockEffectCallback4).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tracker/core/react/tests/useTrackOnMountOnce.test.tsx
+++ b/tracker/core/react/tests/useTrackOnMountOnce.test.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2021-2022 Objectiv B.V.
+ */
+
+import { makeVisibleEvent, Tracker } from '@objectiv/tracker-core';
+import { render } from '@testing-library/react';
+import { renderHook } from '@testing-library/react-hooks';
+import React from 'react';
+import { useEffect } from 'react';
+import { TrackerProvider, useTrackOnMountOnce } from '../src';
+
+describe('useTrackOnMountOnce', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  const spyTransport = { transportName: 'SpyTransport', handle: jest.fn(), isUsable: () => true };
+  const renderSpy = jest.fn();
+  const tracker = new Tracker({ applicationId: 'app-id', transport: spyTransport });
+
+  const Index = () => {
+    return (
+      <TrackerProvider tracker={tracker}>
+        <Application />
+      </TrackerProvider>
+    );
+  };
+
+  const Application = () => {
+    useTrackOnMountOnce({ event: makeVisibleEvent() });
+
+    useEffect(renderSpy);
+
+    return <>Test application</>;
+  };
+
+  it('should execute once on mount', () => {
+    render(<Index />);
+
+    expect(spyTransport.handle).toHaveBeenCalledTimes(1);
+    expect(spyTransport.handle).toHaveBeenCalledWith(expect.objectContaining({ _type: 'VisibleEvent' }));
+  });
+
+  it('should not execute on unmount', () => {
+    const { unmount } = render(<Index />);
+
+    unmount();
+
+    expect(spyTransport.handle).toHaveBeenCalledTimes(1);
+    expect(spyTransport.handle).toHaveBeenCalledWith(expect.objectContaining({ _type: 'VisibleEvent' }));
+  });
+
+  it('should not execute on rerender', () => {
+    const { rerender } = render(<Index />);
+
+    rerender(<Index />);
+    rerender(<Index />);
+
+    expect(renderSpy).toHaveBeenCalledTimes(3);
+    expect(spyTransport.handle).toHaveBeenCalledTimes(1);
+    expect(spyTransport.handle).toHaveBeenCalledWith(expect.objectContaining({ _type: 'VisibleEvent' }));
+  });
+
+  it('should allow overriding the tracker with a custom one', () => {
+    const spyTransport2 = { transportName: 'spyTransport2', handle: jest.fn(), isUsable: () => true };
+    const anotherTracker = new Tracker({ applicationId: 'app-id', transport: spyTransport2 });
+    renderHook(() => useTrackOnMountOnce({ event: makeVisibleEvent(), tracker: anotherTracker }));
+
+    expect(spyTransport.handle).not.toHaveBeenCalled();
+    expect(spyTransport2.handle).toHaveBeenCalledTimes(1);
+    expect(spyTransport2.handle).toHaveBeenCalledWith(expect.objectContaining({ _type: 'VisibleEvent' }));
+  });
+});

--- a/tracker/core/react/tests/useTrackOnUnmountOnce.test.tsx
+++ b/tracker/core/react/tests/useTrackOnUnmountOnce.test.tsx
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2021-2022 Objectiv B.V.
+ */
+
+import { makeHiddenEvent, Tracker } from '@objectiv/tracker-core';
+import { render } from '@testing-library/react';
+import { renderHook } from '@testing-library/react-hooks';
+import React from 'react';
+import { useEffect } from 'react';
+import { TrackerProvider, useTrackOnUnmountOnce } from '../src';
+
+describe('useTrackOnUnmountOnce', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  const spyTransport = { transportName: 'SpyTransport', handle: jest.fn(), isUsable: () => true };
+  const renderSpy = jest.fn();
+  const tracker = new Tracker({ applicationId: 'app-id', transport: spyTransport });
+
+  const Index = () => {
+    return (
+      <TrackerProvider tracker={tracker}>
+        <Application />
+      </TrackerProvider>
+    );
+  };
+
+  const Application = () => {
+    useTrackOnUnmountOnce({ event: makeHiddenEvent() });
+
+    useEffect(renderSpy);
+
+    return <>Test application</>;
+  };
+
+  it('should not execute on mount', () => {
+    render(<Index />);
+
+    expect(spyTransport.handle).not.toHaveBeenCalled();
+  });
+
+  it('should execute on unmount', () => {
+    const { unmount } = render(<Index />);
+
+    unmount();
+
+    expect(spyTransport.handle).toHaveBeenCalledTimes(1);
+    expect(spyTransport.handle).toHaveBeenCalledWith(expect.objectContaining({ _type: 'HiddenEvent' }));
+  });
+
+  it('should not execute on rerender', () => {
+    const { rerender } = render(<Index />);
+
+    rerender(<Index />);
+    rerender(<Index />);
+
+    expect(renderSpy).toHaveBeenCalledTimes(3);
+    expect(spyTransport.handle).not.toHaveBeenCalled();
+  });
+
+  it('should allow overriding the tracker with a custom one', () => {
+    const spyTransport2 = {
+      transportName: 'spyTransport2',
+      handle: jest.fn(),
+      isUsable: () => true,
+    };
+    const anotherTracker = new Tracker({ applicationId: 'app-id', transport: spyTransport2 });
+    const { unmount } = renderHook(() => useTrackOnUnmountOnce({ event: makeHiddenEvent(), tracker: anotherTracker }));
+
+    unmount();
+
+    expect(spyTransport.handle).not.toHaveBeenCalled();
+    expect(spyTransport2.handle).toHaveBeenCalledTimes(1);
+    expect(spyTransport2.handle).toHaveBeenCalledWith(expect.objectContaining({ _type: 'HiddenEvent' }));
+  });
+});


### PR DESCRIPTION
Certain events should trigger only once, e.g. ApplicationLoadedEvent. 

React 18 introduce changes to how StrictMode affects the rendering of Components in dev mode which causes all components to be mounted, unmounted and re-mounted. 

See: https://reactjs.org/blog/2022/03/08/react-18-upgrade-guide.html#updates-to-strict-mode

In this PR:
 - Introduced new hooks that execute only once even in React 18 StrictMode. These hooks are part of React Code, thus available to both React and React Native SDKs, and can be used to start migrating React 17 code to be compatible with Reusable State concerns.
 - Modified `ObjectProvider` to use `useOnMountOnce`, so it's ready for the new behavior.
