### PR TITLE
Bach: `use materialize(distinct=True)` in Series.unique

### DIFF
--- a/bach/bach/dataframe.py
+++ b/bach/bach/dataframe.py
@@ -3255,7 +3255,7 @@ class DataFrame:
         if isinstance(self.index[index_to_unstack], SeriesAbstractMultiLevel):
             raise IndexError(f'"{level}" cannot be unstacked, since it is a MultiLevel series.')
 
-        values = self.index[index_to_unstack].unique().to_numpy()
+        values = self.index[index_to_unstack].unique(skipna=False).to_numpy()
 
         if None in values or numpy.nan in values:
             raise ValueError("index contains empty values, cannot be unstacked")

--- a/bach/bach/series/series.py
+++ b/bach/bach/series/series.py
@@ -1566,7 +1566,6 @@ class Series(ABC):
         if partition:
             raise ValueError('Can not use group_by in combination with unique(). Materialize() first.')
 
-        # TODO: remove this when Series.loc is supported
         df = self.to_frame().reset_index(drop=True)
 
         if skipna:

--- a/bach/bach/series/series.py
+++ b/bach/bach/series/series.py
@@ -1560,7 +1560,7 @@ class Series(ABC):
         Return all unique values in this Series.
 
         :param partition: The partition or window to apply.
-        :param skipna: only ``skipna=True`` supported. This means NULL values are ignored.
+        :param skipna: If true, all NULL values are ignored.
         :returns: a new Series with the aggregation applied
         """
         if partition:

--- a/bach/tests/functional/bach/test_series.py
+++ b/bach/tests/functional/bach/test_series.py
@@ -265,11 +265,6 @@ def test_type_agnostic_aggregation_functions():
 def test_unique(engine):
     bt = get_df_with_test_data(engine, full_data_set=True)
     uq = bt.municipality.unique()
-    assert not uq.expression.is_single_value
-
-    muni_single = bt.municipality[:1]
-    uq_single = muni_single.unique()
-    assert uq_single.expression.is_single_value == muni_single.expression.is_single_value == True
 
     with pytest.raises(ValueError, match='dtypes of indexes should be the same'):
         # the uq series have an index with different dtypes


### PR DESCRIPTION
For avoiding conflicts regards group by and non aggregated expressions for BigQuery, its easier just to add a DISTINCT for `Series.unique`