### PR TITLE
IdentityContext tweaks

### DIFF
--- a/backend/objectiv_backend/schema/schema.py
+++ b/backend/objectiv_backend/schema/schema.py
@@ -295,6 +295,8 @@ class MarketingContext(AbstractGlobalContext):
 class IdentityContext(AbstractGlobalContext):
     """
         A Global Context to track the identity of users across sessions, platforms, devices. Multiple can be present.
+    The `id` field is used to specify the type of identification e.g. backend, md5(email), supplier_cookie.
+    The `value` field should contain the unique identifier within that scope.
 
         Attributes:
         value (str):
@@ -318,7 +320,8 @@ class IdentityContext(AbstractGlobalContext):
 
 class AbstractLocationContext(AbstractContext, ABC):
     """
-        AbstractLocationContext are the abstract parents of all Location Contexts. Location Contexts are meant to describe where an event originated from in the visual UI.
+        AbstractLocationContext are the abstract parents of all Location Contexts.
+    Location Contexts are meant to describe where an event originated from in the visual UI.
 
         Attributes:
         id (str):
@@ -503,7 +506,8 @@ class OverlayContext(AbstractLocationContext):
 
 class ContentContext(AbstractLocationContext):
     """
-        A Location Context that describes a logical section of the UI that contains other Location Contexts. Enabling Data Science to analyze this section specifically.
+        A Location Context that describes a logical section of the UI that contains other Location Contexts.
+    Enabling Data Science to analyze this section specifically.
 
         Attributes:
         id (str):

--- a/backend/objectiv_backend/schema/schema.py
+++ b/backend/objectiv_backend/schema/schema.py
@@ -132,7 +132,7 @@ class HttpContext(AbstractGlobalContext):
 
 class InputValueContext(AbstractGlobalContext):
     """
-        A GlobalContext containing the value of a single input element. Multiple InputValueContexts may be present in Global Contexts at the same time.
+        A GlobalContext containing the value of a single input element. Multiple can be present.
 
         Attributes:
         value (str):
@@ -297,23 +297,23 @@ class IdentityContext(AbstractGlobalContext):
         A Global Context to track the identity of users across sessions, platforms, devices. Multiple can be present.
 
         Attributes:
-        name (str):
-                The identity source, e.g. backend, authentication, email, etc. Possibly with hashing method, e.g. `md5(email)`.
+        value (str):
+                The unique identifier for this user/group/entity within the scope defined by `id`.
         id (str):
                 A unique string identifier to be combined with the Context Type (`_type`)
                 for Context instance uniqueness.
     """
     _type = 'IdentityContext'
 
-    def __init__(self, name: str, id: str, **kwargs: Optional[Any]):
+    def __init__(self, value: str, id: str, **kwargs: Optional[Any]):
         """
-        :param name: 
-            The identity source, e.g. backend, authentication, email, etc. Possibly with hashing method, e.g. `md5(email)`.
+        :param value: 
+            The unique identifier for this user/group/entity within the scope defined by `id`.
         :param id: 
             A unique string identifier to be combined with the Context Type (`_type`)
             for Context instance uniqueness.
         """
-        AbstractGlobalContext.__init__(self, name=name, id=id, **kwargs)
+        AbstractGlobalContext.__init__(self, value=value, id=id, **kwargs)
 
 
 class AbstractLocationContext(AbstractContext, ABC):

--- a/schema/base_schema.json5
+++ b/schema/base_schema.json5
@@ -184,7 +184,7 @@
       }
     },
     "InputValueContext": {
-      "description": "A GlobalContext containing the value of a single input element. Multiple InputValueContexts may be present in Global Contexts at the same time.",
+      "description": "A GlobalContext containing the value of a single input element. Multiple can be present.",
       "parents": ["AbstractGlobalContext"],
       "properties": {
         "value": {
@@ -261,8 +261,8 @@
       "description": "A Global Context to track the identity of users across sessions, platforms, devices. Multiple can be present.",
       "parents": ["AbstractGlobalContext"],
       "properties": {
-        "name": {
-          "description": "The identity source, e.g. backend, authentication, email, etc. Possibly with hashing method, e.g. `md5(email)`.",
+        "value": {
+          "description": "The unique identifier for this user/group/entity within the scope defined by `id`.",
           "type": "string"
         }
       }

--- a/schema/base_schema.json5
+++ b/schema/base_schema.json5
@@ -258,7 +258,9 @@
       }
     },
     "IdentityContext": {
-      "description": "A Global Context to track the identity of users across sessions, platforms, devices. Multiple can be present.",
+      "description": "A Global Context to track the identity of users across sessions, platforms, devices. Multiple can be present.\n\
+        The `id` field is used to specify the type of identification e.g. backend, md5(email), supplier_cookie.\n\
+        The `value` field should contain the unique identifier within that scope.",
       "parents": ["AbstractGlobalContext"],
       "properties": {
         "value": {
@@ -268,7 +270,8 @@
       }
     },
     "AbstractLocationContext": {
-      "description": "AbstractLocationContext are the abstract parents of all Location Contexts. Location Contexts are meant to describe where an event originated from in the visual UI.",
+      "description": "AbstractLocationContext are the abstract parents of all Location Contexts.\n\
+        Location Contexts are meant to describe where an event originated from in the visual UI.",
       "parents": ["AbstractContext"],
       "requiresContext": ["RootLocationContext", "PathContext"]
     },
@@ -312,7 +315,8 @@
       "parents": ["AbstractLocationContext"]
     },
     "ContentContext": {
-      "description": "A Location Context that describes a logical section of the UI that contains other Location Contexts. Enabling Data Science to analyze this section specifically.",
+      "description": "A Location Context that describes a logical section of the UI that contains other Location Contexts. \n\
+        Enabling Data Science to analyze this section specifically.",
       "parents": ["AbstractLocationContext"]
     }
   }

--- a/tracker/core/schema/src/abstracts.d.ts
+++ b/tracker/core/schema/src/abstracts.d.ts
@@ -69,7 +69,8 @@ export abstract class AbstractGlobalContext extends AbstractContext {
 }
 
 /**
- * AbstractLocationContext are the abstract parents of all Location Contexts. Location Contexts are meant to describe where an event originated from in the visual UI.
+ * AbstractLocationContext are the abstract parents of all Location Contexts.
+ * Location Contexts are meant to describe where an event originated from in the visual UI.
  * Inheritance: AbstractLocationContext -> AbstractContext
  */
 export abstract class AbstractLocationContext extends AbstractContext {

--- a/tracker/core/schema/src/global_contexts.d.ts
+++ b/tracker/core/schema/src/global_contexts.d.ts
@@ -58,7 +58,7 @@ export interface HttpContext extends AbstractGlobalContext {
 }
 
 /**
- * A GlobalContext containing the value of a single input element. Multiple InputValueContexts may be present in Global Contexts at the same time.
+ * A GlobalContext containing the value of a single input element. Multiple can be present.
  * Inheritance: InputValueContext -> AbstractGlobalContext -> AbstractContext
  */
 export interface InputValueContext extends AbstractGlobalContext {
@@ -174,7 +174,7 @@ export interface IdentityContext extends AbstractGlobalContext {
   readonly _type: 'IdentityContext';
 
   /**
-   * The identity source, e.g. backend, authentication, email, etc. Possibly with hashing method, e.g. `md5(email)`.
+   * The unique identifier for this user/group/entity within the scope defined by `id`.
    */
-  name: string;
+  value: string;
 }

--- a/tracker/core/schema/src/global_contexts.d.ts
+++ b/tracker/core/schema/src/global_contexts.d.ts
@@ -165,6 +165,8 @@ export interface MarketingContext extends AbstractGlobalContext {
 
 /**
  * A Global Context to track the identity of users across sessions, platforms, devices. Multiple can be present.
+ * The `id` field is used to specify the type of identification e.g. backend, md5(email), supplier_cookie.
+ * The `value` field should contain the unique identifier within that scope.
  * Inheritance: IdentityContext -> AbstractGlobalContext -> AbstractContext
  */
 export interface IdentityContext extends AbstractGlobalContext {

--- a/tracker/core/schema/src/location_contexts.d.ts
+++ b/tracker/core/schema/src/location_contexts.d.ts
@@ -99,7 +99,8 @@ export interface OverlayContext extends AbstractLocationContext {
 }
 
 /**
- * A Location Context that describes a logical section of the UI that contains other Location Contexts. Enabling Data Science to analyze this section specifically.
+ * A Location Context that describes a logical section of the UI that contains other Location Contexts.
+ * Enabling Data Science to analyze this section specifically.
  * Inheritance: ContentContext -> AbstractLocationContext -> AbstractContext
  */
 export interface ContentContext extends AbstractLocationContext {

--- a/tracker/core/tracker/src/ContextFactories.ts
+++ b/tracker/core/tracker/src/ContextFactories.ts
@@ -107,15 +107,15 @@ export const makeHttpContext = (props: {
  * @param {Object} props - factory properties
  * @param {string} props.id - A unique string identifier to be combined with the Context Type (`_type`)
  *         for Context instance uniqueness.
- * @param {string} props.name - The identity source, e.g. backend, authentication, email, etc. Possibly with hashing method, e.g. `md5(email)`.
+ * @param {string} props.value - The unique identifier for this user/group/entity within the scope defined by `id`.
  * @returns {IdentityContext} - IdentityContext: A Global Context to track the identity of users across sessions, platforms, devices. Multiple can be present.
  */
-export const makeIdentityContext = (props: { id: string; name: string }): IdentityContext => ({
+export const makeIdentityContext = (props: { id: string; value: string }): IdentityContext => ({
   __instance_id: generateUUID(),
   __global_context: true,
   _type: GlobalContextName.IdentityContext,
   id: props.id,
-  name: props.name,
+  value: props.value,
 });
 
 /** Creates instance of InputContext
@@ -136,7 +136,7 @@ export const makeInputContext = (props: { id: string }): InputContext => ({
  * @param {string} props.id - A unique string identifier to be combined with the Context Type (`_type`)
  *         for Context instance uniqueness.
  * @param {string} props.value - The value of the input element.
- * @returns {InputValueContext} - InputValueContext: A GlobalContext containing the value of a single input element. Multiple InputValueContexts may be present in Global Contexts at the same time.
+ * @returns {InputValueContext} - InputValueContext: A GlobalContext containing the value of a single input element. Multiple can be present.
  */
 export const makeInputValueContext = (props: { id: string; value: string }): InputValueContext => ({
   __instance_id: generateUUID(),

--- a/tracker/core/tracker/src/ContextFactories.ts
+++ b/tracker/core/tracker/src/ContextFactories.ts
@@ -42,7 +42,8 @@ export const makeApplicationContext = (props: { id: string }): ApplicationContex
  * @param {Object} props - factory properties
  * @param {string} props.id - A unique string identifier to be combined with the Context Type (`_type`)
  *         for Context instance uniqueness.
- * @returns {ContentContext} - ContentContext: A Location Context that describes a logical section of the UI that contains other Location Contexts. Enabling Data Science to analyze this section specifically.
+ * @returns {ContentContext} - ContentContext: A Location Context that describes a logical section of the UI that contains other Location Contexts.
+ * 	Enabling Data Science to analyze this section specifically.
  */
 export const makeContentContext = (props: { id: string }): ContentContext => ({
   __instance_id: generateUUID(),
@@ -109,6 +110,8 @@ export const makeHttpContext = (props: {
  *         for Context instance uniqueness.
  * @param {string} props.value - The unique identifier for this user/group/entity within the scope defined by `id`.
  * @returns {IdentityContext} - IdentityContext: A Global Context to track the identity of users across sessions, platforms, devices. Multiple can be present.
+ * 	The `id` field is used to specify the type of identification e.g. backend, md5(email), supplier_cookie.
+ * 	The `value` field should contain the unique identifier within that scope.
  */
 export const makeIdentityContext = (props: { id: string; value: string }): IdentityContext => ({
   __instance_id: generateUUID(),

--- a/tracker/core/tracker/tests/ContextFactories.test.ts
+++ b/tracker/core/tracker/tests/ContextFactories.test.ts
@@ -182,15 +182,15 @@ describe('Context Factories', () => {
   it(GlobalContextName.IdentityContext, () => {
     expect(
       makeIdentityContext({
-        id: generateUUID(),
-        value: 'backend',
+        id: 'backend',
+        value: generateUUID(),
       })
     ).toStrictEqual({
       __instance_id: matchUUID,
       __global_context: true,
       _type: GlobalContextName.IdentityContext,
-      id: matchUUID,
-      value: 'backend',
+      id: 'backend',
+      value: matchUUID,
     });
   });
 

--- a/tracker/core/tracker/tests/ContextFactories.test.ts
+++ b/tracker/core/tracker/tests/ContextFactories.test.ts
@@ -183,14 +183,14 @@ describe('Context Factories', () => {
     expect(
       makeIdentityContext({
         id: generateUUID(),
-        name: 'backend',
+        value: 'backend',
       })
     ).toStrictEqual({
       __instance_id: matchUUID,
       __global_context: true,
       _type: GlobalContextName.IdentityContext,
       id: matchUUID,
-      name: 'backend',
+      value: 'backend',
     });
   });
 

--- a/tracker/plugins/identity-context/src/IdentityContextPlugin.ts
+++ b/tracker/plugins/identity-context/src/IdentityContextPlugin.ts
@@ -9,7 +9,7 @@ import { ContextsConfig, makeIdentityContext, TrackerPluginInterface } from '@ob
  */
 export type IdentityContextAttributes = {
   id: string;
-  name: string;
+  value: string;
 };
 
 /**

--- a/tracker/plugins/identity-context/tests/IdentityContextPlugin.test.ts
+++ b/tracker/plugins/identity-context/tests/IdentityContextPlugin.test.ts
@@ -16,44 +16,44 @@ describe('IdentityContextPlugin', () => {
 
   it('should allow configuring the IdentityContext attributes by value', async () => {
     const identityContextPlugin = new IdentityContextPlugin({
-      id: 'test',
-      value: 'backend',
+      id: 'backend',
+      value: 'test',
     });
     expect(identityContextPlugin).toBeInstanceOf(IdentityContextPlugin);
     expect(identityContextPlugin.config).toStrictEqual({
-      id: 'test',
-      value: 'backend',
+      id: 'backend',
+      value: 'test',
     });
   });
 
   it('should allow configuring the IdentityContext attributes by value array', async () => {
     const identityContextPlugin = new IdentityContextPlugin([
       {
-        id: 'test 1',
-        value: 'backend',
+        id: 'backend',
+        value: 'test 1',
       },
       {
-        id: 'test 2',
-        value: 'authentication',
+        id: 'authentication',
+        value: 'test 2',
       },
     ]);
     expect(identityContextPlugin).toBeInstanceOf(IdentityContextPlugin);
     expect(identityContextPlugin.config).toStrictEqual([
       {
-        id: 'test 1',
-        value: 'backend',
+        id: 'backend',
+        value: 'test 1',
       },
       {
-        id: 'test 2',
-        value: 'authentication',
+        id: 'authentication',
+        value: 'test 2',
       },
     ]);
   });
 
   it('should allow configuring the IdentityContext attributes by function returning an object', async () => {
     const identityContextPlugin = new IdentityContextPlugin(() => ({
-      id: 'test',
-      value: 'backend',
+      id: 'backend',
+      value: 'test',
     }));
     expect(identityContextPlugin).toBeInstanceOf(IdentityContextPlugin);
     expect(identityContextPlugin.config).toBeInstanceOf(Function);
@@ -62,12 +62,12 @@ describe('IdentityContextPlugin', () => {
   it('should allow configuring the IdentityContext attributes by function returning an array of objects', async () => {
     const identityContextPlugin = new IdentityContextPlugin(() => [
       {
-        id: 'test 1',
-        value: 'backend',
+        id: 'backend',
+        value: 'test 1',
       },
       {
-        id: 'test 2',
-        value: 'authentication',
+        id: 'authentication',
+        value: 'test 2',
       },
     ]);
     expect(identityContextPlugin).toBeInstanceOf(IdentityContextPlugin);
@@ -87,8 +87,8 @@ describe('IdentityContextPlugin', () => {
       applicationId: 'app-id',
       plugins: [
         new IdentityContextPlugin({
-          id: 'test 1',
-          value: 'backend',
+          id: 'backend',
+          value: 'test 1',
         }),
       ],
     });
@@ -98,8 +98,8 @@ describe('IdentityContextPlugin', () => {
       expect.arrayContaining([
         expect.objectContaining({
           _type: GlobalContextName.IdentityContext,
-          id: 'test 1',
-          value: 'backend',
+          id: 'backend',
+          value: 'test 1',
         }),
       ])
     );
@@ -119,12 +119,12 @@ describe('IdentityContextPlugin', () => {
       plugins: [
         new IdentityContextPlugin([
           {
-            id: 'test 1',
-            value: 'backend',
+            id: 'backend',
+            value: 'test 1',
           },
           {
-            id: 'test 2',
-            value: 'authentication',
+            id: 'authentication',
+            value: 'test 2',
           },
         ]),
       ],
@@ -135,13 +135,13 @@ describe('IdentityContextPlugin', () => {
       expect.arrayContaining([
         expect.objectContaining({
           _type: GlobalContextName.IdentityContext,
-          id: 'test 1',
-          value: 'backend',
+          id: 'backend',
+          value: 'test 1',
         }),
         expect.objectContaining({
           _type: GlobalContextName.IdentityContext,
-          id: 'test 2',
-          value: 'authentication',
+          id: 'authentication',
+          value: 'test 2',
         }),
       ])
     );
@@ -160,8 +160,8 @@ describe('IdentityContextPlugin', () => {
       applicationId: 'app-id',
       plugins: [
         new IdentityContextPlugin(() => ({
-          id: 'test 1',
-          value: 'backend',
+          id: 'backend',
+          value: 'test 1',
         })),
       ],
     });
@@ -172,8 +172,8 @@ describe('IdentityContextPlugin', () => {
       expect.arrayContaining([
         expect.objectContaining({
           _type: GlobalContextName.IdentityContext,
-          id: 'test 1',
-          value: 'backend',
+          id: 'backend',
+          value: 'test 1',
         }),
       ])
     );
@@ -193,12 +193,12 @@ describe('IdentityContextPlugin', () => {
       plugins: [
         new IdentityContextPlugin(() => [
           {
-            id: 'test 1',
-            value: 'backend',
+            id: 'backend',
+            value: 'test 1',
           },
           {
-            id: 'test 2',
-            value: 'authentication',
+            id: 'authentication',
+            value: 'test 2',
           },
         ]),
       ],
@@ -210,13 +210,13 @@ describe('IdentityContextPlugin', () => {
       expect.arrayContaining([
         expect.objectContaining({
           _type: GlobalContextName.IdentityContext,
-          id: 'test 1',
-          value: 'backend',
+          id: 'backend',
+          value: 'test 1',
         }),
         expect.objectContaining({
           _type: GlobalContextName.IdentityContext,
-          id: 'test 2',
-          value: 'authentication',
+          id: 'authentication',
+          value: 'test 2',
         }),
       ])
     );
@@ -236,8 +236,8 @@ describe('IdentityContextPlugin', () => {
 
     it('should not log', () => {
       new IdentityContextPlugin({
-        id: 'test',
-        value: 'backend',
+        id: 'backend',
+        value: 'test',
       });
       expect(MockConsoleImplementation.log).not.toHaveBeenCalled();
     });

--- a/tracker/plugins/identity-context/tests/IdentityContextPlugin.test.ts
+++ b/tracker/plugins/identity-context/tests/IdentityContextPlugin.test.ts
@@ -17,12 +17,12 @@ describe('IdentityContextPlugin', () => {
   it('should allow configuring the IdentityContext attributes by value', async () => {
     const identityContextPlugin = new IdentityContextPlugin({
       id: 'test',
-      name: 'backend',
+      value: 'backend',
     });
     expect(identityContextPlugin).toBeInstanceOf(IdentityContextPlugin);
     expect(identityContextPlugin.config).toStrictEqual({
       id: 'test',
-      name: 'backend',
+      value: 'backend',
     });
   });
 
@@ -30,22 +30,22 @@ describe('IdentityContextPlugin', () => {
     const identityContextPlugin = new IdentityContextPlugin([
       {
         id: 'test 1',
-        name: 'backend',
+        value: 'backend',
       },
       {
         id: 'test 2',
-        name: 'authentication',
+        value: 'authentication',
       },
     ]);
     expect(identityContextPlugin).toBeInstanceOf(IdentityContextPlugin);
     expect(identityContextPlugin.config).toStrictEqual([
       {
         id: 'test 1',
-        name: 'backend',
+        value: 'backend',
       },
       {
         id: 'test 2',
-        name: 'authentication',
+        value: 'authentication',
       },
     ]);
   });
@@ -53,7 +53,7 @@ describe('IdentityContextPlugin', () => {
   it('should allow configuring the IdentityContext attributes by function returning an object', async () => {
     const identityContextPlugin = new IdentityContextPlugin(() => ({
       id: 'test',
-      name: 'backend',
+      value: 'backend',
     }));
     expect(identityContextPlugin).toBeInstanceOf(IdentityContextPlugin);
     expect(identityContextPlugin.config).toBeInstanceOf(Function);
@@ -63,11 +63,11 @@ describe('IdentityContextPlugin', () => {
     const identityContextPlugin = new IdentityContextPlugin(() => [
       {
         id: 'test 1',
-        name: 'backend',
+        value: 'backend',
       },
       {
         id: 'test 2',
-        name: 'authentication',
+        value: 'authentication',
       },
     ]);
     expect(identityContextPlugin).toBeInstanceOf(IdentityContextPlugin);
@@ -88,7 +88,7 @@ describe('IdentityContextPlugin', () => {
       plugins: [
         new IdentityContextPlugin({
           id: 'test 1',
-          name: 'backend',
+          value: 'backend',
         }),
       ],
     });
@@ -99,7 +99,7 @@ describe('IdentityContextPlugin', () => {
         expect.objectContaining({
           _type: GlobalContextName.IdentityContext,
           id: 'test 1',
-          name: 'backend',
+          value: 'backend',
         }),
       ])
     );
@@ -120,11 +120,11 @@ describe('IdentityContextPlugin', () => {
         new IdentityContextPlugin([
           {
             id: 'test 1',
-            name: 'backend',
+            value: 'backend',
           },
           {
             id: 'test 2',
-            name: 'authentication',
+            value: 'authentication',
           },
         ]),
       ],
@@ -136,12 +136,12 @@ describe('IdentityContextPlugin', () => {
         expect.objectContaining({
           _type: GlobalContextName.IdentityContext,
           id: 'test 1',
-          name: 'backend',
+          value: 'backend',
         }),
         expect.objectContaining({
           _type: GlobalContextName.IdentityContext,
           id: 'test 2',
-          name: 'authentication',
+          value: 'authentication',
         }),
       ])
     );
@@ -161,7 +161,7 @@ describe('IdentityContextPlugin', () => {
       plugins: [
         new IdentityContextPlugin(() => ({
           id: 'test 1',
-          name: 'backend',
+          value: 'backend',
         })),
       ],
     });
@@ -173,7 +173,7 @@ describe('IdentityContextPlugin', () => {
         expect.objectContaining({
           _type: GlobalContextName.IdentityContext,
           id: 'test 1',
-          name: 'backend',
+          value: 'backend',
         }),
       ])
     );
@@ -194,11 +194,11 @@ describe('IdentityContextPlugin', () => {
         new IdentityContextPlugin(() => [
           {
             id: 'test 1',
-            name: 'backend',
+            value: 'backend',
           },
           {
             id: 'test 2',
-            name: 'authentication',
+            value: 'authentication',
           },
         ]),
       ],
@@ -211,12 +211,12 @@ describe('IdentityContextPlugin', () => {
         expect.objectContaining({
           _type: GlobalContextName.IdentityContext,
           id: 'test 1',
-          name: 'backend',
+          value: 'backend',
         }),
         expect.objectContaining({
           _type: GlobalContextName.IdentityContext,
           id: 'test 2',
-          name: 'authentication',
+          value: 'authentication',
         }),
       ])
     );
@@ -237,7 +237,7 @@ describe('IdentityContextPlugin', () => {
     it('should not log', () => {
       new IdentityContextPlugin({
         id: 'test',
-        name: 'backend',
+        value: 'backend',
       });
       expect(MockConsoleImplementation.log).not.toHaveBeenCalled();
     });

--- a/tracker/trackers/react/tests/ReactTracker.test.ts
+++ b/tracker/trackers/react/tests/ReactTracker.test.ts
@@ -2,7 +2,7 @@
  * Copyright 2021-2022 Objectiv B.V.
  */
 
-import { IdentityContextPlugin } from '@objectiv/plugin-identity-context';
+import { IdentityContextAttributes, IdentityContextPlugin } from '@objectiv/plugin-identity-context';
 import { RootLocationContextFromURLPlugin } from '@objectiv/plugin-root-location-context-from-url';
 import { AbstractGlobalContext } from '@objectiv/schema';
 import { expectToThrow, MockConsoleImplementation } from '@objectiv/testing-tools';
@@ -225,9 +225,9 @@ describe('ReactTracker', () => {
       /**
        * Mocked identity metadata we will use to enrich the event, via IdentityContext
        */
-      const identityMetadata = {
+      const identityMetadata: IdentityContextAttributes = {
         id: '123abc',
-        name: 'authentication',
+        value: 'authentication',
       };
 
       /**

--- a/tracker/trackers/react/tests/ReactTracker.test.ts
+++ b/tracker/trackers/react/tests/ReactTracker.test.ts
@@ -226,8 +226,8 @@ describe('ReactTracker', () => {
        * Mocked identity metadata we will use to enrich the event, via IdentityContext
        */
       const identityMetadata: IdentityContextAttributes = {
-        id: '123abc',
-        value: 'authentication',
+        id: 'authentication',
+        value: '123abc',
       };
 
       /**


### PR DESCRIPTION
Some minor refinement to IdentityContext. 

The name attribute has been renamed to value, for consistency with the other contexts. Thus the `id` attribute now determines the scope and `value` is where developers will actually set their identity hash.

Factories and classes have been regenerated accordingly. Tests have been updated to reflect this change as well.