### PR TITLE
Make boolean min() and max() work on BQ

### DIFF
--- a/bach/tests/functional/bach/test_df_describe.py
+++ b/bach/tests/functional/bach/test_df_describe.py
@@ -185,14 +185,14 @@ def test_describe_time(engine) -> None:
     pd.testing.assert_frame_equal(expected_df, result.to_pandas())
 
 
-def test_describe_boolean(pg_engine) -> None:
+def test_describe_boolean(engine) -> None:
     pdf = pd.DataFrame(
         data=[
             [True], [False], [True],
         ],
         columns=['column'],
     )
-    df = DataFrame.from_pandas(engine=pg_engine, df=pdf, convert_objects=True)
+    df = DataFrame.from_pandas(engine=engine, df=pdf, convert_objects=True)
 
     result = df.describe()
     result = result.reset_index(drop=False)

--- a/bach/tests/functional/bach/test_series_boolean.py
+++ b/bach/tests/functional/bach/test_series_boolean.py
@@ -71,9 +71,8 @@ def test_operations(engine):
     )
 
 
-def test_min_max(pg_engine):
-    # TODO: BigQuery
-    df = get_df_with_test_data(pg_engine)[['founding']]
+def test_min_max(engine):
+    df = get_df_with_test_data(engine)[['founding']]
     df['mixed'] = df['founding'] < 1400
     df['yes'] = True
     df['no'] = False


### PR DESCRIPTION
Fixes a small issue: `SeriesBoolean.min()` and max() on BigQuery

This solves https://github.com/objectiv/objectiv-analytics/issues/806