### PR TITLE
Nextjs compatible core

### DIFF
--- a/tracker/core/developer-tools/package.json
+++ b/tracker/core/developer-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/developer-tools",
-  "version": "0.0.22-0",
+  "version": "0.0.22-1",
   "description": "Validation and logging utilities to help pinpoint instrumentation issues while developing",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -55,8 +55,8 @@
     "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
-    "@objectiv/testing-tools": "^0.0.22-0",
-    "@objectiv/tracker-core": "^0.0.22-0",
+    "@objectiv/testing-tools": "^0.0.22-1",
+    "@objectiv/tracker-core": "^0.0.22-1",
     "@types/jest": "^27.4.1",
     "jest": "^27.5.1",
     "jest-standard-reporter": "^2.0.0",
@@ -68,7 +68,7 @@
     "typescript": "^4.6.2"
   },
   "peerDependencies": {
-    "@objectiv/schema": "^0.0.22-0",
-    "@objectiv/tracker-core": "^0.0.22-0"
+    "@objectiv/schema": "^0.0.22-1",
+    "@objectiv/tracker-core": "^0.0.22-1"
   }
 }

--- a/tracker/core/react/package.json
+++ b/tracker/core/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/tracker-react-core",
-  "version": "0.0.22-0",
+  "version": "0.0.22-1",
   "description": "Objectiv tracker core module for React trackers",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -51,8 +51,8 @@
     "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
-    "@objectiv/developer-tools": "^0.0.22-0",
-    "@objectiv/testing-tools": "^0.0.22-0",
+    "@objectiv/developer-tools": "^0.0.22-1",
+    "@objectiv/testing-tools": "^0.0.22-1",
     "@testing-library/react": "^12.1.4",
     "@testing-library/react-hooks": "^7.0.2",
     "@types/jest": "^27.4.1",
@@ -67,8 +67,8 @@
     "typescript": "^4.6.2"
   },
   "dependencies": {
-    "@objectiv/schema": "^0.0.22-0",
-    "@objectiv/tracker-core": "~0.0.22-0",
+    "@objectiv/schema": "^0.0.22-1",
+    "@objectiv/tracker-core": "~0.0.22-1",
     "fast-deep-equal": "^3.1.3"
   },
   "peerDependencies": {

--- a/tracker/core/react/tests/ObjectivProvider.test.tsx
+++ b/tracker/core/react/tests/ObjectivProvider.test.tsx
@@ -3,7 +3,7 @@
  */
 
 import '@objectiv/developer-tools';
-import { matchUUID, MockConsoleImplementation } from '@objectiv/testing-tools';
+import { MockConsoleImplementation } from '@objectiv/testing-tools';
 import {
   GlobalContextName,
   LocationContextName,
@@ -74,16 +74,6 @@ describe('ObjectivProvider', () => {
                 eventMatches: expect.any(Function),
               },
             ],
-          },
-          {
-            pluginName: 'ApplicationContextPlugin',
-            initialized: true,
-            applicationContext: {
-              __instance_id: matchUUID,
-              __global_context: true,
-              _type: GlobalContextName.ApplicationContext,
-              id: 'app-id',
-            },
           },
         ],
       }),

--- a/tracker/core/react/tests/TrackerProvider.test.tsx
+++ b/tracker/core/react/tests/TrackerProvider.test.tsx
@@ -2,7 +2,7 @@
  * Copyright 2021-2022 Objectiv B.V.
  */
 
-import { matchUUID, MockConsoleImplementation } from '@objectiv/testing-tools';
+import { MockConsoleImplementation } from '@objectiv/testing-tools';
 import { GlobalContextName, LocationContextName, Tracker, TrackerPlatform } from '@objectiv/tracker-core';
 import { render } from '@testing-library/react';
 import React from 'react';
@@ -65,16 +65,6 @@ describe('TrackerProvider', () => {
                 eventMatches: expect.any(Function),
               },
             ],
-          },
-          {
-            pluginName: 'ApplicationContextPlugin',
-            initialized: true,
-            applicationContext: {
-              __instance_id: matchUUID,
-              __global_context: true,
-              _type: GlobalContextName.ApplicationContext,
-              id: 'app-id',
-            },
           },
         ],
       }),

--- a/tracker/core/react/tests/TrackingContextProvider.test.tsx
+++ b/tracker/core/react/tests/TrackingContextProvider.test.tsx
@@ -2,7 +2,7 @@
  * Copyright 2021-2022 Objectiv B.V.
  */
 
-import { expectToThrow, matchUUID, MockConsoleImplementation } from '@objectiv/testing-tools';
+import { expectToThrow, MockConsoleImplementation } from '@objectiv/testing-tools';
 import {
   GlobalContextName,
   LocationContextName,
@@ -73,16 +73,6 @@ describe('TrackingContextProvider', () => {
                 eventMatches: expect.any(Function),
               },
             ],
-          },
-          {
-            pluginName: 'ApplicationContextPlugin',
-            initialized: true,
-            applicationContext: {
-              __instance_id: matchUUID,
-              __global_context: true,
-              _type: GlobalContextName.ApplicationContext,
-              id: 'app-id',
-            },
           },
         ],
       }),

--- a/tracker/core/schema/package.json
+++ b/tracker/core/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/schema",
-  "version": "0.0.22-0",
+  "version": "0.0.22-1",
   "description": "Objectiv TypeScript implementation of the open analytics taxonomy",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",

--- a/tracker/core/testing-tools/package.json
+++ b/tracker/core/testing-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/testing-tools",
-  "version": "0.0.22-0",
+  "version": "0.0.22-1",
   "private": true,
   "license": "Apache-2.0",
   "description": "Mocks and other testing utilities shared across Objectiv Trackers",
@@ -14,7 +14,7 @@
     "check:dependencies": "npx depcheck"
   },
   "devDependencies": {
-    "@objectiv/tracker-core": "^0.0.22-0",
+    "@objectiv/tracker-core": "^0.0.22-1",
     "prettier": "^2.5.1",
     "typescript": "^4.6.2"
   }

--- a/tracker/core/tracker/jest.config.js
+++ b/tracker/core/tracker/jest.config.js
@@ -12,6 +12,5 @@ module.exports = {
     '@objectiv/tracker-core': '<rootDir>../../core/tracker/src',
     '@objectiv/developer-tools': '<rootDir>../../core/developer-tools/src',
     '@objectiv/testing-tools': '<rootDir>../../core/testing-tools/src',
-    '@objectiv/plugin-(.*)': '<rootDir>/../../plugins/$1/src',
   },
 };

--- a/tracker/core/tracker/package.json
+++ b/tracker/core/tracker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/tracker-core",
-  "version": "0.0.22-0",
+  "version": "0.0.22-1",
   "description": "Core functionality for Objectiv JavaScript trackers",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -50,7 +50,7 @@
     "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
-    "@objectiv/testing-tools": "^0.0.22-0",
+    "@objectiv/testing-tools": "^0.0.22-1",
     "@types/jest": "^27.4.1",
     "@types/uuid": "^8.3.4",
     "jest": "^27.5.1",
@@ -62,9 +62,8 @@
     "typescript": "^4.6.2"
   },
   "dependencies": {
-    "@objectiv/developer-tools": "^0.0.22-0",
-    "@objectiv/plugin-application-context": "^0.0.22-0",
-    "@objectiv/schema": "^0.0.22-0",
+    "@objectiv/developer-tools": "^0.0.22-1",
+    "@objectiv/schema": "^0.0.22-1",
     "uuid": "^8.3.2"
   }
 }

--- a/tracker/core/tracker/src/Tracker.ts
+++ b/tracker/core/tracker/src/Tracker.ts
@@ -2,7 +2,6 @@
  * Copyright 2021-2022 Objectiv B.V.
  */
 
-import { ApplicationContextPlugin } from '@objectiv/plugin-application-context';
 import { AbstractGlobalContext, AbstractLocationContext, Contexts } from '@objectiv/schema';
 import { ContextsConfig } from './Context';
 import { waitForPromise } from './helpers';
@@ -62,27 +61,16 @@ export type TrackerConfig = ContextsConfig & {
    * Optional. Determines if the TrackerInstance.trackEvent will process Events or not.
    */
   active?: boolean;
-
-  /**
-   * Optional. Whether to track ApplicationContext automatically. Enabled by default.
-   */
-  trackApplicationContext?: boolean;
 };
 
 /**
  * The default list of Plugins of Core Tracker
  */
-export const makeCoreTrackerDefaultPluginsList = (trackerConfig: TrackerConfig) => {
-  const { trackApplicationContext = true } = trackerConfig;
-
+export const makeCoreTrackerDefaultPluginsList = () => {
   const plugins: TrackerPluginInterface[] = [];
 
   if (globalThis.objectiv.devTools) {
     plugins.push(globalThis.objectiv.devTools.OpenTaxonomyValidationPlugin);
-  }
-
-  if (trackApplicationContext) {
-    plugins.push(new ApplicationContextPlugin());
   }
 
   return plugins;
@@ -171,7 +159,7 @@ export class Tracker implements TrackerInterface {
     if (isPluginsArray(trackerConfig.plugins) || trackerConfig.plugins === undefined) {
       this.plugins = new TrackerPlugins({
         tracker: this,
-        plugins: [...makeCoreTrackerDefaultPluginsList(trackerConfig), ...(trackerConfig.plugins ?? [])],
+        plugins: [...makeCoreTrackerDefaultPluginsList(), ...(trackerConfig.plugins ?? [])],
       });
     } else {
       this.plugins = trackerConfig.plugins;

--- a/tracker/core/tracker/tests/Tracker.test.ts
+++ b/tracker/core/tracker/tests/Tracker.test.ts
@@ -66,16 +66,6 @@ describe('Tracker', () => {
           },
         ],
       },
-      {
-        pluginName: 'ApplicationContextPlugin',
-        initialized: true,
-        applicationContext: {
-          __instance_id: matchUUID,
-          __global_context: true,
-          _type: GlobalContextName.ApplicationContext,
-          id: 'app-id',
-        },
-      },
     ]);
     expect(testTracker.applicationId).toBe('app-id');
     expect(testTracker.location_stack).toStrictEqual([]);
@@ -89,67 +79,6 @@ describe('Tracker', () => {
     const testTracker = new Tracker({
       applicationId: 'app-id',
       transport: testTransport,
-    });
-    await expect(testTracker.waitForQueue()).resolves.toBe(true);
-    expect(testTracker).toBeInstanceOf(Tracker);
-    expect(testTracker.transport).toStrictEqual(testTransport);
-    expect(testTracker.plugins.plugins).toEqual([
-      {
-        pluginName: 'OpenTaxonomyValidationPlugin',
-        initialized: true,
-        validationRules: [
-          {
-            validationRuleName: 'GlobalContextValidationRule',
-            logPrefix: 'OpenTaxonomyValidationPlugin',
-            contextName: GlobalContextName.ApplicationContext,
-            platform: 'CORE',
-            once: true,
-            validate: expect.any(Function),
-          },
-          {
-            validationRuleName: 'LocationContextValidationRule',
-            logPrefix: 'OpenTaxonomyValidationPlugin',
-            contextName: LocationContextName.RootLocationContext,
-            platform: 'CORE',
-            position: 0,
-            once: true,
-            validate: expect.any(Function),
-            eventMatches: expect.any(Function),
-          },
-          {
-            validationRuleName: 'GlobalContextValidationRule',
-            logPrefix: 'OpenTaxonomyValidationPlugin',
-            contextName: GlobalContextName.PathContext,
-            platform: 'CORE',
-            once: true,
-            validate: expect.any(Function),
-            eventMatches: expect.any(Function),
-          },
-        ],
-      },
-      {
-        pluginName: 'ApplicationContextPlugin',
-        initialized: true,
-        applicationContext: {
-          __instance_id: matchUUID,
-          __global_context: true,
-          _type: GlobalContextName.ApplicationContext,
-          id: 'app-id',
-        },
-      },
-    ]);
-    expect(testTracker.location_stack).toStrictEqual([]);
-    expect(testTracker.global_contexts).toStrictEqual([]);
-    expect(MockConsoleImplementation.log).toHaveBeenCalledWith('Application ID: app-id');
-  });
-
-  it('should instantiate without the ApplicationContext plugin', async () => {
-    expect(MockConsoleImplementation.log).not.toHaveBeenCalled();
-    const testTransport = new LogTransport();
-    const testTracker = new Tracker({
-      applicationId: 'app-id',
-      transport: testTransport,
-      trackApplicationContext: false,
     });
     await expect(testTracker.waitForQueue()).resolves.toBe(true);
     expect(testTracker).toBeInstanceOf(Tracker);
@@ -341,7 +270,6 @@ describe('Tracker', () => {
         { __instance_id: matchUUID, __global_context: true, _type: 'global', id: 'X' },
         { __instance_id: matchUUID, __global_context: true, _type: 'global', id: 'Y' },
         { __instance_id: matchUUID, __global_context: true, _type: 'global', id: 'Z' },
-        { __instance_id: matchUUID, __global_context: true, _type: GlobalContextName.ApplicationContext, id: 'app-id' },
       ]);
     });
 
@@ -427,7 +355,6 @@ describe('Tracker', () => {
       const testTracker = new Tracker({
         applicationId: 'app-id',
         transport: testTransport,
-        trackApplicationContext: false,
       });
       testTracker.plugins.plugins = [];
       jest.resetAllMocks();
@@ -681,18 +608,6 @@ describe('Without developer tools', () => {
     await expect(testTracker.waitForQueue()).resolves.toBe(true);
     expect(testTracker).toBeInstanceOf(Tracker);
     expect(testTracker.transport).toStrictEqual(testTransport);
-    expect(testTracker.plugins.plugins).toEqual([
-      expect.objectContaining({
-        pluginName: 'ApplicationContextPlugin',
-        initialized: true,
-        applicationContext: {
-          __instance_id: matchUUID,
-          __global_context: true,
-          _type: GlobalContextName.ApplicationContext,
-          id: 'app-id',
-        },
-      }),
-    ]);
     expect(testTracker.location_stack).toStrictEqual([]);
     expect(testTracker.global_contexts).toStrictEqual([]);
     expect(MockConsoleImplementation.log).not.toHaveBeenCalled();

--- a/tracker/core/utilities/package.json
+++ b/tracker/core/utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/utilities",
-  "version": "0.0.22-0",
+  "version": "0.0.22-1",
   "private": true,
   "license": "Apache-2.0",
   "description": "Objectiv Core Utilities",

--- a/tracker/plugins/application-context/package.json
+++ b/tracker/plugins/application-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/plugin-application-context",
-  "version": "0.0.22-0",
+  "version": "0.0.22-1",
   "description": "Plugin for Objectiv trackers to automatically generate and attach ApplicationContext to all Events",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -52,8 +52,8 @@
     "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
-    "@objectiv/developer-tools": "^0.0.22-0",
-    "@objectiv/testing-tools": "^0.0.22-0",
+    "@objectiv/developer-tools": "^0.0.22-1",
+    "@objectiv/testing-tools": "^0.0.22-1",
     "@types/jest": "^27.4.1",
     "jest": "^27.5.1",
     "jest-standard-reporter": "^2.0.0",
@@ -63,6 +63,6 @@
     "typescript": "^4.6.2"
   },
   "peerDependencies": {
-    "@objectiv/tracker-core": "^0.0.22-0"
+    "@objectiv/tracker-core": "^0.0.22-1"
   }
 }

--- a/tracker/plugins/http-context/package.json
+++ b/tracker/plugins/http-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/plugin-http-context",
-  "version": "0.0.22-0",
+  "version": "0.0.22-1",
   "description": "Plugin for Objectiv trackers to automatically generate and attach HttpContext from document and navigator APIs",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -54,8 +54,8 @@
     "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
-    "@objectiv/developer-tools": "^0.0.22-0",
-    "@objectiv/testing-tools": "^0.0.22-0",
+    "@objectiv/developer-tools": "^0.0.22-1",
+    "@objectiv/testing-tools": "^0.0.22-1",
     "@types/jest": "^27.4.1",
     "jest": "^27.5.1",
     "jest-extended": "^2.0.0",
@@ -66,6 +66,6 @@
     "typescript": "^4.6.2"
   },
   "peerDependencies": {
-    "@objectiv/tracker-core": "^0.0.22-0"
+    "@objectiv/tracker-core": "^0.0.22-1"
   }
 }

--- a/tracker/plugins/identity-context/package.json
+++ b/tracker/plugins/identity-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/plugin-identity-context",
-  "version": "0.0.22-0",
+  "version": "0.0.22-1",
   "description": "Plugin for Objectiv trackers to generate IdentityContext instances",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -53,8 +53,8 @@
     "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
-    "@objectiv/developer-tools": "^0.0.22-0",
-    "@objectiv/testing-tools": "^0.0.22-0",
+    "@objectiv/developer-tools": "^0.0.22-1",
+    "@objectiv/testing-tools": "^0.0.22-1",
     "@types/jest": "^27.4.1",
     "jest": "^27.5.1",
     "jest-standard-reporter": "^2.0.0",
@@ -64,6 +64,6 @@
     "typescript": "^4.6.2"
   },
   "peerDependencies": {
-    "@objectiv/tracker-core": "^0.0.22-0"
+    "@objectiv/tracker-core": "^0.0.22-1"
   }
 }

--- a/tracker/plugins/locale-context/package.json
+++ b/tracker/plugins/locale-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/plugin-locale-context",
-  "version": "0.0.22-0",
+  "version": "0.0.22-1",
   "description": "Plugin for Objectiv trackers to automatically generate and attach LocaleContext",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -52,8 +52,8 @@
     "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
-    "@objectiv/developer-tools": "^0.0.22-0",
-    "@objectiv/testing-tools": "^0.0.22-0",
+    "@objectiv/developer-tools": "^0.0.22-1",
+    "@objectiv/testing-tools": "^0.0.22-1",
     "@types/jest": "^27.4.1",
     "jest": "^27.5.1",
     "jest-extended": "^2.0.0",
@@ -64,6 +64,6 @@
     "typescript": "^4.6.2"
   },
   "peerDependencies": {
-    "@objectiv/tracker-core": "^0.0.22-0"
+    "@objectiv/tracker-core": "^0.0.22-1"
   }
 }

--- a/tracker/plugins/path-context-from-url/package.json
+++ b/tracker/plugins/path-context-from-url/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/plugin-path-context-from-url",
-  "version": "0.0.22-0",
+  "version": "0.0.22-1",
   "description": "Plugin for Objectiv trackers to automatically generate and attach PathContext from URLs",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -52,8 +52,8 @@
     "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
-    "@objectiv/developer-tools": "^0.0.22-0",
-    "@objectiv/testing-tools": "^0.0.22-0",
+    "@objectiv/developer-tools": "^0.0.22-1",
+    "@objectiv/testing-tools": "^0.0.22-1",
     "@types/jest": "^27.4.1",
     "jest": "^27.5.1",
     "jest-extended": "^2.0.0",
@@ -64,6 +64,6 @@
     "typescript": "^4.6.2"
   },
   "peerDependencies": {
-    "@objectiv/tracker-core": "^0.0.22-0"
+    "@objectiv/tracker-core": "^0.0.22-1"
   }
 }

--- a/tracker/plugins/react-navigation/package.json
+++ b/tracker/plugins/react-navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/plugin-react-navigation",
-  "version": "0.0.22-0",
+  "version": "0.0.22-1",
   "description": "Automatically tracked React Navigation 6+ Components, listeners and state for Objectiv React Native Tracker",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -53,12 +53,12 @@
     "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "dependencies": {
-    "@objectiv/tracker-react-core": "^0.0.22-0",
-    "@objectiv/tracker-react-native": "^0.0.22-0"
+    "@objectiv/tracker-react-core": "^0.0.22-1",
+    "@objectiv/tracker-react-native": "^0.0.22-1"
   },
   "devDependencies": {
-    "@objectiv/developer-tools": "^0.0.22-0",
-    "@objectiv/testing-tools": "^0.0.22-0",
+    "@objectiv/developer-tools": "^0.0.22-1",
+    "@objectiv/testing-tools": "^0.0.22-1",
     "@react-navigation/bottom-tabs": "^6.2.0",
     "@react-navigation/core": "^6.1.1",
     "@react-navigation/native": "^6.0.8",

--- a/tracker/plugins/react-router-tracked-components/package.json
+++ b/tracker/plugins/react-router-tracked-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/plugin-react-router-tracked-components",
-  "version": "0.0.22-0",
+  "version": "0.0.22-1",
   "description": "React Router 6 automatically tracked Link and NavLink Components for Objectiv React Tracker",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -54,12 +54,12 @@
     "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "dependencies": {
-    "@objectiv/tracker-core": "^0.0.22-0",
-    "@objectiv/tracker-react": "^0.0.22-0"
+    "@objectiv/tracker-core": "^0.0.22-1",
+    "@objectiv/tracker-react": "^0.0.22-1"
   },
   "devDependencies": {
-    "@objectiv/developer-tools": "^0.0.22-0",
-    "@objectiv/testing-tools": "^0.0.22-0",
+    "@objectiv/developer-tools": "^0.0.22-1",
+    "@objectiv/testing-tools": "^0.0.22-1",
     "@testing-library/react": "^12.1.4",
     "@types/jest": "^27.4.1",
     "jest": "^27.5.1",

--- a/tracker/plugins/root-location-context-from-url/package.json
+++ b/tracker/plugins/root-location-context-from-url/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/plugin-root-location-context-from-url",
-  "version": "0.0.22-0",
+  "version": "0.0.22-1",
   "description": "Plugin for Objectiv trackers to automatically generate and attach RootLocationContext from URLs",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -53,8 +53,8 @@
     "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
-    "@objectiv/developer-tools": "^0.0.22-0",
-    "@objectiv/testing-tools": "^0.0.22-0",
+    "@objectiv/developer-tools": "^0.0.22-1",
+    "@objectiv/testing-tools": "^0.0.22-1",
     "@types/jest": "^27.4.1",
     "jest": "^27.5.1",
     "jest-extended": "^2.0.0",
@@ -65,6 +65,6 @@
     "typescript": "^4.6.2"
   },
   "peerDependencies": {
-    "@objectiv/tracker-core": "^0.0.22-0"
+    "@objectiv/tracker-core": "^0.0.22-1"
   }
 }

--- a/tracker/queues/local-storage/package.json
+++ b/tracker/queues/local-storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/queue-local-storage",
-  "version": "0.0.22-0",
+  "version": "0.0.22-1",
   "description": "A TrackerQueueStore based on localStorage API",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -51,8 +51,8 @@
     "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
-    "@objectiv/developer-tools": "^0.0.22-0",
-    "@objectiv/testing-tools": "^0.0.22-0",
+    "@objectiv/developer-tools": "^0.0.22-1",
+    "@objectiv/testing-tools": "^0.0.22-1",
     "@types/jest": "^27.4.1",
     "jest": "^27.5.1",
     "jest-standard-reporter": "^2.0.0",
@@ -62,6 +62,6 @@
     "typescript": "^4.6.2"
   },
   "dependencies": {
-    "@objectiv/tracker-core": "~0.0.22-0"
+    "@objectiv/tracker-core": "~0.0.22-1"
   }
 }

--- a/tracker/trackers/angular/package.json
+++ b/tracker/trackers/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/tracker-angular",
-  "version": "0.0.22-0",
+  "version": "0.0.22-1",
   "description": "Objectiv Angular framework analytics tracker for the open analytics taxonomy",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -38,13 +38,13 @@
   "peerDependencies": {
     "@angular/common": "^9.0.0",
     "@angular/core": "^9.0.0",
-    "@objectiv/tracker-browser": "^0.0.22-0"
+    "@objectiv/tracker-browser": "^0.0.22-1"
   },
   "devDependencies": {
     "@angular/compiler": "~9.1.13",
     "@angular/compiler-cli": "~9.1.13",
     "@angular/core": "~9.1.13",
-    "@objectiv/tracker-browser": "^0.0.22-0",
+    "@objectiv/tracker-browser": "^0.0.22-1",
     "ng-packagr": "^9.0.0",
     "prettier": "^2.5.1",
     "rxjs": "~6.5.4",

--- a/tracker/trackers/browser/package.json
+++ b/tracker/trackers/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/tracker-browser",
-  "version": "0.0.22-0",
+  "version": "0.0.22-1",
   "description": "Objectiv Web application analytics tracker for the open analytics taxonomy",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -50,8 +50,8 @@
     "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
-    "@objectiv/developer-tools": "^0.0.22-0",
-    "@objectiv/testing-tools": "^0.0.22-0",
+    "@objectiv/developer-tools": "^0.0.22-1",
+    "@objectiv/testing-tools": "^0.0.22-1",
     "@types/jest": "^27.4.1",
     "jest": "^27.5.1",
     "jest-fetch-mock": "^3.0.3",
@@ -63,14 +63,15 @@
     "typescript": "^4.6.2"
   },
   "dependencies": {
-    "@objectiv/plugin-http-context": "^0.0.22-0",
-    "@objectiv/plugin-path-context-from-url": "^0.0.22-0",
-    "@objectiv/plugin-root-location-context-from-url": "^0.0.22-0",
-    "@objectiv/queue-local-storage": "^0.0.22-0",
-    "@objectiv/schema": "^0.0.22-0",
-    "@objectiv/tracker-core": "^0.0.22-0",
-    "@objectiv/transport-debug": "^0.0.22-0",
-    "@objectiv/transport-fetch": "^0.0.22-0",
-    "@objectiv/transport-xhr": "^0.0.22-0"
+    "@objectiv/plugin-application-context": "^0.0.22-1",
+    "@objectiv/plugin-http-context": "^0.0.22-1",
+    "@objectiv/plugin-path-context-from-url": "^0.0.22-1",
+    "@objectiv/plugin-root-location-context-from-url": "^0.0.22-1",
+    "@objectiv/queue-local-storage": "^0.0.22-1",
+    "@objectiv/schema": "^0.0.22-1",
+    "@objectiv/tracker-core": "^0.0.22-1",
+    "@objectiv/transport-debug": "^0.0.22-1",
+    "@objectiv/transport-fetch": "^0.0.22-1",
+    "@objectiv/transport-xhr": "^0.0.22-1"
   }
 }

--- a/tracker/trackers/browser/src/common/factories/makeBrowserTrackerDefaultPluginsList.ts
+++ b/tracker/trackers/browser/src/common/factories/makeBrowserTrackerDefaultPluginsList.ts
@@ -2,6 +2,7 @@
  * Copyright 2021-2022 Objectiv B.V.
  */
 
+import { ApplicationContextPlugin } from '@objectiv/plugin-application-context';
 import { HttpContextPlugin } from '@objectiv/plugin-http-context';
 import { PathContextFromURLPlugin } from '@objectiv/plugin-path-context-from-url';
 import { RootLocationContextFromURLPlugin } from '@objectiv/plugin-root-location-context-from-url';
@@ -13,12 +14,17 @@ import { BrowserTrackerConfig } from '../../definitions/BrowserTrackerConfig';
  */
 export const makeBrowserTrackerDefaultPluginsList = (trackerConfig: BrowserTrackerConfig) => {
   const {
+    trackApplicationContext = true,
     trackHttpContext = true,
     trackPathContextFromURL = true,
     trackRootLocationContextFromURL = true,
   } = trackerConfig;
 
   const plugins: TrackerPluginInterface[] = [];
+
+  if (trackApplicationContext) {
+    plugins.push(new ApplicationContextPlugin());
+  }
 
   if (trackHttpContext) {
     plugins.push(new HttpContextPlugin());

--- a/tracker/trackers/browser/src/definitions/BrowserTrackerConfig.ts
+++ b/tracker/trackers/browser/src/definitions/BrowserTrackerConfig.ts
@@ -21,6 +21,11 @@ export type BrowserTrackerConfig = Omit<TrackerConfig, 'platform'> & {
   trackApplicationLoadedEvent?: boolean;
 
   /**
+   * Optional. Whether to track ApplicationContext automatically. Enabled by default.
+   */
+  trackApplicationContext?: boolean;
+
+  /**
    * Optional. Whether to automatically create HttpContext based on Document and Navigation APIs. Enabled by default.
    */
   trackHttpContext?: boolean;

--- a/tracker/trackers/react-native/package.json
+++ b/tracker/trackers/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/tracker-react-native",
-  "version": "0.0.22-0",
+  "version": "0.0.22-1",
   "description": "Objectiv React Native application analytics tracker the open analytics taxonomy",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -50,9 +50,9 @@
     "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
-    "@objectiv/developer-tools": "^0.0.22-0",
-    "@objectiv/testing-tools": "^0.0.22-0",
-    "@objectiv/transport-debug": "^0.0.22-0",
+    "@objectiv/developer-tools": "^0.0.22-1",
+    "@objectiv/testing-tools": "^0.0.22-1",
+    "@objectiv/transport-debug": "^0.0.22-1",
     "@testing-library/react-native": "^9.0.0",
     "@types/react-native": "^0.67.2",
     "jest": "^27.5.1",
@@ -65,9 +65,10 @@
     "typescript": "^4.6.2"
   },
   "dependencies": {
-    "@objectiv/tracker-core": "~0.0.22-0",
-    "@objectiv/tracker-react-core": "~0.0.22-0",
-    "@objectiv/transport-fetch": "^0.0.22-0",
+    "@objectiv/plugin-application-context": "^0.0.22-1",
+    "@objectiv/tracker-core": "~0.0.22-1",
+    "@objectiv/tracker-react-core": "~0.0.22-1",
+    "@objectiv/transport-fetch": "^0.0.22-1",
     "react-native-get-random-values": "^1.7.2"
   },
   "peerDependencies": {

--- a/tracker/trackers/react-native/src/ReactNativeTracker.ts
+++ b/tracker/trackers/react-native/src/ReactNativeTracker.ts
@@ -16,6 +16,11 @@ export type ReactNativeTrackerConfig = Omit<TrackerConfig, 'platform'> & {
    * The collector endpoint URL.
    */
   endpoint?: string;
+
+  /**
+   * Optional. Whether to track ApplicationContext automatically. Enabled by default.
+   */
+  trackApplicationContext?: boolean;
 };
 
 /**
@@ -74,7 +79,7 @@ export class ReactNativeTracker extends Tracker {
 
     // Configure to use provided `plugins` or automatically create a Plugins instance with some sensible web defaults
     if (isPluginsArray(trackerConfig.plugins) || trackerConfig.plugins === undefined) {
-      config.plugins = [...makeReactNativeTrackerDefaultPluginsList(), ...(trackerConfig.plugins ?? [])];
+      config.plugins = [...makeReactNativeTrackerDefaultPluginsList(trackerConfig), ...(trackerConfig.plugins ?? [])];
     } else {
       config.plugins = trackerConfig.plugins;
     }

--- a/tracker/trackers/react-native/src/common/factories/makeReactNativeTrackerDefaultPluginsList.ts
+++ b/tracker/trackers/react-native/src/common/factories/makeReactNativeTrackerDefaultPluginsList.ts
@@ -2,9 +2,21 @@
  * Copyright 2022 Objectiv B.V.
  */
 
+import { ApplicationContextPlugin } from '@objectiv/plugin-application-context';
+import { TrackerPluginInterface } from '@objectiv/tracker-core';
+import { ReactNativeTrackerConfig } from '@objectiv/tracker-react-native';
+
 /**
  * The default list of Plugins of React Native Tracker
  */
-export const makeReactNativeTrackerDefaultPluginsList = () => {
-  return [];
+export const makeReactNativeTrackerDefaultPluginsList = (trackerConfig: ReactNativeTrackerConfig) => {
+  const { trackApplicationContext = true } = trackerConfig;
+
+  const plugins: TrackerPluginInterface[] = [];
+
+  if (trackApplicationContext) {
+    plugins.push(new ApplicationContextPlugin());
+  }
+
+  return plugins;
 };

--- a/tracker/trackers/react-native/tests/ReactNativeTracker.test.ts
+++ b/tracker/trackers/react-native/tests/ReactNativeTracker.test.ts
@@ -100,6 +100,18 @@ describe('ReactNativeTracker', () => {
       );
     });
 
+    it('should allow disabling all plugins, exception made for OpenTaxonomyValidationPlugin ', () => {
+      const testTracker = new ReactNativeTracker({
+        applicationId: 'app-id',
+        endpoint: 'localhost',
+        trackApplicationContext: false,
+      });
+      expect(testTracker).toBeInstanceOf(ReactNativeTracker);
+      expect(testTracker.plugins?.plugins).toEqual([
+        expect.objectContaining({ pluginName: 'OpenTaxonomyValidationPlugin' }),
+      ]);
+    });
+
     it('should add Plugins `plugins` has been specified', () => {
       const testTracker = new ReactNativeTracker({
         applicationId: 'app-id',

--- a/tracker/trackers/react/package.json
+++ b/tracker/trackers/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/tracker-react",
-  "version": "0.0.22-0",
+  "version": "0.0.22-1",
   "description": "Objectiv React application analytics tracker for the open analytics taxonomy",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -50,9 +50,9 @@
     "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
-    "@objectiv/developer-tools": "^0.0.22-0",
-    "@objectiv/testing-tools": "^0.0.22-0",
-    "@objectiv/transport-debug": "^0.0.22-0",
+    "@objectiv/developer-tools": "^0.0.22-1",
+    "@objectiv/testing-tools": "^0.0.22-1",
+    "@objectiv/transport-debug": "^0.0.22-1",
     "@testing-library/react": "^12.1.4",
     "@types/jest": "^27.4.1",
     "@types/react": "^17.0.39",
@@ -68,14 +68,15 @@
     "typescript": "^4.6.2"
   },
   "dependencies": {
-    "@objectiv/plugin-http-context": "^0.0.22-0",
-    "@objectiv/plugin-path-context-from-url": "^0.0.22-0",
-    "@objectiv/plugin-root-location-context-from-url": "^0.0.22-0",
-    "@objectiv/queue-local-storage": "^0.0.22-0",
-    "@objectiv/tracker-core": "~0.0.22-0",
-    "@objectiv/tracker-react-core": "~0.0.22-0",
-    "@objectiv/transport-fetch": "^0.0.22-0",
-    "@objectiv/transport-xhr": "^0.0.22-0"
+    "@objectiv/plugin-application-context": "^0.0.22-1",
+    "@objectiv/plugin-http-context": "^0.0.22-1",
+    "@objectiv/plugin-path-context-from-url": "^0.0.22-1",
+    "@objectiv/plugin-root-location-context-from-url": "^0.0.22-1",
+    "@objectiv/queue-local-storage": "^0.0.22-1",
+    "@objectiv/tracker-core": "~0.0.22-1",
+    "@objectiv/tracker-react-core": "~0.0.22-1",
+    "@objectiv/transport-fetch": "^0.0.22-1",
+    "@objectiv/transport-xhr": "^0.0.22-1"
   },
   "peerDependencies": {
     "react": ">=16.8",

--- a/tracker/trackers/react/src/ReactTracker.ts
+++ b/tracker/trackers/react/src/ReactTracker.ts
@@ -18,6 +18,11 @@ export type ReactTrackerConfig = Omit<TrackerConfig, 'platform'> & {
   endpoint?: string;
 
   /**
+   * Optional. Whether to track ApplicationContext automatically. Enabled by default.
+   */
+  trackApplicationContext?: boolean;
+
+  /**
    * Optional. Whether to automatically create HttpContext based on Document and Navigation APIs. Enabled by default.
    */
   trackHttpContext?: boolean;

--- a/tracker/trackers/react/src/common/factories/makeReactTrackerDefaultPluginsList.ts
+++ b/tracker/trackers/react/src/common/factories/makeReactTrackerDefaultPluginsList.ts
@@ -2,6 +2,7 @@
  * Copyright 2021-2022 Objectiv B.V.
  */
 
+import { ApplicationContextPlugin } from '@objectiv/plugin-application-context';
 import { HttpContextPlugin } from '@objectiv/plugin-http-context';
 import { PathContextFromURLPlugin } from '@objectiv/plugin-path-context-from-url';
 import { RootLocationContextFromURLPlugin } from '@objectiv/plugin-root-location-context-from-url';
@@ -13,12 +14,17 @@ import { ReactTrackerConfig } from '../../ReactTracker';
  */
 export const makeReactTrackerDefaultPluginsList = (trackerConfig: ReactTrackerConfig) => {
   const {
+    trackApplicationContext = true,
     trackHttpContext = true,
     trackPathContextFromURL = true,
     trackRootLocationContextFromURL = true,
   } = trackerConfig;
 
   const plugins: TrackerPluginInterface[] = [];
+
+  if (trackApplicationContext) {
+    plugins.push(new ApplicationContextPlugin());
+  }
 
   if (trackHttpContext) {
     plugins.push(new HttpContextPlugin());

--- a/tracker/transports/debug/package.json
+++ b/tracker/transports/debug/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/transport-debug",
-  "version": "0.0.22-0",
+  "version": "0.0.22-1",
   "description": "A TrackerTransport that logs incoming events to console.debug",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -61,6 +61,6 @@
     "typescript": "^4.6.2"
   },
   "dependencies": {
-    "@objectiv/tracker-core": "~0.0.22-0"
+    "@objectiv/tracker-core": "~0.0.22-1"
   }
 }

--- a/tracker/transports/fetch/package.json
+++ b/tracker/transports/fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/transport-fetch",
-  "version": "0.0.22-0",
+  "version": "0.0.22-1",
   "description": "A TrackerTransport based on Fetch API",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -51,8 +51,8 @@
     "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
-    "@objectiv/developer-tools": "^0.0.22-0",
-    "@objectiv/testing-tools": "^0.0.22-0",
+    "@objectiv/developer-tools": "^0.0.22-1",
+    "@objectiv/testing-tools": "^0.0.22-1",
     "@types/jest": "^27.4.1",
     "jest": "^27.5.1",
     "jest-fetch-mock": "^3.0.3",
@@ -63,6 +63,6 @@
     "typescript": "^4.6.2"
   },
   "dependencies": {
-    "@objectiv/tracker-core": "~0.0.22-0"
+    "@objectiv/tracker-core": "~0.0.22-1"
   }
 }

--- a/tracker/transports/xhr/package.json
+++ b/tracker/transports/xhr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/transport-xhr",
-  "version": "0.0.22-0",
+  "version": "0.0.22-1",
   "description": "A TrackerTransport based on XMLHttpRequest API",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -52,8 +52,8 @@
     "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
-    "@objectiv/developer-tools": "^0.0.22-0",
-    "@objectiv/testing-tools": "^0.0.22-0",
+    "@objectiv/developer-tools": "^0.0.22-1",
+    "@objectiv/testing-tools": "^0.0.22-1",
     "@types/jest": "^27.4.1",
     "jest": "^27.5.1",
     "jest-standard-reporter": "^2.0.0",
@@ -64,6 +64,6 @@
     "xhr-mock": "^2.5.1"
   },
   "dependencies": {
-    "@objectiv/tracker-core": "~0.0.22-0"
+    "@objectiv/tracker-core": "~0.0.22-1"
   }
 }

--- a/tracker/yarn.lock
+++ b/tracker/yarn.lock
@@ -1756,6 +1756,7 @@ __metadata:
   resolution: "@objectiv/tracker-browser@workspace:trackers/browser"
   dependencies:
     "@objectiv/developer-tools": ^0.0.22-0
+    "@objectiv/plugin-application-context": ^0.0.22-0
     "@objectiv/plugin-http-context": ^0.0.22-0
     "@objectiv/plugin-path-context-from-url": ^0.0.22-0
     "@objectiv/plugin-root-location-context-from-url": ^0.0.22-0
@@ -1783,7 +1784,6 @@ __metadata:
   resolution: "@objectiv/tracker-core@workspace:core/tracker"
   dependencies:
     "@objectiv/developer-tools": ^0.0.22-0
-    "@objectiv/plugin-application-context": ^0.0.22-0
     "@objectiv/schema": ^0.0.22-0
     "@objectiv/testing-tools": ^0.0.22-0
     "@types/jest": ^27.4.1
@@ -1831,6 +1831,7 @@ __metadata:
   resolution: "@objectiv/tracker-react-native@workspace:trackers/react-native"
   dependencies:
     "@objectiv/developer-tools": ^0.0.22-0
+    "@objectiv/plugin-application-context": ^0.0.22-0
     "@objectiv/testing-tools": ^0.0.22-0
     "@objectiv/tracker-core": ~0.0.22-0
     "@objectiv/tracker-react-core": ~0.0.22-0
@@ -1858,6 +1859,7 @@ __metadata:
   resolution: "@objectiv/tracker-react@workspace:trackers/react"
   dependencies:
     "@objectiv/developer-tools": ^0.0.22-0
+    "@objectiv/plugin-application-context": ^0.0.22-0
     "@objectiv/plugin-http-context": ^0.0.22-0
     "@objectiv/plugin-path-context-from-url": ^0.0.22-0
     "@objectiv/plugin-root-location-context-from-url": ^0.0.22-0

--- a/tracker/yarn.lock
+++ b/tracker/yarn.lock
@@ -1505,12 +1505,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@objectiv/developer-tools@^0.0.22-0, @objectiv/developer-tools@workspace:core/developer-tools":
+"@objectiv/developer-tools@^0.0.22-1, @objectiv/developer-tools@workspace:core/developer-tools":
   version: 0.0.0-use.local
   resolution: "@objectiv/developer-tools@workspace:core/developer-tools"
   dependencies:
-    "@objectiv/testing-tools": ^0.0.22-0
-    "@objectiv/tracker-core": ^0.0.22-0
+    "@objectiv/testing-tools": ^0.0.22-1
+    "@objectiv/tracker-core": ^0.0.22-1
     "@types/jest": ^27.4.1
     jest: ^27.5.1
     jest-standard-reporter: ^2.0.0
@@ -1521,17 +1521,17 @@ __metadata:
     tsup: ^5.12.0
     typescript: ^4.6.2
   peerDependencies:
-    "@objectiv/schema": ^0.0.22-0
-    "@objectiv/tracker-core": ^0.0.22-0
+    "@objectiv/schema": ^0.0.22-1
+    "@objectiv/tracker-core": ^0.0.22-1
   languageName: unknown
   linkType: soft
 
-"@objectiv/plugin-application-context@^0.0.22-0, @objectiv/plugin-application-context@workspace:plugins/application-context":
+"@objectiv/plugin-application-context@^0.0.22-1, @objectiv/plugin-application-context@workspace:plugins/application-context":
   version: 0.0.0-use.local
   resolution: "@objectiv/plugin-application-context@workspace:plugins/application-context"
   dependencies:
-    "@objectiv/developer-tools": ^0.0.22-0
-    "@objectiv/testing-tools": ^0.0.22-0
+    "@objectiv/developer-tools": ^0.0.22-1
+    "@objectiv/testing-tools": ^0.0.22-1
     "@types/jest": ^27.4.1
     jest: ^27.5.1
     jest-standard-reporter: ^2.0.0
@@ -1540,16 +1540,16 @@ __metadata:
     tsup: ^5.12.0
     typescript: ^4.6.2
   peerDependencies:
-    "@objectiv/tracker-core": ^0.0.22-0
+    "@objectiv/tracker-core": ^0.0.22-1
   languageName: unknown
   linkType: soft
 
-"@objectiv/plugin-http-context@^0.0.22-0, @objectiv/plugin-http-context@workspace:plugins/http-context":
+"@objectiv/plugin-http-context@^0.0.22-1, @objectiv/plugin-http-context@workspace:plugins/http-context":
   version: 0.0.0-use.local
   resolution: "@objectiv/plugin-http-context@workspace:plugins/http-context"
   dependencies:
-    "@objectiv/developer-tools": ^0.0.22-0
-    "@objectiv/testing-tools": ^0.0.22-0
+    "@objectiv/developer-tools": ^0.0.22-1
+    "@objectiv/testing-tools": ^0.0.22-1
     "@types/jest": ^27.4.1
     jest: ^27.5.1
     jest-extended: ^2.0.0
@@ -1559,7 +1559,7 @@ __metadata:
     tsup: ^5.12.0
     typescript: ^4.6.2
   peerDependencies:
-    "@objectiv/tracker-core": ^0.0.22-0
+    "@objectiv/tracker-core": ^0.0.22-1
   languageName: unknown
   linkType: soft
 
@@ -1567,8 +1567,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@objectiv/plugin-identity-context@workspace:plugins/identity-context"
   dependencies:
-    "@objectiv/developer-tools": ^0.0.22-0
-    "@objectiv/testing-tools": ^0.0.22-0
+    "@objectiv/developer-tools": ^0.0.22-1
+    "@objectiv/testing-tools": ^0.0.22-1
     "@types/jest": ^27.4.1
     jest: ^27.5.1
     jest-standard-reporter: ^2.0.0
@@ -1577,7 +1577,7 @@ __metadata:
     tsup: ^5.12.0
     typescript: ^4.6.2
   peerDependencies:
-    "@objectiv/tracker-core": ^0.0.22-0
+    "@objectiv/tracker-core": ^0.0.22-1
   languageName: unknown
   linkType: soft
 
@@ -1585,8 +1585,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@objectiv/plugin-locale-context@workspace:plugins/locale-context"
   dependencies:
-    "@objectiv/developer-tools": ^0.0.22-0
-    "@objectiv/testing-tools": ^0.0.22-0
+    "@objectiv/developer-tools": ^0.0.22-1
+    "@objectiv/testing-tools": ^0.0.22-1
     "@types/jest": ^27.4.1
     jest: ^27.5.1
     jest-extended: ^2.0.0
@@ -1596,16 +1596,16 @@ __metadata:
     tsup: ^5.12.0
     typescript: ^4.6.2
   peerDependencies:
-    "@objectiv/tracker-core": ^0.0.22-0
+    "@objectiv/tracker-core": ^0.0.22-1
   languageName: unknown
   linkType: soft
 
-"@objectiv/plugin-path-context-from-url@^0.0.22-0, @objectiv/plugin-path-context-from-url@workspace:plugins/path-context-from-url":
+"@objectiv/plugin-path-context-from-url@^0.0.22-1, @objectiv/plugin-path-context-from-url@workspace:plugins/path-context-from-url":
   version: 0.0.0-use.local
   resolution: "@objectiv/plugin-path-context-from-url@workspace:plugins/path-context-from-url"
   dependencies:
-    "@objectiv/developer-tools": ^0.0.22-0
-    "@objectiv/testing-tools": ^0.0.22-0
+    "@objectiv/developer-tools": ^0.0.22-1
+    "@objectiv/testing-tools": ^0.0.22-1
     "@types/jest": ^27.4.1
     jest: ^27.5.1
     jest-extended: ^2.0.0
@@ -1615,7 +1615,7 @@ __metadata:
     tsup: ^5.12.0
     typescript: ^4.6.2
   peerDependencies:
-    "@objectiv/tracker-core": ^0.0.22-0
+    "@objectiv/tracker-core": ^0.0.22-1
   languageName: unknown
   linkType: soft
 
@@ -1623,10 +1623,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@objectiv/plugin-react-navigation@workspace:plugins/react-navigation"
   dependencies:
-    "@objectiv/developer-tools": ^0.0.22-0
-    "@objectiv/testing-tools": ^0.0.22-0
-    "@objectiv/tracker-react-core": ^0.0.22-0
-    "@objectiv/tracker-react-native": ^0.0.22-0
+    "@objectiv/developer-tools": ^0.0.22-1
+    "@objectiv/testing-tools": ^0.0.22-1
+    "@objectiv/tracker-react-core": ^0.0.22-1
+    "@objectiv/tracker-react-native": ^0.0.22-1
     "@react-navigation/bottom-tabs": ^6.2.0
     "@react-navigation/core": ^6.1.1
     "@react-navigation/native": ^6.0.8
@@ -1655,10 +1655,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@objectiv/plugin-react-router-tracked-components@workspace:plugins/react-router-tracked-components"
   dependencies:
-    "@objectiv/developer-tools": ^0.0.22-0
-    "@objectiv/testing-tools": ^0.0.22-0
-    "@objectiv/tracker-core": ^0.0.22-0
-    "@objectiv/tracker-react": ^0.0.22-0
+    "@objectiv/developer-tools": ^0.0.22-1
+    "@objectiv/testing-tools": ^0.0.22-1
+    "@objectiv/tracker-core": ^0.0.22-1
+    "@objectiv/tracker-react": ^0.0.22-1
     "@testing-library/react": ^12.1.4
     "@types/jest": ^27.4.1
     jest: ^27.5.1
@@ -1675,12 +1675,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@objectiv/plugin-root-location-context-from-url@^0.0.22-0, @objectiv/plugin-root-location-context-from-url@workspace:plugins/root-location-context-from-url":
+"@objectiv/plugin-root-location-context-from-url@^0.0.22-1, @objectiv/plugin-root-location-context-from-url@workspace:plugins/root-location-context-from-url":
   version: 0.0.0-use.local
   resolution: "@objectiv/plugin-root-location-context-from-url@workspace:plugins/root-location-context-from-url"
   dependencies:
-    "@objectiv/developer-tools": ^0.0.22-0
-    "@objectiv/testing-tools": ^0.0.22-0
+    "@objectiv/developer-tools": ^0.0.22-1
+    "@objectiv/testing-tools": ^0.0.22-1
     "@types/jest": ^27.4.1
     jest: ^27.5.1
     jest-extended: ^2.0.0
@@ -1690,17 +1690,17 @@ __metadata:
     tsup: ^5.12.0
     typescript: ^4.6.2
   peerDependencies:
-    "@objectiv/tracker-core": ^0.0.22-0
+    "@objectiv/tracker-core": ^0.0.22-1
   languageName: unknown
   linkType: soft
 
-"@objectiv/queue-local-storage@^0.0.22-0, @objectiv/queue-local-storage@workspace:queues/local-storage":
+"@objectiv/queue-local-storage@^0.0.22-1, @objectiv/queue-local-storage@workspace:queues/local-storage":
   version: 0.0.0-use.local
   resolution: "@objectiv/queue-local-storage@workspace:queues/local-storage"
   dependencies:
-    "@objectiv/developer-tools": ^0.0.22-0
-    "@objectiv/testing-tools": ^0.0.22-0
-    "@objectiv/tracker-core": ~0.0.22-0
+    "@objectiv/developer-tools": ^0.0.22-1
+    "@objectiv/testing-tools": ^0.0.22-1
+    "@objectiv/tracker-core": ~0.0.22-1
     "@types/jest": ^27.4.1
     jest: ^27.5.1
     jest-standard-reporter: ^2.0.0
@@ -1711,7 +1711,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@objectiv/schema@^0.0.22-0, @objectiv/schema@workspace:core/schema":
+"@objectiv/schema@^0.0.22-1, @objectiv/schema@workspace:core/schema":
   version: 0.0.0-use.local
   resolution: "@objectiv/schema@workspace:core/schema"
   dependencies:
@@ -1720,11 +1720,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@objectiv/testing-tools@^0.0.22-0, @objectiv/testing-tools@workspace:core/testing-tools":
+"@objectiv/testing-tools@^0.0.22-1, @objectiv/testing-tools@workspace:core/testing-tools":
   version: 0.0.0-use.local
   resolution: "@objectiv/testing-tools@workspace:core/testing-tools"
   dependencies:
-    "@objectiv/tracker-core": ^0.0.22-0
+    "@objectiv/tracker-core": ^0.0.22-1
     prettier: ^2.5.1
     typescript: ^4.6.2
   languageName: unknown
@@ -1737,7 +1737,7 @@ __metadata:
     "@angular/compiler": ~9.1.13
     "@angular/compiler-cli": ~9.1.13
     "@angular/core": ~9.1.13
-    "@objectiv/tracker-browser": ^0.0.22-0
+    "@objectiv/tracker-browser": ^0.0.22-1
     ng-packagr: ^9.0.0
     prettier: ^2.5.1
     rxjs: ~6.5.4
@@ -1747,26 +1747,26 @@ __metadata:
   peerDependencies:
     "@angular/common": ^9.0.0
     "@angular/core": ^9.0.0
-    "@objectiv/tracker-browser": ^0.0.22-0
+    "@objectiv/tracker-browser": ^0.0.22-1
   languageName: unknown
   linkType: soft
 
-"@objectiv/tracker-browser@^0.0.22-0, @objectiv/tracker-browser@workspace:trackers/browser":
+"@objectiv/tracker-browser@^0.0.22-1, @objectiv/tracker-browser@workspace:trackers/browser":
   version: 0.0.0-use.local
   resolution: "@objectiv/tracker-browser@workspace:trackers/browser"
   dependencies:
-    "@objectiv/developer-tools": ^0.0.22-0
-    "@objectiv/plugin-application-context": ^0.0.22-0
-    "@objectiv/plugin-http-context": ^0.0.22-0
-    "@objectiv/plugin-path-context-from-url": ^0.0.22-0
-    "@objectiv/plugin-root-location-context-from-url": ^0.0.22-0
-    "@objectiv/queue-local-storage": ^0.0.22-0
-    "@objectiv/schema": ^0.0.22-0
-    "@objectiv/testing-tools": ^0.0.22-0
-    "@objectiv/tracker-core": ^0.0.22-0
-    "@objectiv/transport-debug": ^0.0.22-0
-    "@objectiv/transport-fetch": ^0.0.22-0
-    "@objectiv/transport-xhr": ^0.0.22-0
+    "@objectiv/developer-tools": ^0.0.22-1
+    "@objectiv/plugin-application-context": ^0.0.22-1
+    "@objectiv/plugin-http-context": ^0.0.22-1
+    "@objectiv/plugin-path-context-from-url": ^0.0.22-1
+    "@objectiv/plugin-root-location-context-from-url": ^0.0.22-1
+    "@objectiv/queue-local-storage": ^0.0.22-1
+    "@objectiv/schema": ^0.0.22-1
+    "@objectiv/testing-tools": ^0.0.22-1
+    "@objectiv/tracker-core": ^0.0.22-1
+    "@objectiv/transport-debug": ^0.0.22-1
+    "@objectiv/transport-fetch": ^0.0.22-1
+    "@objectiv/transport-xhr": ^0.0.22-1
     "@types/jest": ^27.4.1
     jest: ^27.5.1
     jest-fetch-mock: ^3.0.3
@@ -1779,13 +1779,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@objectiv/tracker-core@^0.0.22-0, @objectiv/tracker-core@workspace:core/tracker, @objectiv/tracker-core@~0.0.22-0":
+"@objectiv/tracker-core@^0.0.22-1, @objectiv/tracker-core@workspace:core/tracker, @objectiv/tracker-core@~0.0.22-1":
   version: 0.0.0-use.local
   resolution: "@objectiv/tracker-core@workspace:core/tracker"
   dependencies:
-    "@objectiv/developer-tools": ^0.0.22-0
-    "@objectiv/schema": ^0.0.22-0
-    "@objectiv/testing-tools": ^0.0.22-0
+    "@objectiv/developer-tools": ^0.0.22-1
+    "@objectiv/schema": ^0.0.22-1
+    "@objectiv/testing-tools": ^0.0.22-1
     "@types/jest": ^27.4.1
     "@types/uuid": ^8.3.4
     jest: ^27.5.1
@@ -1799,14 +1799,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@objectiv/tracker-react-core@^0.0.22-0, @objectiv/tracker-react-core@workspace:core/react, @objectiv/tracker-react-core@~0.0.22-0":
+"@objectiv/tracker-react-core@^0.0.22-1, @objectiv/tracker-react-core@workspace:core/react, @objectiv/tracker-react-core@~0.0.22-1":
   version: 0.0.0-use.local
   resolution: "@objectiv/tracker-react-core@workspace:core/react"
   dependencies:
-    "@objectiv/developer-tools": ^0.0.22-0
-    "@objectiv/schema": ^0.0.22-0
-    "@objectiv/testing-tools": ^0.0.22-0
-    "@objectiv/tracker-core": ~0.0.22-0
+    "@objectiv/developer-tools": ^0.0.22-1
+    "@objectiv/schema": ^0.0.22-1
+    "@objectiv/testing-tools": ^0.0.22-1
+    "@objectiv/tracker-core": ~0.0.22-1
     "@testing-library/react": ^12.1.4
     "@testing-library/react-hooks": ^7.0.2
     "@types/jest": ^27.4.1
@@ -1826,17 +1826,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@objectiv/tracker-react-native@^0.0.22-0, @objectiv/tracker-react-native@workspace:trackers/react-native":
+"@objectiv/tracker-react-native@^0.0.22-1, @objectiv/tracker-react-native@workspace:trackers/react-native":
   version: 0.0.0-use.local
   resolution: "@objectiv/tracker-react-native@workspace:trackers/react-native"
   dependencies:
-    "@objectiv/developer-tools": ^0.0.22-0
-    "@objectiv/plugin-application-context": ^0.0.22-0
-    "@objectiv/testing-tools": ^0.0.22-0
-    "@objectiv/tracker-core": ~0.0.22-0
-    "@objectiv/tracker-react-core": ~0.0.22-0
-    "@objectiv/transport-debug": ^0.0.22-0
-    "@objectiv/transport-fetch": ^0.0.22-0
+    "@objectiv/developer-tools": ^0.0.22-1
+    "@objectiv/plugin-application-context": ^0.0.22-1
+    "@objectiv/testing-tools": ^0.0.22-1
+    "@objectiv/tracker-core": ~0.0.22-1
+    "@objectiv/tracker-react-core": ~0.0.22-1
+    "@objectiv/transport-debug": ^0.0.22-1
+    "@objectiv/transport-fetch": ^0.0.22-1
     "@testing-library/react-native": ^9.0.0
     "@types/react-native": ^0.67.2
     jest: ^27.5.1
@@ -1854,22 +1854,22 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@objectiv/tracker-react@^0.0.22-0, @objectiv/tracker-react@workspace:trackers/react":
+"@objectiv/tracker-react@^0.0.22-1, @objectiv/tracker-react@workspace:trackers/react":
   version: 0.0.0-use.local
   resolution: "@objectiv/tracker-react@workspace:trackers/react"
   dependencies:
-    "@objectiv/developer-tools": ^0.0.22-0
-    "@objectiv/plugin-application-context": ^0.0.22-0
-    "@objectiv/plugin-http-context": ^0.0.22-0
-    "@objectiv/plugin-path-context-from-url": ^0.0.22-0
-    "@objectiv/plugin-root-location-context-from-url": ^0.0.22-0
-    "@objectiv/queue-local-storage": ^0.0.22-0
-    "@objectiv/testing-tools": ^0.0.22-0
-    "@objectiv/tracker-core": ~0.0.22-0
-    "@objectiv/tracker-react-core": ~0.0.22-0
-    "@objectiv/transport-debug": ^0.0.22-0
-    "@objectiv/transport-fetch": ^0.0.22-0
-    "@objectiv/transport-xhr": ^0.0.22-0
+    "@objectiv/developer-tools": ^0.0.22-1
+    "@objectiv/plugin-application-context": ^0.0.22-1
+    "@objectiv/plugin-http-context": ^0.0.22-1
+    "@objectiv/plugin-path-context-from-url": ^0.0.22-1
+    "@objectiv/plugin-root-location-context-from-url": ^0.0.22-1
+    "@objectiv/queue-local-storage": ^0.0.22-1
+    "@objectiv/testing-tools": ^0.0.22-1
+    "@objectiv/tracker-core": ~0.0.22-1
+    "@objectiv/tracker-react-core": ~0.0.22-1
+    "@objectiv/transport-debug": ^0.0.22-1
+    "@objectiv/transport-fetch": ^0.0.22-1
+    "@objectiv/transport-xhr": ^0.0.22-1
     "@testing-library/react": ^12.1.4
     "@types/jest": ^27.4.1
     "@types/react": ^17.0.39
@@ -1889,11 +1889,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@objectiv/transport-debug@^0.0.22-0, @objectiv/transport-debug@workspace:transports/debug":
+"@objectiv/transport-debug@^0.0.22-1, @objectiv/transport-debug@workspace:transports/debug":
   version: 0.0.0-use.local
   resolution: "@objectiv/transport-debug@workspace:transports/debug"
   dependencies:
-    "@objectiv/tracker-core": ~0.0.22-0
+    "@objectiv/tracker-core": ~0.0.22-1
     "@types/jest": ^27.4.1
     jest: ^27.5.1
     jest-standard-reporter: ^2.0.0
@@ -1904,13 +1904,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@objectiv/transport-fetch@^0.0.22-0, @objectiv/transport-fetch@workspace:transports/fetch":
+"@objectiv/transport-fetch@^0.0.22-1, @objectiv/transport-fetch@workspace:transports/fetch":
   version: 0.0.0-use.local
   resolution: "@objectiv/transport-fetch@workspace:transports/fetch"
   dependencies:
-    "@objectiv/developer-tools": ^0.0.22-0
-    "@objectiv/testing-tools": ^0.0.22-0
-    "@objectiv/tracker-core": ~0.0.22-0
+    "@objectiv/developer-tools": ^0.0.22-1
+    "@objectiv/testing-tools": ^0.0.22-1
+    "@objectiv/tracker-core": ~0.0.22-1
     "@types/jest": ^27.4.1
     jest: ^27.5.1
     jest-fetch-mock: ^3.0.3
@@ -1922,13 +1922,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@objectiv/transport-xhr@^0.0.22-0, @objectiv/transport-xhr@workspace:transports/xhr":
+"@objectiv/transport-xhr@^0.0.22-1, @objectiv/transport-xhr@workspace:transports/xhr":
   version: 0.0.0-use.local
   resolution: "@objectiv/transport-xhr@workspace:transports/xhr"
   dependencies:
-    "@objectiv/developer-tools": ^0.0.22-0
-    "@objectiv/testing-tools": ^0.0.22-0
-    "@objectiv/tracker-core": ~0.0.22-0
+    "@objectiv/developer-tools": ^0.0.22-1
+    "@objectiv/testing-tools": ^0.0.22-1
+    "@objectiv/tracker-core": ~0.0.22-1
     "@types/jest": ^27.4.1
     jest: ^27.5.1
     jest-standard-reporter: ^2.0.0


### PR DESCRIPTION
Nextjs is not compatible with circular module dependencies. This triggers an error during build when importing Core Tracker, as it depends on ApplicationContextPlugin and vice-versa.

In this PR I've moved the plugin initialization out of Core Tracker and into the tracker themselves. This solve the circular dependency and provides a leaner core, so it's actually a win-win situation.

This version is on NPM as v0.0.22-1.