### PR TITLE
Experiment: Zero deps trackers

### DIFF
--- a/tracker/core/react/package.json
+++ b/tracker/core/react/package.json
@@ -68,8 +68,7 @@
   },
   "dependencies": {
     "@objectiv/schema": "^0.0.21-4",
-    "@objectiv/tracker-core": "~0.0.21-4",
-    "fast-deep-equal": "^3.1.3"
+    "@objectiv/tracker-core": "~0.0.21-4"
   },
   "peerDependencies": {
     "react": ">=16.8",

--- a/tracker/core/react/src/hooks/useOnChange.ts
+++ b/tracker/core/react/src/hooks/useOnChange.ts
@@ -3,7 +3,6 @@
  */
 
 import { useEffect, useRef } from 'react';
-import isEqual from 'fast-deep-equal';
 import { OnChangeEffectCallback } from '../types';
 
 /**
@@ -16,7 +15,7 @@ export const useOnChange = <T>(state: T, effect: OnChangeEffectCallback<T>) => {
   latestEffectRef.current = effect;
 
   useEffect(() => {
-    if (!isEqual(previousStateRef.current, state)) {
+    if (JSON.stringify(previousStateRef.current) !== JSON.stringify(state)) {
       effect(previousStateRef.current, state);
       previousStateRef.current = state;
     }

--- a/tracker/core/tracker/package.json
+++ b/tracker/core/tracker/package.json
@@ -64,7 +64,6 @@
   "dependencies": {
     "@objectiv/developer-tools": "^0.0.21-4",
     "@objectiv/plugin-application-context": "^0.0.21-4",
-    "@objectiv/schema": "^0.0.21-4",
-    "uuid": "^8.3.2"
+    "@objectiv/schema": "^0.0.21-4"
   }
 }

--- a/tracker/core/tracker/src/helpers.ts
+++ b/tracker/core/tracker/src/helpers.ts
@@ -39,7 +39,7 @@ export function isNonEmptyArray<T>(array: T[]): array is NonEmptyArray<T> {
  *  > 181a434e63b00000000000000000
  *
  *  Would result in a UUID like this:
- *  > 181a434e63b0-63b0-4000-8000-000000000000
+ *  > 181a434e-63b0-4000-8000-000000000000
  *
  *  Still more than fine for our use-case.
  */

--- a/tracker/core/tracker/src/helpers.ts
+++ b/tracker/core/tracker/src/helpers.ts
@@ -20,7 +20,8 @@ export function isNonEmptyArray<T>(array: T[]): array is NonEmptyArray<T> {
 }
 
 /**
- * A client-only valid UUID v4 generator. Does not guarantee 100% uniqueness, but it's good enough for what we need.
+ * A client-only valid UUID v4 generator. Does not use cryptographically-strong random values, but it's good enough
+ * for what we need.
  *
  * The random string we use for building the UUID is composed by:
  *

--- a/tracker/trackers/react-native/package.json
+++ b/tracker/trackers/react-native/package.json
@@ -67,8 +67,7 @@
   "dependencies": {
     "@objectiv/tracker-core": "~0.0.21-4",
     "@objectiv/tracker-react-core": "~0.0.21-4",
-    "@objectiv/transport-fetch": "^0.0.21-4",
-    "react-native-get-random-values": "^1.7.2"
+    "@objectiv/transport-fetch": "^0.0.21-4"
   },
   "peerDependencies": {
     "react": ">=16.8",

--- a/tracker/trackers/react-native/src/index.ts
+++ b/tracker/trackers/react-native/src/index.ts
@@ -1,8 +1,6 @@
 /*
  * Copyright 2022 Objectiv B.V.
  */
-import 'react-native-get-random-values';
-
 export * from '@objectiv/tracker-react-core';
 
 export * from './common/factories/makeReactNativeTrackerDefaultPluginsList';

--- a/tracker/yarn.lock
+++ b/tracker/yarn.lock
@@ -1792,7 +1792,6 @@ __metadata:
     "@testing-library/react-hooks": ^7.0.2
     "@types/jest": ^27.4.1
     "@types/react": ^17.0.39
-    fast-deep-equal: ^3.1.3
     jest: ^27.5.1
     jest-standard-reporter: ^2.0.0
     prettier: ^2.5.1

--- a/tracker/yarn.lock
+++ b/tracker/yarn.lock
@@ -1776,7 +1776,6 @@ __metadata:
     ts-jest: ^27.1.3
     tsup: ^5.12.0
     typescript: ^4.6.2
-    uuid: ^8.3.2
   languageName: unknown
   linkType: soft
 
@@ -1823,7 +1822,6 @@ __metadata:
     jest-standard-reporter: ^2.0.0
     prettier: ^2.5.1
     react-native: ^0.67.3
-    react-native-get-random-values: ^1.7.2
     react-test-renderer: ^17.0.2
     tsup: ^5.12.0
     typescript: ^4.6.2
@@ -4964,13 +4962,6 @@ __metadata:
     snapdragon: ^0.8.1
     to-regex: ^3.0.1
   checksum: a41531b8934735b684cef5e8c5a01d0f298d7d384500ceca38793a9ce098125aab04ee73e2d75d5b2901bc5dddd2b64e1b5e3bf19139ea48bac52af4a92f1d00
-  languageName: node
-  linkType: hard
-
-"fast-base64-decode@npm:^1.0.0":
-  version: 1.0.0
-  resolution: "fast-base64-decode@npm:1.0.0"
-  checksum: 4c59eb1775a7f132333f296c5082476fdcc8f58d023c42ed6d378d2e2da4c328c7a71562f271181a725dd17cdaa8f2805346cc330cdbad3b8e4b9751508bd0a3
   languageName: node
   linkType: hard
 
@@ -9045,17 +9036,6 @@ fsevents@~2.1.2:
   languageName: node
   linkType: hard
 
-"react-native-get-random-values@npm:^1.7.2":
-  version: 1.7.2
-  resolution: "react-native-get-random-values@npm:1.7.2"
-  dependencies:
-    fast-base64-decode: ^1.0.0
-  peerDependencies:
-    react-native: ">=0.56"
-  checksum: 45782003973b2ceca90b1f73462021e1aa2fc7e00c830ccafbb6f8a6ef7de34989cfc05d49b0f670b399ba1ead5de117a9c69d250fdc0390ca54e38b9f828385
-  languageName: node
-  linkType: hard
-
 "react-native-safe-area-context@npm:^4.1.2":
   version: 4.2.1
   resolution: "react-native-safe-area-context@npm:4.2.1"
@@ -11100,15 +11080,6 @@ typescript@~3.8.3:
   bin:
     uuid: ./bin/uuid
   checksum: 58de2feed61c59060b40f8203c0e4ed7fd6f99d42534a499f1741218a1dd0c129f4aa1de797bcf822c8ea5da7e4137aa3673431a96dae729047f7aca7b27866f
-  languageName: node
-  linkType: hard
-
-"uuid@npm:^8.3.2":
-  version: 8.3.2
-  resolution: "uuid@npm:8.3.2"
-  bin:
-    uuid: dist/bin/uuid
-  checksum: 5575a8a75c13120e2f10e6ddc801b2c7ed7d8f3c8ac22c7ed0c7b2ba6383ec0abda88c905085d630e251719e0777045ae3236f04c812184b7c765f63a70e58df
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Currently our Trackers have two dependencies:
- fast-deep-equal
- UUID

In this PR I've tried to remove both of them by switching to alternate methods. 

**fast-deep-equal**
For `fast-deep-equal`, I decided to use instead JSON.stringify.
The main rationale here is that this function was used to compare React's useEffect dependencies in some helper hooks. Fast-deep-equal worked fine but, for what we need to do, using JSON to stringify both objects and compare the results works equally as well and it's actually faster. No compromise here.

**UUID**
We rely on the well known [uiid](https://github.com/uuidjs/uuid) package. 
The main issue with it is that it relies on `crypto`. This has proved unreliable in a number of cases:
- Google Bot is known to run in an environment (maybe they have their own implementation, or some caching going on) that does **not** generate random values. We have had several duplicates popping in at regular intervals. Something that should never happen.
- React Native doesn't have `crypto` at all. Which means we have to preload a polyfill to implement the same API.
- Latest Jest is not compatible with the uuid package unless we use a custom resolver or some other workaround.

I checked lots of discussion, including comments from the author of UUID, on what would be a decent compromise to generate valid UIID v4 with very low chances of collisions and without having to rely on crypto. 

I also checked the source code of libraries like [nanoid](https://github.com/ai/nanoid) (they have a non-secure version of the library that doesn't rely on crypto) and what several crypto polyfills do under the hood.

In most cases it seems to boil down to using a combination of timestamps + one or more Math.random calls and some base 16 or base 32 conversions. 

I've written a custom implementation that does just that. It's very simple:

```
function generateUUID()  {
  const rng = Date.now().toString(16) + Math.random().toString(16) + '0'.repeat(16);
  return [rng.substring(0, 8), rng.substring(8, 12), '4000-8' + rng.substring(13, 16), rng.substring(16, 28)].join('-');
};
```

Check the code for more info on the limitations of this approach.