### PR TITLE
Sqlmodel `to_sql()` performance improvement

### DIFF
--- a/bach/requirements-dev.txt
+++ b/bach/requirements-dev.txt
@@ -1,5 +1,6 @@
 pytest==6.2.5
 pytest-xdist==2.5.0
+pytest-timeout==2.1.0
 mypy==0.910
 pycodestyle==2.7.0
 ipython==7.31.1

--- a/bach/tests/conftest.py
+++ b/bach/tests/conftest.py
@@ -31,6 +31,11 @@ Category 4 and 5 are for functionality that we explicitly not support on some da
 
 Category 2, 4, and 5 are the exception, these need to be marked with the `db_independent`, `skip_postgres`,
 or `skip_bigquery` marks.
+
+### Other
+For all unittests we add a timeout of 1 second. If they take longer they will be stopped and considered
+failed.
+
 """
 import os
 from enum import Enum

--- a/bach/tests/conftest.py
+++ b/bach/tests/conftest.py
@@ -34,7 +34,7 @@ or `skip_bigquery` marks.
 """
 import os
 from enum import Enum
-from typing import Dict
+from typing import Dict, List
 
 import pytest
 from _pytest.main import Session
@@ -124,6 +124,21 @@ def pytest_generate_tests(metafunc: Metafunc):
         metafunc.parametrize("dialect", dialects)
     if 'engine' in metafunc.fixturenames:
         metafunc.parametrize("engine", engines)
+
+
+def pytest_collection_modifyitems(session, config, items: List[pytest.Item]):
+    # Unit tests should be quick. Add a timeout, after which the test will be cancelled and failed. This is
+    # enforced by pytest-timeout. We actually have a few unittests that previously would have taken minutes
+    # to run. Having this timeout should prevent performance regressions.
+
+    # This function will automatically be callled by pytest when it has collected all tests to run,
+    # see https://docs.pytest.org/en/6.2.x/reference.html#pytest.hookspec.pytest_collection_modifyitems
+    for item in items:
+        # Check if item is a unittest. This is a bit hackish, but should work on virtual all setups.
+        if '/unit/' in str(item.fspath):
+            # 1.0 seconds is actual lenient. Almost all tests run within 0.1 on a fast laptop, and even the
+            # slowest tests consistently run within 0.5 on a fast laptop.
+            item.add_marker(pytest.mark.timeout(1.0))
 
 
 def pytest_runtest_setup(item: Function):

--- a/bach/tests/unit/sql_models/test_graph_operations.py
+++ b/bach/tests/unit/sql_models/test_graph_operations.py
@@ -234,6 +234,9 @@ def test_find_nodes_path_length():
     assert result == [FoundNode(model=vm2, reference_path=('ref_left', 'ref_left', 'ref_right', 'ref_left'))]
 
 
+# be explicit as this is also a performance test: max 1 sec runtime.
+# But conftests.py should already define limit for all unittests.
+@pytest.mark.timeout(1)
 def test_find_nodes_long_and_short_path_performance():
     # We'll build a graph with a simple structure but with a lot of paths. The number of joins is controlled
     # through the `depth` constant. Schematically the graph looks like this (all joins between 2 and N-1 are
@@ -252,7 +255,8 @@ def test_find_nodes_long_and_short_path_performance():
     #
     # If this test takes longer than a second to run, then that's a regression!
     #
-    depth = 25
+    import time; time.sleep(0.1)
+    depth = 50
     vm = ValueModel.build(key='a', val=1)
     graph = vm
     for _ in range(depth):

--- a/bach/tests/unit/sql_models/test_graph_operations.py
+++ b/bach/tests/unit/sql_models/test_graph_operations.py
@@ -219,19 +219,55 @@ def test_find_nodes_path_length():
     result = find_nodes(graph, function=lambda n: n is vm1, first_instance=True)
     assert result == [FoundNode(model=vm1, reference_path=('ref_right', 'ref'))]
     result = find_nodes(graph, function=lambda n: n is vm1, first_instance=False)
-    assert result == [FoundNode(model=vm1, reference_path=('ref_left', 'ref_right', 'ref_right', 'ref'))]
+    assert result == [FoundNode(model=vm1, reference_path=('ref_left', 'ref_left', 'ref_right', 'ref_right'))]
 
     # find vm1 from jm4, both with longest and shortest path
     result = find_nodes(jm4, function=lambda n: n is vm1, first_instance=True)
     assert result == [FoundNode(model=vm1, reference_path=('ref_left', 'ref_right', 'ref_right'))]
     result = find_nodes(jm4, function=lambda n: n is vm1, first_instance=False)
-    assert result == [FoundNode(model=vm1, reference_path=('ref_right', 'ref_right', 'ref'))]
+    assert result == [FoundNode(model=vm1, reference_path=('ref_left', 'ref_right', 'ref_right'))]
 
     # find vm2 from graph, both with longest and shortest path
     result = find_nodes(graph, function=lambda n: n is vm2)
     assert result == [FoundNode(model=vm2, reference_path=('ref_left', 'ref_left', 'ref_left'))]
     result = find_nodes(graph, function=lambda n: n is vm2, first_instance=False)
-    assert result == [FoundNode(model=vm2, reference_path=('ref_left', 'ref_right', 'ref_left', 'ref_left'))]
+    assert result == [FoundNode(model=vm2, reference_path=('ref_left', 'ref_left', 'ref_right', 'ref_left'))]
+
+
+def test_find_nodes_long_and_short_path_performance():
+    # We'll build a graph with a simple structure but with a lot of paths. The number of joins is controlled
+    # through the `depth` constant. Schematically the graph looks like this (all joins between 2 and N-1 are
+    # omitted):
+    #
+    #               /------------------------------------------------------------------------------\
+    #              /                                                                                +-- graph
+    #   vm <------+                                                                                /
+    #              \              /----\             /- ... -\                /----\              /
+    #               +-- join1 <--+     +-- join2 <--+         +-- joinN-1 <--+      +-- joinN <--/
+    #                             \----/             \- ... -/                \----/
+    #
+    # There are a lot of possible reference paths from the `graph` node to `vm` node: 2^depth + 1
+    # For depth values above ~ 18 this used to get noticeably slow (> 1 second to run), for values larger
+    # than 23 it was unbearable slow (> 1 minute to run) .
+    #
+    # If this test takes longer than a second to run, then that's a regression!
+    #
+    depth = 25
+    vm = ValueModel.build(key='a', val=1)
+    graph = vm
+    for _ in range(depth):
+        graph = JoinModel.build(ref_left=graph, ref_right=graph)
+    graph = JoinModel.build(ref_left=graph, ref_right=vm)
+
+    # shortest path: one step
+    expected_path = ('ref_right',)
+    result = find_nodes(graph, function=lambda n: n is vm, first_instance=True)
+    assert result == [FoundNode(model=vm, reference_path=expected_path)]
+
+    # longest path: depth + 1 steps
+    expected_path = ('ref_left', ) * (depth + 1)
+    result = find_nodes(graph, function=lambda n: n is vm, first_instance=False)
+    assert result == [FoundNode(model=vm, reference_path=expected_path)]
 
 
 def test_get_all_placeholders():

--- a/bach/tests/unit/sql_models/test_graph_operations.py
+++ b/bach/tests/unit/sql_models/test_graph_operations.py
@@ -255,7 +255,6 @@ def test_find_nodes_long_and_short_path_performance():
     #
     # If this test takes longer than a second to run, then that's a regression!
     #
-    import time; time.sleep(0.1)
     depth = 50
     vm = ValueModel.build(key='a', val=1)
     graph = vm

--- a/bach/tests/unit/sql_models/test_sql_generator.py
+++ b/bach/tests/unit/sql_models/test_sql_generator.py
@@ -241,6 +241,9 @@ def test_code_deduplication_multiple_instances(dialect):
     assert sql.count('one.val + two.val') == 2
 
 
+# be explicit as this is also a performance test: max 1 sec runtime.
+# But conftests.py should already define limit for all unittests.
+@pytest.mark.timeout(1)
 def test_code_deduplication_multiple_reference_many_paths(dialect):
     # Similar to test_code_deduplication_multiple_reference above, but with a generated graph with a lot
     # more possible references paths

--- a/bach/tests/unit/sql_models/test_sql_generator.py
+++ b/bach/tests/unit/sql_models/test_sql_generator.py
@@ -248,9 +248,7 @@ def test_code_deduplication_multiple_reference_many_paths(dialect):
     # The generated graph will have 2^depth possible reference paths. Our initial version produced sql for
     # 2^depth ctes. This test acts as a sort of performance test to see that this both performs well, and
     # that this doesn't generate a big sql output.
-
-    # TODO: optimize the find_nodes() function in this case, and increase depth to 20 again
-    depth = 15
+    depth = 20
     graph = SourceTable.build()
     for _ in range(depth):
         graph = Add.build(


### PR DESCRIPTION
Change: Fixed performance issue in `find_nodes()`:
* Keep track of nodes that have already been discovered
* Don't visit nodes twice, unless the new path is longer than the previously discovered path.

This is a follow-up to https://github.com/objectiv/objectiv-analytics/pull/972/files#r913747845