### PR TITLE
Simplify array_contains for BQ

### DIFF
--- a/bach/bach/series/series_json.py
+++ b/bach/bach/series/series_json.py
@@ -409,8 +409,7 @@ class JsonAccessor(Generic[TSeriesJson]):
         :param item: item to be verified if it is contained by the array. Only supports scalar values.
         :returns: boolean series indicating if the array contains the element.
 
-        This assumes the top-level item in the json is an array. Will result in an exception (later on) if
-        that's not the case!
+        This assumes the top-level item in the json is an array.
         """
 
         return self._implementation.array_contains(item)
@@ -583,33 +582,17 @@ class JsonBigQueryAccessorImpl(Generic[TSeriesJson]):
 
     def array_contains(self, item: Union[int, float, bool, str]) -> 'SeriesBoolean':
         """ For documentation, see implementation in class :class:`JsonAccessor` """
-        # Implementing __ge__ for BigQuery, since @> operator is not supported, we need to
-        # simulate it by verifying if all searched items exist in the array.
-        # all items are converted into string by using json.dumps
-
-        to_search_expr = Expression.string_value(json.dumps([item]))
-        # get all the searching values that exist in the array
-        search_stmt = (
-            'select searching_value '
-            f'from UNNEST(JSON_QUERY_ARRAY({{}})) as searching_value '
-            f'where searching_value in UNNEST(JSON_QUERY_ARRAY({{}}))'
+        item_json = json.dumps(item)
+        in_expr = Expression.construct(
+            '(SELECT {} IN UNNEST(JSON_QUERY_ARRAY({})))',
+            Expression.string_value(item_json),
+            self._series_object
         )
-        # get the amount of contained items
-        num_found_expr = Expression.construct(
-            f'CASE WHEN {{}} THEN (select array_length(array({search_stmt}))) END',
-            self._series_object.notnull(),
-            to_search_expr,
-            self._series_object,
-        )
-        from bach.series import SeriesInt64, SeriesBoolean
-        num_found_series = (
-            self._series_object.copy_override(expression=num_found_expr)
-            .copy_override_type(SeriesInt64)
-        )
-
-        # verify if the length of contained items is the same as requested.
-        found_all = num_found_series == len([item])
-        return found_all.copy_override_type(SeriesBoolean)
+        expression = Expression.construct('IF({} IS NULL, NULL, {})', self._series_object, in_expr)
+        from bach.series import SeriesBoolean
+        return self._series_object\
+            .copy_override(expression=expression)\
+            .copy_override_type(SeriesBoolean)
 
 
 class JsonPostgresAccessorImpl(Generic[TSeriesJson]):


### PR DESCRIPTION
This resolves issue #912

SQL before:
```sql
(CASE WHEN (`column` is not null) THEN (select array_length(array(select searching_value from UNNEST(JSON_QUERY_ARRAY("""[\"a\"]""")) as searching_value where searching_value in UNNEST(JSON_QUERY_ARRAY(`column`))))) END = 1) as `a`
```

SQL after
```sql
IF(`column` IS NULL, NULL, (SELECT "\"a\"" IN UNNEST(JSON_QUERY_ARRAY(`column`)))) as `a`
```