### PR TITLE
Add video to `retention_matrix` docs

### DIFF
--- a/modelhub/modelhub/aggregate.py
+++ b/modelhub/modelhub/aggregate.py
@@ -325,7 +325,7 @@ class Aggregate:
 
         :returns: retention matrix bach DataFrame.
 
-        .. vimeoplayer:: 
+        .. vimeoplayer::
             :videoid: 723381969
             :trackingid: product-demo-retention-matrix
             :paddingbottom: 58.25%

--- a/modelhub/modelhub/aggregate.py
+++ b/modelhub/modelhub/aggregate.py
@@ -324,6 +324,11 @@ class Aggregate:
         :param display: if display==True visualize the retention matrix as a heat map
 
         :returns: retention matrix bach DataFrame.
+
+        .. vimeoplayer:: 
+            :videoid: 723381969
+            :trackingid: product-demo-retention-matrix
+            :paddingbottom: 58.25%
         """
 
         available_formats = {'daily', 'weekly', 'monthly', 'yearly'}


### PR DESCRIPTION
Adds a product demo video for the `retention_matrix` model to the documentation.
