### PR TITLE
Bach BQ: Removed `materialization` when in DataFrame.groupby

### DIFF
--- a/bach/bach/dataframe.py
+++ b/bach/bach/dataframe.py
@@ -1960,7 +1960,8 @@ class DataFrame:
             raise Exception(
                 'Current order by clause is referencing expressions that are neither aggregated or grouped,'
                 ' while the DataFrame itself is grouped.'
-                ' Please call DataFrame.sort_values or DataFrame.sort_index and try materializing again.'
+                ' Please call DataFrame.sort_values([]) or DataFrame.sort_index() for removing'
+                ' sorting and try again.'
             )
 
         exprs = []

--- a/bach/bach/dataframe.py
+++ b/bach/bach/dataframe.py
@@ -1958,15 +1958,15 @@ class DataFrame:
             )
         ):
             raise Exception(
-                'Current order by clause is referencing expressions that are neither '
-                'aggregated or grouped. Please call DataFrame.sort_value or DataFrame.sort_index '
-                'and try materializing again.'
+                'Current order by clause is referencing expressions that are neither aggregated or grouped,'
+                ' while the DataFrame itself is grouped.'
+                ' Please call DataFrame.sort_values or DataFrame.sort_index and try materializing again.'
             )
 
         exprs = []
         fmtstr = []
 
-        for sc in self._order_by:
+        for sc in self.order_by:
             # pandas sorts by default all nulls last
             fmt = f"{{}} {'asc' if sc.asc else 'desc'} nulls last"
             if sc.expression.has_multi_level_expressions:

--- a/bach/bach/partitioning.py
+++ b/bach/bach/partitioning.py
@@ -141,33 +141,28 @@ class GroupBy:
                 for n in self._index.keys())
         )
 
-    def get_index_column_expressions(self, construct_multi_levels: bool = False) -> Dict[str, Expression]:
-        """
-        returns a mapping between column name and expression
-        """
-        if construct_multi_levels:
-            return {g.name: g.get_column_expression() for g in self._index.values()}
-
-        from bach.series import SeriesAbstractMultiLevel
-        exprs = {}
-        for g in self._index.values():
-            if not isinstance(g, SeriesAbstractMultiLevel):
-                exprs[g.name] = g.get_column_expression()
-                continue
-            for lvl in g.levels.values():
-                exprs[lvl.name] = lvl.get_column_expression()
-
-        return exprs
-
     def get_index_expressions(self) -> List[Expression]:
         from bach.series import SeriesAbstractMultiLevel
-        exprs = [
-            [g.expression]
-            if not isinstance(g, SeriesAbstractMultiLevel)
-            else g.level_expressions
-            for g in self.index.values()
-        ]
-        return list(itertools.chain.from_iterable(exprs))
+        exprs = []
+        for idx in self.index.values():
+            if isinstance(idx, SeriesAbstractMultiLevel):
+                exprs += idx.level_expressions
+                continue
+
+            # BigQuery MUST use a reference for considering expression in GROUP BY clause
+            # for example:
+            # a) SELECT `x` + 1 as `x`, sum(y) from table GROUP BY `x`
+            # is not equivalent to:
+            # b) SELECT `x` + 1 as `x`, sum(y) from table GROUP BY `x` + 1
+            # GROUP BY expression from b) actually is (`x` + 1) + 1
+            # meanwhile GROUP BY expression from a) is (`x` + 1)
+            # this logic does not applies in Postgres
+            if is_bigquery(idx.engine):
+                exprs.append(Expression.column_reference(idx.name))
+            else:
+                exprs.append(idx.expression)
+
+        return exprs
 
     def get_group_by_column_expression(self) -> Optional[Expression]:
         """

--- a/bach/bach/partitioning.py
+++ b/bach/bach/partitioning.py
@@ -449,6 +449,18 @@ class Window(GroupBy):
         else:
             return Expression.construct('')
 
+    def get_index_expressions(self) -> List[Expression]:
+        from bach.series import SeriesAbstractMultiLevel
+        exprs = []
+        for idx in self.index.values():
+            if isinstance(idx, SeriesAbstractMultiLevel):
+                exprs += idx.level_expressions
+                continue
+
+            exprs.append(idx.expression)
+
+        return exprs
+
     def get_window_expression(self, window_func: Expression) -> Expression:
         """
         Given the window_func generate a statement like:

--- a/bach/bach/series/series_multi_level.py
+++ b/bach/bach/series/series_multi_level.py
@@ -179,12 +179,6 @@ class SeriesAbstractMultiLevel(Series, ABC):
         """ INTERNAL: Returns a list with each level expression"""
         return [level.expression for level in self.levels.values()]
 
-    def get_all_level_column_expression(self, table_alias: str = None) -> List[Expression]:
-        """
-        INTERNAL: Returns a list with each level column expression
-        """
-        return [level.get_column_expression(table_alias) for level in self.levels.values()]
-
     @abstractmethod
     def get_column_expression(self, table_alias: str = None) -> Expression:
         """

--- a/bach/tests/functional/bach/test_df_getitem.py
+++ b/bach/tests/functional/bach/test_df_getitem.py
@@ -169,9 +169,6 @@ def test_get_item_mixed_groupby(engine):
 
     # check that it's illegal to mix different groupings in filters
     expected_message = "Can not apply aggregated BooleanSeries with non matching group_by"
-    if is_bigquery(engine):
-        # on bigquery we have materialized grouped_other. This results in a different error message
-        expected_message = "Cannot apply Boolean series with a different base_node to DataFrame"
 
     with pytest.raises(ValueError, match=expected_message):
             grouped[grouped_other_sum > 50000]


### PR DESCRIPTION
Decided to remove the automatic materialization  for BQ when grouping by as it was a bit annoying when applying window functions, since `df.groupby` removes sorting for the df. Also it is a bit frustrating when trying to do simple operations and ending up with an unnecessary subquery. After playing around a bit more with this, I noticed that we can reference the expression used in the `groupby` by just referencing to the column from the select:

For example, for the following data:
```sql
WITH PlayerStats AS
 (
  SELECT 'Adams' as LastName, 51 as OpponentID, 3 as PointsScored UNION ALL
  SELECT 'Buchanan', 77, 0 UNION ALL
  SELECT 'Coolidge', 77, 1 UNION ALL
  SELECT 'Adams', 52, 4 UNION ALL
  SELECT 'Buchanan', 50, 13 UNION ALL
  SELECT 'Barahona', 50, -5
)
```
Making reference to the same expression in both SELECT  and GROUP BY clause will be something like:
```
SELECT 
LEFT(`LastName`, 2),
SUM(PointsScored) AS `TotalPointsScored`
FROM PlayerStats
GROUP BY LEFT(`LastName`, 2)
```
Now, this introduces many conflicts when adding the column reference in the select expression `e.g LEFT(LastName, 2) as LastName` and considering the same expression in the GROUP BY clause will actually do something like:
`LEFT(LEFT(LastName, 2), 2)` which is incorrect (**this is not the case for Postgres, it will actually consider the main column**). Now, the solution for this is actually just making reference to the alias in GROUP BY  clause for BigQuery, resulting into:

```
SELECT 
LEFT(`LastName`, 2) AS `LastName`,
SUM(PointsScored) AS `TotalPointsScored`
FROM PlayerStats
GROUP BY `LastName`
```

After removing the materialization, I noticed some problems regards the `ORDER BY`. Seems that the ORDER BY clause works similar to the GROUP BY.
Therefore, I think that if ORDER BY expression diverge from GROUP BY  or AGGREGATED expressions, we should raise an exception and tell the user to remove or changed the sort for the DataFrame. As it is way too difficult to know what the user wants to actually sort by