### PR TITLE
Bq materialization test follow up

### DIFF
--- a/bach/sql_models/model.py
+++ b/bach/sql_models/model.py
@@ -75,7 +75,7 @@ class Materialization(Enum):
         return self.value.has_lasting_effect
 
     @classmethod
-    def get_by_name(cls, type_name) -> 'Materialization':
+    def get_by_type_name(cls, type_name) -> 'Materialization':
         for mat in cls:
             if mat.type_name == type_name:
                 return mat
@@ -84,7 +84,7 @@ class Materialization(Enum):
     @classmethod
     def normalize(cls, materialization: Union['Materialization', str]) -> 'Materialization':
         if isinstance(materialization, str):
-            return Materialization.get_by_name(materialization)
+            return Materialization.get_by_type_name(materialization)
         if isinstance(materialization, Materialization):
             return materialization
         raise ValueError(f'materialization must be of type str or Materialization, '

--- a/bach/sql_models/model.py
+++ b/bach/sql_models/model.py
@@ -35,25 +35,27 @@ class MaterializationType(NamedTuple):
     is_cte:
         True indicates that a SqlModel with this materialization can be used as a CTE by another SqlModel.
         False indicates that a SqlModel with this materialization cannot be used as a CTE
+    has_lasting_effect: true iff the materialization is a permanent table or view
     """
     type_name: str
     is_statement: bool
     is_cte: bool
+    has_lasting_effect: bool
 
 
 class Materialization(Enum):
-    CTE = MaterializationType('cte', False, True)
+    CTE = MaterializationType('cte', False, True, False)
     """ A QUERY can be used as a CTE, but is also a stand-alone query."""
-    QUERY = MaterializationType('query', True, True)
-    VIEW = MaterializationType('view', True, False)
-    TABLE = MaterializationType('table', True, False)
+    QUERY = MaterializationType('query', True, True, False)
+    VIEW = MaterializationType('view', True, False, True)
+    TABLE = MaterializationType('table', True, False, True)
     """
     TEMP TABLE is a temporary table that is limited to the current session, or a table that is guaranteed to
     be cleaned up by the database at some later time.
     """
-    TEMP_TABLE = MaterializationType('temp_table', True, False)
+    TEMP_TABLE = MaterializationType('temp_table', True, False, False)
     """ A VIRTUAL_NODE will not be turned into a statement, nor generate any CTEs"""
-    VIRTUAL_NODE = MaterializationType('virtual', False, False)
+    VIRTUAL_NODE = MaterializationType('virtual', False, False, False)
 
     @property
     def type_name(self) -> str:
@@ -70,10 +72,7 @@ class Materialization(Enum):
 
     @property
     def has_lasting_effect(self) -> bool:
-        """ Return true if the materialization is a permanent table or view."""
-        # TODO: make these functions consistent, e.g. have a field in value for this, or remove those from
-        # others
-        return self in (Materialization.VIEW, Materialization.TABLE)
+        return self.value.has_lasting_effect
 
     @classmethod
     def get_by_name(cls, type_name) -> 'Materialization':

--- a/bach/sql_models/model.py
+++ b/bach/sql_models/model.py
@@ -44,18 +44,18 @@ class MaterializationType(NamedTuple):
 
 
 class Materialization(Enum):
-    CTE = MaterializationType('cte', False, True, False)
+    CTE = MaterializationType('cte', is_statement=False, is_cte=True, has_lasting_effect=False)
     """ A QUERY can be used as a CTE, but is also a stand-alone query."""
-    QUERY = MaterializationType('query', True, True, False)
-    VIEW = MaterializationType('view', True, False, True)
-    TABLE = MaterializationType('table', True, False, True)
+    QUERY = MaterializationType('query', is_statement=True, is_cte=True, has_lasting_effect=False)
+    VIEW = MaterializationType('view', is_statement=True, is_cte=False, has_lasting_effect=True)
+    TABLE = MaterializationType('table', is_statement=True, is_cte=False, has_lasting_effect=True)
     """
     TEMP TABLE is a temporary table that is limited to the current session, or a table that is guaranteed to
     be cleaned up by the database at some later time.
     """
-    TEMP_TABLE = MaterializationType('temp_table', True, False, False)
+    TEMP_TABLE = MaterializationType('temp_table', is_statement=True, is_cte=False, has_lasting_effect=False)
     """ A VIRTUAL_NODE will not be turned into a statement, nor generate any CTEs"""
-    VIRTUAL_NODE = MaterializationType('virtual', False, False, False)
+    VIRTUAL_NODE = MaterializationType('virtual', is_statement=False, is_cte=False, has_lasting_effect=False)
 
     @property
     def type_name(self) -> str:

--- a/bach/sql_models/sql_generator.py
+++ b/bach/sql_models/sql_generator.py
@@ -126,7 +126,7 @@ def _materialize(dialect: Dialect, sql_query: str, model: SqlModel) -> str:
         if is_postgres(dialect):
             return f'create temporary table {quoted_name} on commit drop as {sql_query}'
         if is_bigquery(dialect):
-            return f'CREATE TEMP TABLE {quoted_name} as {sql_query}'
+            return f'CREATE TEMP TABLE {quoted_name} AS {sql_query}'
         raise DatabaseNotSupportedException(dialect, f'Cannot create temporary table for {dialect.name}')
     if materialization == Materialization.VIRTUAL_NODE:
         return ''

--- a/bach/tests/functional/sql_models/test_sql_generator_materialization.py
+++ b/bach/tests/functional/sql_models/test_sql_generator_materialization.py
@@ -91,10 +91,10 @@ def test_execute_multi_statement_sql_materialization(pg_engine):
     assert len(sql_statements) == 5
     result = run_queries(engine=pg_engine, sql_statements=sql_statements)
     assert result == {
-        'JoinModel___e0bab08e339f02ef255537649ef13be1': None,
-        'JoinModel___e716b40925362305c0dda48e7bb5bd06': None,
-        'RefValueModel___b67e68430810f9b67ae041ce0119c479': None,
-        'RefValueModel___c32fc33ab9d72eccd40c53ba2bf71ab8': (
+        'JoinModel___217a4aca3f6eb18bcd833bb6d8fc4953': None,
+        'JoinModel___3e090538453c4ba34d586639715a3db2': None,
+        'RefValueModel___58764d28c32cf9c71fee32f9055194f2': None,
+        'RefValueModel___f1f66ce5c1f6c9cf2539f09daace1565': (
             ['key', 'value'],
             [['a', 6]]
         ),

--- a/bach/tests/unit/sql_models/test_sql_generator.py
+++ b/bach/tests/unit/sql_models/test_sql_generator.py
@@ -45,20 +45,20 @@ def test_format_injection_composed_models(dialect):
     model = mb(a="'{{y}}'")
     mb = CustomSqlModelBuilder('select {a} from {{x}}')
     result = to_sql(dialect=dialect, model=mb(a='y', x=model))
-    expected = 'with "CustomSqlModel___1415e9e145b7bdd712c6fadaac5a6483" as (select \'{{y}}\' from x)\n' \
-               'select y from "CustomSqlModel___1415e9e145b7bdd712c6fadaac5a6483"'
+    expected = 'with "CustomSqlModel___cdc8d7087835e90c219061949951b631" as (select \'{{y}}\' from x)\n' \
+               'select y from "CustomSqlModel___cdc8d7087835e90c219061949951b631"'
     expected = dialect_expected(expected)
     assert result == expected
 
     result = to_sql(dialect=dialect, model=mb(a="'{y}'", x=model))
-    expected = 'with "CustomSqlModel___1415e9e145b7bdd712c6fadaac5a6483" as (select \'{{y}}\' from x)\n' \
-               "select '{y}' from \"CustomSqlModel___1415e9e145b7bdd712c6fadaac5a6483\""
+    expected = 'with "CustomSqlModel___cdc8d7087835e90c219061949951b631" as (select \'{{y}}\' from x)\n' \
+               "select '{y}' from \"CustomSqlModel___cdc8d7087835e90c219061949951b631\""
     expected = dialect_expected(expected)
     assert result == expected
 
     result = to_sql(dialect=dialect, model=mb(a="'{{y}}'", x=model))
-    expected = 'with "CustomSqlModel___1415e9e145b7bdd712c6fadaac5a6483" as (select \'{{y}}\' from x)\n' \
-               "select '{{y}}' from \"CustomSqlModel___1415e9e145b7bdd712c6fadaac5a6483\""
+    expected = 'with "CustomSqlModel___cdc8d7087835e90c219061949951b631" as (select \'{{y}}\' from x)\n' \
+               "select '{{y}}' from \"CustomSqlModel___cdc8d7087835e90c219061949951b631\""
     expected = dialect_expected(expected)
     assert result == expected
 
@@ -139,17 +139,17 @@ def test_model_thrice_simple():
     )
     result = to_sql(dialect=dialect, model=model)
     expected = '''
-        with "Source ""Table""___a4a63d6f66f547fb2994ed020c76db56" as (
+        with "Source ""Table""___8767445ba1af5136eeffd5341e01045d" as (
             select 1 as val
-        ), "Double___160c435d2dd8220f87ab1d2a1e3e6c5b" as (
+        ), "Double___f121c8a22ad316abde7720951c3289dc" as (
             select (val * 2) as val
-            from "Source ""Table""___a4a63d6f66f547fb2994ed020c76db56"
-        ), "Double___3a93a6eda1f771832d32e871fe86498f" as (
+            from "Source ""Table""___8767445ba1af5136eeffd5341e01045d"
+        ), "Double___82474fb08efe26024ac77a358a288af8" as (
             select (val * 2) as val
-            from "Double___160c435d2dd8220f87ab1d2a1e3e6c5b"
+            from "Double___f121c8a22ad316abde7720951c3289dc"
         )
         select (val * 2) as val
-        from "Double___3a93a6eda1f771832d32e871fe86498f"
+        from "Double___82474fb08efe26024ac77a358a288af8"
     '''
     assert_roughly_equal_sql(result, expected)
 

--- a/bach/tests/unit/sql_models/test_sql_generator_materialization.py
+++ b/bach/tests/unit/sql_models/test_sql_generator_materialization.py
@@ -23,17 +23,17 @@ def test_simple_to_sql(dialect):
 
     # assert that output of to_sql_materialized_nodes() matched to_sql()
     expected_view = GeneratedSqlStatement(
-        name='JoinModel___72375bcf8a25de05a031b9b40b871b7e',
+        name='JoinModel___2c6ab23e2f26eec98c57470d04d05cbf',
         sql=sql_view,
         materialization=Materialization.VIEW
     )
     expected_table = GeneratedSqlStatement(
-        name='JoinModel___ba94544f10ddca3e10485ffc73a35215',
+        name='JoinModel___9141afd6d19376e1c7d2025997f249b7',
         sql=sql_table,
         materialization=Materialization.TABLE
     )
     expected_temp_table = GeneratedSqlStatement(
-        name='JoinModel___873a21bbc5cca01b28d8794d0e96eb3e',
+        name='JoinModel___440ba69f7e973ec9a376255c3fd16edc',
         sql=sql_temp_table,
         materialization=Materialization.TEMP_TABLE
     )
@@ -43,17 +43,17 @@ def test_simple_to_sql(dialect):
 
     # assert that the sql generate for the table is correct
     expected_sql_table = '''
-        create table "JoinModel___ba94544f10ddca3e10485ffc73a35215"
-        as with "ValueModel___a51a289cdeb34824db00b4f82b33a4fb" as (
+        create table "JoinModel___9141afd6d19376e1c7d2025997f249b7"
+        as with "ValueModel___02030afa3603fd134cde7518272d1076" as (
             select 'a' as key, 1 as value
-        ), "RefModel___4baad8d19279117cdf36a9fb054d94d2" as (
-            select * from "ValueModel___a51a289cdeb34824db00b4f82b33a4fb"
-        ), "ValueModel___39ec2678bd193588e7aa47444a87ffd2" as (
+        ), "RefModel___b24f07393e1432fcb37d0bc96d4eb407" as (
+            select * from "ValueModel___02030afa3603fd134cde7518272d1076"
+        ), "ValueModel___97e2f0126c5b60ef0a61a64cb166011e" as (
             select 'a' as key, 2 as value
         )
         select l.key, l.value + r.value as value
-        from "RefModel___4baad8d19279117cdf36a9fb054d94d2" as l
-        inner join "ValueModel___39ec2678bd193588e7aa47444a87ffd2" as r on l.key=r.key
+        from "RefModel___b24f07393e1432fcb37d0bc96d4eb407" as l
+        inner join "ValueModel___97e2f0126c5b60ef0a61a64cb166011e" as r on l.key=r.key
     '''
     if is_bigquery(dialect):
         expected_sql_table = expected_sql_table.replace('"', '`')
@@ -84,11 +84,11 @@ def test_edge_node_materialization(dialect):
     assert len(result) == 3
     expected_query = '''
         select l.key, l.value + r.value as value
-        from "ValueModel___0cf6df2c76283647c26101b0e472e617" as l
-        inner join "ValueModel___5d92f18dfba41ab7101110d9679b9faf" as r on l.key=r.key
+        from "ValueModel___130be867558e4620e86279b05dfbacd5" as l
+        inner join "ValueModel___c51ebb544836be4d838c7e20080c3496" as r on l.key=r.key
     '''
-    expected_table = 'create table "ValueModel___5d92f18dfba41ab7101110d9679b9faf" as select \'a\' as key, 2 as value'
-    expected_view = 'create view "ValueModel___0cf6df2c76283647c26101b0e472e617" as select \'a\' as key, 1 as value'
+    expected_table = 'create table "ValueModel___c51ebb544836be4d838c7e20080c3496" as select \'a\' as key, 2 as value'
+    expected_view = 'create view "ValueModel___130be867558e4620e86279b05dfbacd5" as select \'a\' as key, 1 as value'
     if is_bigquery(dialect):
         expected_query = expected_query.replace('"', '`')
         expected_table = expected_table.replace('"', '`')
@@ -114,17 +114,17 @@ def test_non_edge_node_materialization(dialect):
     assert len(result) == 2
     # TODO: the naming of these views and tables in the generated sql is something we need to improve
     jm_expected_sql = '''
-        create view "JoinModel___2303c02e10ed1183d253c6ce249f6f4b" as
-        with "ValueModel___a51a289cdeb34824db00b4f82b33a4fb" as (
+        create view "JoinModel___325a4dbda493ad13c52f92cce0db2df4" as
+        with "ValueModel___02030afa3603fd134cde7518272d1076" as (
             select 'a' as key, 1 as value
-        ), "ValueModel___39ec2678bd193588e7aa47444a87ffd2" as (
+        ), "ValueModel___97e2f0126c5b60ef0a61a64cb166011e" as (
             select 'a' as key, 2 as value
         )
         select l.key, l.value + r.value as value
-        from "ValueModel___a51a289cdeb34824db00b4f82b33a4fb" as l
-        inner join "ValueModel___39ec2678bd193588e7aa47444a87ffd2" as r on l.key=r.key
+        from "ValueModel___02030afa3603fd134cde7518272d1076" as l
+        inner join "ValueModel___97e2f0126c5b60ef0a61a64cb166011e" as r on l.key=r.key
     '''
-    graph_expected_sql = 'select * from "JoinModel___2303c02e10ed1183d253c6ce249f6f4b"'
+    graph_expected_sql = 'select * from "JoinModel___325a4dbda493ad13c52f92cce0db2df4"'
     if is_bigquery(dialect):
         jm_expected_sql = jm_expected_sql.replace('"', '`')
         graph_expected_sql = graph_expected_sql.replace('"', '`')


### PR DESCRIPTION
Addresses a TODO from earlier branch https://github.com/objectiv/objectiv-analytics/pull/901/files#r902742839

Change:
* For `SqlModel._calculate_hash()` now use the Materialization's unique type-name, instead of the Materialization type's full tuple of properties. This means that if we ever add/remove a property the hashes don't change again.
* All tests that (indirectly) check the hash
* Made implementation of `Materialization.has_lasting_effect` consistent with other properties.