### PR TITLE
Require pandas >= 1.3.1 on install, else bach will die upon querying

### DIFF
--- a/bach/setup.cfg
+++ b/bach/setup.cfg
@@ -24,7 +24,7 @@ classifiers =
 install_requires =
     psycopg2-binary
     sqlalchemy
-    pandas
+    pandas>=1.3.1
     sqlparse
 python_requires = >=3.7
 packages = find:


### PR DESCRIPTION
because pandas read_sql_query does not have the right signature before 1.3