### PR TITLE
bach: Add `DataFrame.database_create_table()`

### DIFF
--- a/bach/tests/functional/bach/test_df_database_create.py
+++ b/bach/tests/functional/bach/test_df_database_create.py
@@ -1,0 +1,56 @@
+"""
+Copyright 2022 Objectiv B.V.
+"""
+from random import randrange
+
+import pytest
+
+from tests.functional.bach.test_data_and_utils import get_df_with_test_data, assert_equals_data
+from sql_models.sql_generator import to_sql
+from sql_models.util import quote_identifier
+
+
+def test_database_create_table(engine):
+    df = get_df_with_test_data(engine)
+
+    # We add a random value to the dataframe, that way we can check that it was actually this test run
+    # that wrote the table, and not some earlier run that happened to write the same data to the same table.
+    random_value = randrange(1_000_000)
+    df['x'] = random_value
+    expected_columns = [
+        '_index_skating_order', 'skating_order', 'city', 'municipality', 'inhabitants', 'founding', 'x'
+    ]
+    expected_data = [
+        [1, 1, 'Ljouwert', 'Leeuwarden', 93485, 1285, random_value],
+        [2, 2, 'Snits', 'Súdwest-Fryslân', 33520, 1456, random_value],
+        [3, 3, 'Drylts', 'Súdwest-Fryslân', 3055, 1268, random_value]
+    ]
+
+    df_from_table = df.database_create_table(
+        table_name='test_df_database_create__test_database_create_table',
+        overwrite=True
+    )
+    assert_equals_data(df_from_table, expected_columns=expected_columns, expected_data=expected_data)
+
+    # check that df_from_table actually queries the table
+    dialect = engine.dialect
+    assert df_from_table.base_node != df.base_node
+    new_sql = to_sql(dialect=dialect, model=df_from_table.base_node)
+    quoted_table_name = quote_identifier(dialect, 'test_df_database_create__test_database_create_table')
+    expected_sql_fragment = f'FROM {quoted_table_name}'
+    assert expected_sql_fragment in new_sql
+
+    # Test again, but with overwrite=False. We expect an error
+    random_value = randrange(1_000_000)
+    df['y'] = random_value
+    # we get a database error, so the exact error is database dependent. Both Postgres and BigQuery should
+    # raise an error containing the phrase 'already exists', but with different capitalization
+    with pytest.raises(Exception, match='[aA]lready [eE]xists'):
+        df_from_table = df.database_create_table(
+            table_name='test_df_database_create__test_database_create_table',
+            overwrite=False
+        )
+    # table should be unchanged after the last failed call
+    assert_equals_data(df_from_table, expected_columns=expected_columns, expected_data=expected_data)
+
+


### PR DESCRIPTION
Added `DataFrame.database_create_table()` to easily create a database table with the current dataframe.

`database_create_table()` vs `savepoints`:
The functionality in this PR duplicates some functionality in `df.savepoints`. But upon reflection I think Savepoints is just too complex. Savepoints was meant to built whole graphs of tables/views/queries and being able to write them all to the database, or in the future export them all to BI tools, or even export them as a graph to tools like dbt. But that makes it rather complex to use, imho. The interface should be very simple for end-users for simple things like creating (potentially very big) tables.