### PR TITLE
Bach float random

### DIFF
--- a/bach/bach/dataframe.py
+++ b/bach/bach/dataframe.py
@@ -999,7 +999,7 @@ class DataFrame:
         the size of the generated SQL query. But this can be useful if the current DataFrame contains
         expressions that you want to evaluate before further expressions are build on top of them. This might
         make sense for very large expressions, or for non-deterministic expressions (e.g. see
-        :py:meth:`SeriesUuid.sql_gen_random_uuid`). Additionally, materializing as a temporary table can
+        :py:meth:`SeriesUuid.random_expression()`). Additionally, materializing as a temporary table can
         improve performance in some instances.
 
         Note this function does NOT query the database or materializes any data in the database. It merely

--- a/bach/bach/series/series.py
+++ b/bach/bach/series/series.py
@@ -800,7 +800,7 @@ class Series(ABC):
         the size of the generated SQL query. But this can be useful if the current Series contains
         expressions that you want to evaluate before further expressions are build on top of them. This might
         make sense for very large expressions, or for non-deterministic expressions (e.g. see
-        :py:meth:`SeriesUuid.sql_gen_random_uuid`).
+        :py:meth:`SeriesUuid.random_expression`).
 
         :param node_name: The name of the node that's going to be created
         :param limit: The limit (slice, int) to apply.

--- a/bach/bach/series/series_numeric.py
+++ b/bach/bach/series/series_numeric.py
@@ -404,7 +404,6 @@ class SeriesFloat64(SeriesAbstractNumeric):
         :param base: DataFrame or Series from which the newly created Series' engine, base_node and index
             parameters are copied.
         """
-        # TODO: tests
         if is_postgres(base.engine):
             expr_str = 'random()'
         elif is_bigquery(base.engine):

--- a/bach/bach/series/series_numeric.py
+++ b/bach/bach/series/series_numeric.py
@@ -7,6 +7,7 @@ from typing import cast, Union, TYPE_CHECKING, Optional, List, Tuple
 import numpy
 from sqlalchemy.engine import Dialect
 
+from bach import DataFrameOrSeries
 from bach.series import Series
 from bach.expression import Expression, AggregateFunctionExpression
 from bach.series.series import WrappedPartition
@@ -374,3 +375,50 @@ class SeriesFloat64(SeriesAbstractNumeric):
         if source_dtype not in ['int64', 'string']:
             raise ValueError(f'cannot convert {source_dtype} to float64')
         return Expression.construct(f'cast({{}} as {cls.get_db_dtype(dialect)})', expression)
+
+    @classmethod
+    def random_expression(cls, base: DataFrameOrSeries) -> 'SeriesFloat64':
+        """
+        Create a new Series object with an expression, that will evaluate to a random float in the range
+        [0, 1) for each row.
+
+        .. warning::
+            The returned Series has a non-deterministic expression, it will give a different result each
+            time it is evaluated by the database.
+
+        The non-deterministic expression can have some unexpected consequences. Consider the following code:
+
+        .. code-block:: python
+
+            df['x'] = SeriesFloat64.random(df)
+            df['y'] = df['x']
+            df['different'] = df['y'] != df['x']
+
+        The df['different'] column will be True for (almost) all rows, because the second statement copies
+        the unevaluated expression, not the result of the expression. So at evaluation time the expression
+        will be evaluated twice for each row, for the 'x' column and the 'y' column, giving different
+        results both times. One way to work around this is to materialize the dataframe in its current state
+        (using materialize()), before adding any columns that reference a column that's created with
+        this function.
+
+        :param base: DataFrame or Series from which the newly created Series' engine, base_node and index
+            parameters are copied.
+        """
+        # TODO: tests
+        if is_postgres(base.engine):
+            expr_str = 'random()'
+        elif is_bigquery(base.engine):
+            expr_str = 'RAND()'
+        else:
+            raise DatabaseNotSupportedException(base.engine)
+        return cls.get_class_instance(
+            engine=base.engine,
+            base_node=base.base_node,
+            index=base.index,
+            name='__tmp',
+            expression=Expression.construct(expr_str),
+            group_by=None,
+            sorted_ascending=None,
+            index_sorting=[],
+            instance_dtype=cls.dtype
+        )

--- a/bach/bach/series/series_uuid.py
+++ b/bach/bach/series/series_uuid.py
@@ -73,7 +73,7 @@ class SeriesUuid(Series):
         raise ValueError(f'cannot convert {source_dtype} to uuid.')
 
     @classmethod
-    def sql_gen_random_uuid(cls, base: DataFrameOrSeries) -> 'SeriesUuid':
+    def random_expression(cls, base: DataFrameOrSeries) -> 'SeriesUuid':
         """
         Create a new Series object with an expression, that will evaluate to a random uuid for each row.
 
@@ -85,7 +85,7 @@ class SeriesUuid(Series):
 
         .. code-block:: python
 
-            df['x'] = SeriesUuid.sql_gen_random_uuid(df)
+            df['x'] = SeriesUuid.random_expression(df)
             df['y'] = df['x']
             df['different'] = df['y'] != df['x']
 

--- a/bach/tests/functional/bach/test_df_materialize.py
+++ b/bach/tests/functional/bach/test_df_materialize.py
@@ -20,7 +20,7 @@ from tests.functional.bach.test_data_and_utils import assert_equals_data, get_df
 def test_materialize(inplace: bool, materialization: Union[Materialization, str], engine: Engine):
     bt = get_df_with_test_data(engine)[['city', 'founding']]
     bt['city'] = bt['city'] + ' '
-    bt['uuid'] = SeriesUuid.sql_gen_random_uuid(bt)
+    bt['uuid'] = SeriesUuid.random_expression(bt)
     bt['founding_str'] = bt['founding'].astype('string')
     bt['city_founding'] = bt['city'] + bt['founding_str']
     bt['founding'] = bt['founding'] + 200
@@ -105,7 +105,7 @@ def test_materialize_with_non_aggregation_series(inplace: bool, engine):
 @pytest.mark.parametrize("inplace", [False, True])
 def test_materialize_non_deterministic_expressions(inplace: bool, engine):
     bt = get_df_with_test_data(engine)[['city']]
-    bt['uuid1'] = SeriesUuid.sql_gen_random_uuid(bt)
+    bt['uuid1'] = SeriesUuid.random_expression(bt)
     # now bt['uuid1'] has not been evaluated, so copying the column should copy the unevaluated expression
     bt['uuid2'] = bt['uuid1']
     bt['eq'] = bt['uuid1'] == bt['uuid2']  # expect False

--- a/bach/tests/functional/bach/test_series_float.py
+++ b/bach/tests/functional/bach/test_series_float.py
@@ -6,7 +6,7 @@ import math
 from unittest.mock import ANY
 
 from bach import SeriesFloat64
-from tests.functional.bach.test_data_and_utils import assert_equals_data, get_df_with_test_data
+from tests.functional.bach.test_data_and_utils import assert_equals_data, get_df_with_test_data, run_query
 from tests.functional.bach.test_series_numeric import helper_test_simple_arithmetic
 
 
@@ -47,3 +47,19 @@ def test_float_int_arithmetic(engine):
 
 def test_float_float_arithmetic(engine):
     helper_test_simple_arithmetic(engine=engine, a=20.01, b=3.33)
+
+
+def test_random_expression(engine):
+    bt = get_df_with_test_data(engine)[['city']]
+    bt['random_float'] = SeriesFloat64.random_expression(base=bt)
+    result = bt.to_pandas()
+    assert list(result.columns) == ['city', 'random_float']
+    distinct_values = set()
+    for value in result['random_float'].values:
+        assert isinstance(value, float)
+        assert 0 <= value < 1
+        # We cannot check whether the generated numbers are random. But we can check
+        # that there are no duplicates. The chance of having a duplicate random number in
+        # 3 rows of data with 64 bit random numbers is so small we just discard that.
+        assert value not in distinct_values
+        distinct_values.add(value)

--- a/bach/tests/functional/bach/test_series_uuid.py
+++ b/bach/tests/functional/bach/test_series_uuid.py
@@ -82,9 +82,9 @@ def test_uuid_from_dtype_to_sql(engine):
     )
 
 
-def test_uuid_generate_random_uuid(engine):
+def test_uuid_random_expression(engine):
     bt = get_df_with_test_data(engine)[['city']]
-    bt['x'] = SeriesUuid.sql_gen_random_uuid(base=bt)
+    bt['x'] = SeriesUuid.random_expression(base=bt)
     assert_equals_data(
         bt,
         expected_columns=['_index_skating_order', 'city', 'x'],
@@ -111,7 +111,7 @@ def test_uuid_compare(engine):
     bt = get_df_with_test_data(engine)[['city', 'founding']]
     bt['a'] = uuid.UUID('0022c7dd-074b-4a44-a7cb-b7716b668264')
     bt['b'] = uuid.UUID('0022c7dd-074b-4a44-a7cb-b7716b668264')
-    bt['c'] = SeriesUuid.sql_gen_random_uuid(bt)
+    bt['c'] = SeriesUuid.random_expression(bt)
     # this is a bit funky, here we copy the 'gen_random_uuid()' expression instead of the result of the
     # expression. As a result bt['d'] != bt['c']. This is something that we might want to change in the
     # future (e.g. by having a flag indicating that we need to create a new node in the DAG if we copy this
@@ -157,7 +157,7 @@ def test_uuid_compare(engine):
 def test_to_pandas(engine):
     bt = get_df_with_test_data(engine)
     bt['a'] = uuid.UUID('0022c7dd-074b-4a44-a7cb-b7716b668264')
-    bt['c'] = SeriesUuid.sql_gen_random_uuid(bt)
+    bt['c'] = SeriesUuid.random_expression(bt)
     result_pdf = bt[['a', 'c']].to_pandas()
     assert result_pdf[['a']].to_numpy()[0] == [uuid.UUID('0022c7dd-074b-4a44-a7cb-b7716b668264')]
     assert type(result_pdf[['a']].to_numpy()[0][0]) == type(uuid.UUID('0022c7dd-074b-4a44-a7cb-b7716b668264'))


### PR DESCRIPTION
Changes:
1. Add a new function to `Float64`: `random_expression()`
2. Renamed existing function `SeriesUuid.sql_gen_random_uuid()` to `SeriesUuid.random_expression()` for more consistency in the naming


This is used by the improved `DataFrame.get_sample()` implementation. That work-in-progress can be found here https://github.com/objectiv/objectiv-analytics/pull/972/files)