### PR TITLE
Support input tracking for HTMLSelectElements in Browser/Angular SDKs

### DIFF
--- a/tracker/core/developer-tools/package.json
+++ b/tracker/core/developer-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/developer-tools",
-  "version": "0.0.22-2",
+  "version": "0.0.22-3",
   "description": "Validation and logging utilities to help pinpoint instrumentation issues while developing",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -55,8 +55,8 @@
     "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
-    "@objectiv/testing-tools": "^0.0.22-2",
-    "@objectiv/tracker-core": "^0.0.22-2",
+    "@objectiv/testing-tools": "^0.0.22-3",
+    "@objectiv/tracker-core": "^0.0.22-3",
     "@types/jest": "^27.4.1",
     "jest": "^27.5.1",
     "jest-standard-reporter": "^2.0.0",
@@ -68,7 +68,7 @@
     "typescript": "^4.6.2"
   },
   "peerDependencies": {
-    "@objectiv/schema": "^0.0.22-2",
-    "@objectiv/tracker-core": "^0.0.22-2"
+    "@objectiv/schema": "^0.0.22-3",
+    "@objectiv/tracker-core": "^0.0.22-3"
   }
 }

--- a/tracker/core/react/package.json
+++ b/tracker/core/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/tracker-react-core",
-  "version": "0.0.22-2",
+  "version": "0.0.22-3",
   "description": "Objectiv tracker core module for React trackers",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -51,8 +51,8 @@
     "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
-    "@objectiv/developer-tools": "^0.0.22-2",
-    "@objectiv/testing-tools": "^0.0.22-2",
+    "@objectiv/developer-tools": "^0.0.22-3",
+    "@objectiv/testing-tools": "^0.0.22-3",
     "@testing-library/react": "^12.1.4",
     "@testing-library/react-hooks": "^7.0.2",
     "@types/jest": "^27.4.1",
@@ -67,8 +67,8 @@
     "typescript": "^4.6.2"
   },
   "dependencies": {
-    "@objectiv/schema": "^0.0.22-2",
-    "@objectiv/tracker-core": "~0.0.22-2",
+    "@objectiv/schema": "^0.0.22-3",
+    "@objectiv/tracker-core": "~0.0.22-3",
     "fast-deep-equal": "^3.1.3"
   },
   "peerDependencies": {

--- a/tracker/core/schema/package.json
+++ b/tracker/core/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/schema",
-  "version": "0.0.22-2",
+  "version": "0.0.22-3",
   "description": "Objectiv TypeScript implementation of the open analytics taxonomy",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",

--- a/tracker/core/testing-tools/package.json
+++ b/tracker/core/testing-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/testing-tools",
-  "version": "0.0.22-2",
+  "version": "0.0.22-3",
   "private": true,
   "license": "Apache-2.0",
   "description": "Mocks and other testing utilities shared across Objectiv Trackers",
@@ -14,7 +14,7 @@
     "check:dependencies": "npx depcheck"
   },
   "devDependencies": {
-    "@objectiv/tracker-core": "^0.0.22-2",
+    "@objectiv/tracker-core": "^0.0.22-3",
     "prettier": "^2.5.1",
     "typescript": "^4.6.2"
   }

--- a/tracker/core/tracker/package.json
+++ b/tracker/core/tracker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/tracker-core",
-  "version": "0.0.22-2",
+  "version": "0.0.22-3",
   "description": "Core functionality for Objectiv JavaScript trackers",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -50,7 +50,7 @@
     "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
-    "@objectiv/testing-tools": "^0.0.22-2",
+    "@objectiv/testing-tools": "^0.0.22-3",
     "@types/jest": "^27.4.1",
     "@types/uuid": "^8.3.4",
     "jest": "^27.5.1",
@@ -62,8 +62,8 @@
     "typescript": "^4.6.2"
   },
   "dependencies": {
-    "@objectiv/developer-tools": "^0.0.22-2",
-    "@objectiv/schema": "^0.0.22-2",
+    "@objectiv/developer-tools": "^0.0.22-3",
+    "@objectiv/schema": "^0.0.22-3",
     "uuid": "^8.3.2"
   }
 }

--- a/tracker/core/utilities/package.json
+++ b/tracker/core/utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/utilities",
-  "version": "0.0.22-2",
+  "version": "0.0.22-3",
   "private": true,
   "license": "Apache-2.0",
   "description": "Objectiv Core Utilities",

--- a/tracker/plugins/application-context/package.json
+++ b/tracker/plugins/application-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/plugin-application-context",
-  "version": "0.0.22-2",
+  "version": "0.0.22-3",
   "description": "Plugin for Objectiv trackers to automatically generate and attach ApplicationContext to all Events",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -52,8 +52,8 @@
     "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
-    "@objectiv/developer-tools": "^0.0.22-2",
-    "@objectiv/testing-tools": "^0.0.22-2",
+    "@objectiv/developer-tools": "^0.0.22-3",
+    "@objectiv/testing-tools": "^0.0.22-3",
     "@types/jest": "^27.4.1",
     "jest": "^27.5.1",
     "jest-standard-reporter": "^2.0.0",
@@ -63,6 +63,6 @@
     "typescript": "^4.6.2"
   },
   "peerDependencies": {
-    "@objectiv/tracker-core": "^0.0.22-2"
+    "@objectiv/tracker-core": "^0.0.22-3"
   }
 }

--- a/tracker/plugins/http-context/package.json
+++ b/tracker/plugins/http-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/plugin-http-context",
-  "version": "0.0.22-2",
+  "version": "0.0.22-3",
   "description": "Plugin for Objectiv trackers to automatically generate and attach HttpContext from document and navigator APIs",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -54,8 +54,8 @@
     "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
-    "@objectiv/developer-tools": "^0.0.22-2",
-    "@objectiv/testing-tools": "^0.0.22-2",
+    "@objectiv/developer-tools": "^0.0.22-3",
+    "@objectiv/testing-tools": "^0.0.22-3",
     "@types/jest": "^27.4.1",
     "jest": "^27.5.1",
     "jest-extended": "^2.0.0",
@@ -66,6 +66,6 @@
     "typescript": "^4.6.2"
   },
   "peerDependencies": {
-    "@objectiv/tracker-core": "^0.0.22-2"
+    "@objectiv/tracker-core": "^0.0.22-3"
   }
 }

--- a/tracker/plugins/identity-context/package.json
+++ b/tracker/plugins/identity-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/plugin-identity-context",
-  "version": "0.0.22-2",
+  "version": "0.0.22-3",
   "description": "Plugin for Objectiv trackers to generate IdentityContext instances",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -53,8 +53,8 @@
     "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
-    "@objectiv/developer-tools": "^0.0.22-2",
-    "@objectiv/testing-tools": "^0.0.22-2",
+    "@objectiv/developer-tools": "^0.0.22-3",
+    "@objectiv/testing-tools": "^0.0.22-3",
     "@types/jest": "^27.4.1",
     "jest": "^27.5.1",
     "jest-standard-reporter": "^2.0.0",
@@ -64,6 +64,6 @@
     "typescript": "^4.6.2"
   },
   "peerDependencies": {
-    "@objectiv/tracker-core": "^0.0.22-2"
+    "@objectiv/tracker-core": "^0.0.22-3"
   }
 }

--- a/tracker/plugins/locale-context/package.json
+++ b/tracker/plugins/locale-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/plugin-locale-context",
-  "version": "0.0.22-2",
+  "version": "0.0.22-3",
   "description": "Plugin for Objectiv trackers to automatically generate and attach LocaleContext",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -52,8 +52,8 @@
     "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
-    "@objectiv/developer-tools": "^0.0.22-2",
-    "@objectiv/testing-tools": "^0.0.22-2",
+    "@objectiv/developer-tools": "^0.0.22-3",
+    "@objectiv/testing-tools": "^0.0.22-3",
     "@types/jest": "^27.4.1",
     "jest": "^27.5.1",
     "jest-extended": "^2.0.0",
@@ -64,6 +64,6 @@
     "typescript": "^4.6.2"
   },
   "peerDependencies": {
-    "@objectiv/tracker-core": "^0.0.22-2"
+    "@objectiv/tracker-core": "^0.0.22-3"
   }
 }

--- a/tracker/plugins/path-context-from-url/package.json
+++ b/tracker/plugins/path-context-from-url/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/plugin-path-context-from-url",
-  "version": "0.0.22-2",
+  "version": "0.0.22-3",
   "description": "Plugin for Objectiv trackers to automatically generate and attach PathContext from URLs",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -52,8 +52,8 @@
     "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
-    "@objectiv/developer-tools": "^0.0.22-2",
-    "@objectiv/testing-tools": "^0.0.22-2",
+    "@objectiv/developer-tools": "^0.0.22-3",
+    "@objectiv/testing-tools": "^0.0.22-3",
     "@types/jest": "^27.4.1",
     "jest": "^27.5.1",
     "jest-extended": "^2.0.0",
@@ -64,6 +64,6 @@
     "typescript": "^4.6.2"
   },
   "peerDependencies": {
-    "@objectiv/tracker-core": "^0.0.22-2"
+    "@objectiv/tracker-core": "^0.0.22-3"
   }
 }

--- a/tracker/plugins/react-navigation/package.json
+++ b/tracker/plugins/react-navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/plugin-react-navigation",
-  "version": "0.0.22-2",
+  "version": "0.0.22-3",
   "description": "Automatically tracked React Navigation 6+ Components, listeners and state for Objectiv React Native Tracker",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -53,12 +53,12 @@
     "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "dependencies": {
-    "@objectiv/tracker-react-core": "^0.0.22-2",
-    "@objectiv/tracker-react-native": "^0.0.22-2"
+    "@objectiv/tracker-react-core": "^0.0.22-3",
+    "@objectiv/tracker-react-native": "^0.0.22-3"
   },
   "devDependencies": {
-    "@objectiv/developer-tools": "^0.0.22-2",
-    "@objectiv/testing-tools": "^0.0.22-2",
+    "@objectiv/developer-tools": "^0.0.22-3",
+    "@objectiv/testing-tools": "^0.0.22-3",
     "@react-navigation/bottom-tabs": "^6.2.0",
     "@react-navigation/core": "^6.1.1",
     "@react-navigation/native": "^6.0.8",

--- a/tracker/plugins/react-router-tracked-components/package.json
+++ b/tracker/plugins/react-router-tracked-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/plugin-react-router-tracked-components",
-  "version": "0.0.22-2",
+  "version": "0.0.22-3",
   "description": "React Router 6 automatically tracked Link and NavLink Components for Objectiv React Tracker",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -54,12 +54,12 @@
     "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "dependencies": {
-    "@objectiv/tracker-core": "^0.0.22-2",
-    "@objectiv/tracker-react": "^0.0.22-2"
+    "@objectiv/tracker-core": "^0.0.22-3",
+    "@objectiv/tracker-react": "^0.0.22-3"
   },
   "devDependencies": {
-    "@objectiv/developer-tools": "^0.0.22-2",
-    "@objectiv/testing-tools": "^0.0.22-2",
+    "@objectiv/developer-tools": "^0.0.22-3",
+    "@objectiv/testing-tools": "^0.0.22-3",
     "@testing-library/react": "^12.1.4",
     "@types/jest": "^27.4.1",
     "jest": "^27.5.1",

--- a/tracker/plugins/root-location-context-from-url/package.json
+++ b/tracker/plugins/root-location-context-from-url/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/plugin-root-location-context-from-url",
-  "version": "0.0.22-2",
+  "version": "0.0.22-3",
   "description": "Plugin for Objectiv trackers to automatically generate and attach RootLocationContext from URLs",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -53,8 +53,8 @@
     "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
-    "@objectiv/developer-tools": "^0.0.22-2",
-    "@objectiv/testing-tools": "^0.0.22-2",
+    "@objectiv/developer-tools": "^0.0.22-3",
+    "@objectiv/testing-tools": "^0.0.22-3",
     "@types/jest": "^27.4.1",
     "jest": "^27.5.1",
     "jest-extended": "^2.0.0",
@@ -65,6 +65,6 @@
     "typescript": "^4.6.2"
   },
   "peerDependencies": {
-    "@objectiv/tracker-core": "^0.0.22-2"
+    "@objectiv/tracker-core": "^0.0.22-3"
   }
 }

--- a/tracker/queues/local-storage/package.json
+++ b/tracker/queues/local-storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/queue-local-storage",
-  "version": "0.0.22-2",
+  "version": "0.0.22-3",
   "description": "A TrackerQueueStore based on localStorage API",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -51,8 +51,8 @@
     "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
-    "@objectiv/developer-tools": "^0.0.22-2",
-    "@objectiv/testing-tools": "^0.0.22-2",
+    "@objectiv/developer-tools": "^0.0.22-3",
+    "@objectiv/testing-tools": "^0.0.22-3",
     "@types/jest": "^27.4.1",
     "jest": "^27.5.1",
     "jest-standard-reporter": "^2.0.0",
@@ -62,6 +62,6 @@
     "typescript": "^4.6.2"
   },
   "dependencies": {
-    "@objectiv/tracker-core": "~0.0.22-2"
+    "@objectiv/tracker-core": "~0.0.22-3"
   }
 }

--- a/tracker/trackers/angular/package.json
+++ b/tracker/trackers/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/tracker-angular",
-  "version": "0.0.22-2",
+  "version": "0.0.22-3",
   "description": "Objectiv Angular framework analytics tracker for the open analytics taxonomy",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -38,13 +38,13 @@
   "peerDependencies": {
     "@angular/common": "^9.0.0",
     "@angular/core": "^9.0.0",
-    "@objectiv/tracker-browser": "^0.0.22-2"
+    "@objectiv/tracker-browser": "^0.0.22-3"
   },
   "devDependencies": {
     "@angular/compiler": "~9.1.13",
     "@angular/compiler-cli": "~9.1.13",
     "@angular/core": "~9.1.13",
-    "@objectiv/tracker-browser": "^0.0.22-2",
+    "@objectiv/tracker-browser": "^0.0.22-3",
     "ng-packagr": "^9.0.0",
     "prettier": "^2.5.1",
     "rxjs": "~6.5.4",

--- a/tracker/trackers/browser/package.json
+++ b/tracker/trackers/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/tracker-browser",
-  "version": "0.0.22-2",
+  "version": "0.0.22-3",
   "description": "Objectiv Web application analytics tracker for the open analytics taxonomy",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -50,8 +50,8 @@
     "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
-    "@objectiv/developer-tools": "^0.0.22-2",
-    "@objectiv/testing-tools": "^0.0.22-2",
+    "@objectiv/developer-tools": "^0.0.22-3",
+    "@objectiv/testing-tools": "^0.0.22-3",
     "@types/jest": "^27.4.1",
     "jest": "^27.5.1",
     "jest-fetch-mock": "^3.0.3",
@@ -63,15 +63,15 @@
     "typescript": "^4.6.2"
   },
   "dependencies": {
-    "@objectiv/plugin-application-context": "^0.0.22-2",
-    "@objectiv/plugin-http-context": "^0.0.22-2",
-    "@objectiv/plugin-path-context-from-url": "^0.0.22-2",
-    "@objectiv/plugin-root-location-context-from-url": "^0.0.22-2",
-    "@objectiv/queue-local-storage": "^0.0.22-2",
-    "@objectiv/schema": "^0.0.22-2",
-    "@objectiv/tracker-core": "^0.0.22-2",
-    "@objectiv/transport-debug": "^0.0.22-2",
-    "@objectiv/transport-fetch": "^0.0.22-2",
-    "@objectiv/transport-xhr": "^0.0.22-2"
+    "@objectiv/plugin-application-context": "^0.0.22-3",
+    "@objectiv/plugin-http-context": "^0.0.22-3",
+    "@objectiv/plugin-path-context-from-url": "^0.0.22-3",
+    "@objectiv/plugin-root-location-context-from-url": "^0.0.22-3",
+    "@objectiv/queue-local-storage": "^0.0.22-3",
+    "@objectiv/schema": "^0.0.22-3",
+    "@objectiv/tracker-core": "^0.0.22-3",
+    "@objectiv/transport-debug": "^0.0.22-3",
+    "@objectiv/transport-fetch": "^0.0.22-3",
+    "@objectiv/transport-xhr": "^0.0.22-3"
   }
 }

--- a/tracker/trackers/browser/src/common/guards/isTagLocationOptions.ts
+++ b/tracker/trackers/browser/src/common/guards/isTagLocationOptions.ts
@@ -2,8 +2,8 @@
  * Copyright 2021-2022 Objectiv B.V.
  */
 
-import { isTrackBlursAttribute } from '@objectiv/tracker-browser';
 import { TagLocationOptions } from '../../definitions/TagLocationOptions';
+import { isTrackBlursAttribute } from './isTrackBlursAttribute';
 import { isTrackClicksAttribute } from './isTrackClicksAttribute';
 import { isTrackVisibilityAttribute } from './isTrackVisibilityAttribute';
 import { isValidateAttribute } from './isValidateAttribute';

--- a/tracker/trackers/browser/src/common/guards/isTagLocationOptions.ts
+++ b/tracker/trackers/browser/src/common/guards/isTagLocationOptions.ts
@@ -2,7 +2,7 @@
  * Copyright 2021-2022 Objectiv B.V.
  */
 
-import { isTrackBlursAttribute } from "@objectiv/tracker-browser";
+import { isTrackBlursAttribute } from '@objectiv/tracker-browser';
 import { TagLocationOptions } from '../../definitions/TagLocationOptions';
 import { isTrackClicksAttribute } from './isTrackClicksAttribute';
 import { isTrackVisibilityAttribute } from './isTrackVisibilityAttribute';

--- a/tracker/trackers/browser/src/common/guards/isTagLocationOptions.ts
+++ b/tracker/trackers/browser/src/common/guards/isTagLocationOptions.ts
@@ -2,6 +2,7 @@
  * Copyright 2021-2022 Objectiv B.V.
  */
 
+import { isTrackBlursAttribute } from "@objectiv/tracker-browser";
 import { TagLocationOptions } from '../../definitions/TagLocationOptions';
 import { isTrackClicksAttribute } from './isTrackClicksAttribute';
 import { isTrackVisibilityAttribute } from './isTrackVisibilityAttribute';
@@ -19,7 +20,7 @@ export const isTagLocationOptions = (object: Partial<TagLocationOptions>): objec
     return false;
   }
 
-  if (object.trackBlurs !== undefined && object.trackBlurs !== true && object.trackBlurs !== false) {
+  if (object.trackBlurs !== undefined && !isTrackBlursAttribute(object.trackBlurs)) {
     return false;
   }
 

--- a/tracker/trackers/browser/src/mutationObserver/makeBlurEventHandler.ts
+++ b/tracker/trackers/browser/src/mutationObserver/makeBlurEventHandler.ts
@@ -23,13 +23,16 @@ export const makeBlurEventHandler =
       (isTaggedElement(event.currentTarget) && event.currentTarget.hasAttribute(TaggingAttribute.trackBlurs))
     ) {
       const globalContexts: GlobalContexts = [];
-      const elementValue = element.getAttribute('value');
 
-      if (trackBlursOptions?.trackValue && locationId && elementValue) {
+      if (
+        trackBlursOptions?.trackValue &&
+        locationId &&
+        (event.target instanceof HTMLInputElement || event.target instanceof HTMLSelectElement)
+      ) {
         globalContexts.push(
           makeInputValueContext({
             id: locationId,
-            value: elementValue,
+            value: event.target.value,
           })
         );
       }

--- a/tracker/trackers/browser/tests/tagLocationHelpers.test.ts
+++ b/tracker/trackers/browser/tests/tagLocationHelpers.test.ts
@@ -134,6 +134,23 @@ describe('tagLocationHelpers', () => {
     expect(taggingAttributes).toStrictEqual(expectedTaggingAttributes);
   });
 
+  it('tagInput with value tracking', () => {
+    const taggingAttributes = tagInput({ id: 'test-input', options: { trackBlurs: { trackValue: true } } });
+
+    const expectedTaggingAttributes = {
+      [TaggingAttribute.elementId]: matchUUID,
+      [TaggingAttribute.context]: JSON.stringify({
+        __instance_id: taggingAttributes ? JSON.parse(taggingAttributes[TaggingAttribute.context]).__instance_id : null,
+        __location_context: true,
+        _type: LocationContextName.InputContext,
+        id: 'test-input',
+      }),
+      [TaggingAttribute.trackBlurs]: '{"trackValue":true}',
+    };
+
+    expect(taggingAttributes).toStrictEqual(expectedTaggingAttributes);
+  });
+
   it('tagLink', () => {
     const taggingAttributes = tagLink({ id: 'link', href: '/test' });
 

--- a/tracker/trackers/react-native/package.json
+++ b/tracker/trackers/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/tracker-react-native",
-  "version": "0.0.22-2",
+  "version": "0.0.22-3",
   "description": "Objectiv React Native application analytics tracker the open analytics taxonomy",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -50,9 +50,9 @@
     "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
-    "@objectiv/developer-tools": "^0.0.22-2",
-    "@objectiv/testing-tools": "^0.0.22-2",
-    "@objectiv/transport-debug": "^0.0.22-2",
+    "@objectiv/developer-tools": "^0.0.22-3",
+    "@objectiv/testing-tools": "^0.0.22-3",
+    "@objectiv/transport-debug": "^0.0.22-3",
     "@testing-library/react-native": "^9.0.0",
     "@types/react-native": "^0.67.2",
     "jest": "^27.5.1",
@@ -65,10 +65,10 @@
     "typescript": "^4.6.2"
   },
   "dependencies": {
-    "@objectiv/plugin-application-context": "^0.0.22-2",
-    "@objectiv/tracker-core": "~0.0.22-2",
-    "@objectiv/tracker-react-core": "~0.0.22-2",
-    "@objectiv/transport-fetch": "^0.0.22-2",
+    "@objectiv/plugin-application-context": "^0.0.22-3",
+    "@objectiv/tracker-core": "~0.0.22-3",
+    "@objectiv/tracker-react-core": "~0.0.22-3",
+    "@objectiv/transport-fetch": "^0.0.22-3",
     "react-native-get-random-values": "^1.7.2"
   },
   "peerDependencies": {

--- a/tracker/trackers/react/package.json
+++ b/tracker/trackers/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/tracker-react",
-  "version": "0.0.22-2",
+  "version": "0.0.22-3",
   "description": "Objectiv React application analytics tracker for the open analytics taxonomy",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -50,9 +50,9 @@
     "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
-    "@objectiv/developer-tools": "^0.0.22-2",
-    "@objectiv/testing-tools": "^0.0.22-2",
-    "@objectiv/transport-debug": "^0.0.22-2",
+    "@objectiv/developer-tools": "^0.0.22-3",
+    "@objectiv/testing-tools": "^0.0.22-3",
+    "@objectiv/transport-debug": "^0.0.22-3",
     "@testing-library/react": "^12.1.4",
     "@types/jest": "^27.4.1",
     "@types/react": "^17.0.39",
@@ -68,15 +68,15 @@
     "typescript": "^4.6.2"
   },
   "dependencies": {
-    "@objectiv/plugin-application-context": "^0.0.22-2",
-    "@objectiv/plugin-http-context": "^0.0.22-2",
-    "@objectiv/plugin-path-context-from-url": "^0.0.22-2",
-    "@objectiv/plugin-root-location-context-from-url": "^0.0.22-2",
-    "@objectiv/queue-local-storage": "^0.0.22-2",
-    "@objectiv/tracker-core": "~0.0.22-2",
-    "@objectiv/tracker-react-core": "~0.0.22-2",
-    "@objectiv/transport-fetch": "^0.0.22-2",
-    "@objectiv/transport-xhr": "^0.0.22-2"
+    "@objectiv/plugin-application-context": "^0.0.22-3",
+    "@objectiv/plugin-http-context": "^0.0.22-3",
+    "@objectiv/plugin-path-context-from-url": "^0.0.22-3",
+    "@objectiv/plugin-root-location-context-from-url": "^0.0.22-3",
+    "@objectiv/queue-local-storage": "^0.0.22-3",
+    "@objectiv/tracker-core": "~0.0.22-3",
+    "@objectiv/tracker-react-core": "~0.0.22-3",
+    "@objectiv/transport-fetch": "^0.0.22-3",
+    "@objectiv/transport-xhr": "^0.0.22-3"
   },
   "peerDependencies": {
     "react": ">=16.8",

--- a/tracker/transports/debug/package.json
+++ b/tracker/transports/debug/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/transport-debug",
-  "version": "0.0.22-2",
+  "version": "0.0.22-3",
   "description": "A TrackerTransport that logs incoming events to console.debug",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -61,6 +61,6 @@
     "typescript": "^4.6.2"
   },
   "dependencies": {
-    "@objectiv/tracker-core": "~0.0.22-2"
+    "@objectiv/tracker-core": "~0.0.22-3"
   }
 }

--- a/tracker/transports/fetch/package.json
+++ b/tracker/transports/fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/transport-fetch",
-  "version": "0.0.22-2",
+  "version": "0.0.22-3",
   "description": "A TrackerTransport based on Fetch API",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -51,8 +51,8 @@
     "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
-    "@objectiv/developer-tools": "^0.0.22-2",
-    "@objectiv/testing-tools": "^0.0.22-2",
+    "@objectiv/developer-tools": "^0.0.22-3",
+    "@objectiv/testing-tools": "^0.0.22-3",
     "@types/jest": "^27.4.1",
     "jest": "^27.5.1",
     "jest-fetch-mock": "^3.0.3",
@@ -63,6 +63,6 @@
     "typescript": "^4.6.2"
   },
   "dependencies": {
-    "@objectiv/tracker-core": "~0.0.22-2"
+    "@objectiv/tracker-core": "~0.0.22-3"
   }
 }

--- a/tracker/transports/xhr/package.json
+++ b/tracker/transports/xhr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/transport-xhr",
-  "version": "0.0.22-2",
+  "version": "0.0.22-3",
   "description": "A TrackerTransport based on XMLHttpRequest API",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -52,8 +52,8 @@
     "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
-    "@objectiv/developer-tools": "^0.0.22-2",
-    "@objectiv/testing-tools": "^0.0.22-2",
+    "@objectiv/developer-tools": "^0.0.22-3",
+    "@objectiv/testing-tools": "^0.0.22-3",
     "@types/jest": "^27.4.1",
     "jest": "^27.5.1",
     "jest-standard-reporter": "^2.0.0",
@@ -64,6 +64,6 @@
     "xhr-mock": "^2.5.1"
   },
   "dependencies": {
-    "@objectiv/tracker-core": "~0.0.22-2"
+    "@objectiv/tracker-core": "~0.0.22-3"
   }
 }

--- a/tracker/yarn.lock
+++ b/tracker/yarn.lock
@@ -1505,12 +1505,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@objectiv/developer-tools@^0.0.22-2, @objectiv/developer-tools@workspace:core/developer-tools":
+"@objectiv/developer-tools@^0.0.22-3, @objectiv/developer-tools@workspace:core/developer-tools":
   version: 0.0.0-use.local
   resolution: "@objectiv/developer-tools@workspace:core/developer-tools"
   dependencies:
-    "@objectiv/testing-tools": ^0.0.22-2
-    "@objectiv/tracker-core": ^0.0.22-2
+    "@objectiv/testing-tools": ^0.0.22-3
+    "@objectiv/tracker-core": ^0.0.22-3
     "@types/jest": ^27.4.1
     jest: ^27.5.1
     jest-standard-reporter: ^2.0.0
@@ -1521,17 +1521,17 @@ __metadata:
     tsup: ^5.12.0
     typescript: ^4.6.2
   peerDependencies:
-    "@objectiv/schema": ^0.0.22-2
-    "@objectiv/tracker-core": ^0.0.22-2
+    "@objectiv/schema": ^0.0.22-3
+    "@objectiv/tracker-core": ^0.0.22-3
   languageName: unknown
   linkType: soft
 
-"@objectiv/plugin-application-context@^0.0.22-2, @objectiv/plugin-application-context@workspace:plugins/application-context":
+"@objectiv/plugin-application-context@^0.0.22-3, @objectiv/plugin-application-context@workspace:plugins/application-context":
   version: 0.0.0-use.local
   resolution: "@objectiv/plugin-application-context@workspace:plugins/application-context"
   dependencies:
-    "@objectiv/developer-tools": ^0.0.22-2
-    "@objectiv/testing-tools": ^0.0.22-2
+    "@objectiv/developer-tools": ^0.0.22-3
+    "@objectiv/testing-tools": ^0.0.22-3
     "@types/jest": ^27.4.1
     jest: ^27.5.1
     jest-standard-reporter: ^2.0.0
@@ -1540,16 +1540,16 @@ __metadata:
     tsup: ^5.12.0
     typescript: ^4.6.2
   peerDependencies:
-    "@objectiv/tracker-core": ^0.0.22-2
+    "@objectiv/tracker-core": ^0.0.22-3
   languageName: unknown
   linkType: soft
 
-"@objectiv/plugin-http-context@^0.0.22-2, @objectiv/plugin-http-context@workspace:plugins/http-context":
+"@objectiv/plugin-http-context@^0.0.22-3, @objectiv/plugin-http-context@workspace:plugins/http-context":
   version: 0.0.0-use.local
   resolution: "@objectiv/plugin-http-context@workspace:plugins/http-context"
   dependencies:
-    "@objectiv/developer-tools": ^0.0.22-2
-    "@objectiv/testing-tools": ^0.0.22-2
+    "@objectiv/developer-tools": ^0.0.22-3
+    "@objectiv/testing-tools": ^0.0.22-3
     "@types/jest": ^27.4.1
     jest: ^27.5.1
     jest-extended: ^2.0.0
@@ -1559,7 +1559,7 @@ __metadata:
     tsup: ^5.12.0
     typescript: ^4.6.2
   peerDependencies:
-    "@objectiv/tracker-core": ^0.0.22-2
+    "@objectiv/tracker-core": ^0.0.22-3
   languageName: unknown
   linkType: soft
 
@@ -1567,8 +1567,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@objectiv/plugin-identity-context@workspace:plugins/identity-context"
   dependencies:
-    "@objectiv/developer-tools": ^0.0.22-2
-    "@objectiv/testing-tools": ^0.0.22-2
+    "@objectiv/developer-tools": ^0.0.22-3
+    "@objectiv/testing-tools": ^0.0.22-3
     "@types/jest": ^27.4.1
     jest: ^27.5.1
     jest-standard-reporter: ^2.0.0
@@ -1577,7 +1577,7 @@ __metadata:
     tsup: ^5.12.0
     typescript: ^4.6.2
   peerDependencies:
-    "@objectiv/tracker-core": ^0.0.22-2
+    "@objectiv/tracker-core": ^0.0.22-3
   languageName: unknown
   linkType: soft
 
@@ -1585,8 +1585,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@objectiv/plugin-locale-context@workspace:plugins/locale-context"
   dependencies:
-    "@objectiv/developer-tools": ^0.0.22-2
-    "@objectiv/testing-tools": ^0.0.22-2
+    "@objectiv/developer-tools": ^0.0.22-3
+    "@objectiv/testing-tools": ^0.0.22-3
     "@types/jest": ^27.4.1
     jest: ^27.5.1
     jest-extended: ^2.0.0
@@ -1596,16 +1596,16 @@ __metadata:
     tsup: ^5.12.0
     typescript: ^4.6.2
   peerDependencies:
-    "@objectiv/tracker-core": ^0.0.22-2
+    "@objectiv/tracker-core": ^0.0.22-3
   languageName: unknown
   linkType: soft
 
-"@objectiv/plugin-path-context-from-url@^0.0.22-2, @objectiv/plugin-path-context-from-url@workspace:plugins/path-context-from-url":
+"@objectiv/plugin-path-context-from-url@^0.0.22-3, @objectiv/plugin-path-context-from-url@workspace:plugins/path-context-from-url":
   version: 0.0.0-use.local
   resolution: "@objectiv/plugin-path-context-from-url@workspace:plugins/path-context-from-url"
   dependencies:
-    "@objectiv/developer-tools": ^0.0.22-2
-    "@objectiv/testing-tools": ^0.0.22-2
+    "@objectiv/developer-tools": ^0.0.22-3
+    "@objectiv/testing-tools": ^0.0.22-3
     "@types/jest": ^27.4.1
     jest: ^27.5.1
     jest-extended: ^2.0.0
@@ -1615,7 +1615,7 @@ __metadata:
     tsup: ^5.12.0
     typescript: ^4.6.2
   peerDependencies:
-    "@objectiv/tracker-core": ^0.0.22-2
+    "@objectiv/tracker-core": ^0.0.22-3
   languageName: unknown
   linkType: soft
 
@@ -1623,10 +1623,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@objectiv/plugin-react-navigation@workspace:plugins/react-navigation"
   dependencies:
-    "@objectiv/developer-tools": ^0.0.22-2
-    "@objectiv/testing-tools": ^0.0.22-2
-    "@objectiv/tracker-react-core": ^0.0.22-2
-    "@objectiv/tracker-react-native": ^0.0.22-2
+    "@objectiv/developer-tools": ^0.0.22-3
+    "@objectiv/testing-tools": ^0.0.22-3
+    "@objectiv/tracker-react-core": ^0.0.22-3
+    "@objectiv/tracker-react-native": ^0.0.22-3
     "@react-navigation/bottom-tabs": ^6.2.0
     "@react-navigation/core": ^6.1.1
     "@react-navigation/native": ^6.0.8
@@ -1655,10 +1655,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@objectiv/plugin-react-router-tracked-components@workspace:plugins/react-router-tracked-components"
   dependencies:
-    "@objectiv/developer-tools": ^0.0.22-2
-    "@objectiv/testing-tools": ^0.0.22-2
-    "@objectiv/tracker-core": ^0.0.22-2
-    "@objectiv/tracker-react": ^0.0.22-2
+    "@objectiv/developer-tools": ^0.0.22-3
+    "@objectiv/testing-tools": ^0.0.22-3
+    "@objectiv/tracker-core": ^0.0.22-3
+    "@objectiv/tracker-react": ^0.0.22-3
     "@testing-library/react": ^12.1.4
     "@types/jest": ^27.4.1
     jest: ^27.5.1
@@ -1675,12 +1675,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@objectiv/plugin-root-location-context-from-url@^0.0.22-2, @objectiv/plugin-root-location-context-from-url@workspace:plugins/root-location-context-from-url":
+"@objectiv/plugin-root-location-context-from-url@^0.0.22-3, @objectiv/plugin-root-location-context-from-url@workspace:plugins/root-location-context-from-url":
   version: 0.0.0-use.local
   resolution: "@objectiv/plugin-root-location-context-from-url@workspace:plugins/root-location-context-from-url"
   dependencies:
-    "@objectiv/developer-tools": ^0.0.22-2
-    "@objectiv/testing-tools": ^0.0.22-2
+    "@objectiv/developer-tools": ^0.0.22-3
+    "@objectiv/testing-tools": ^0.0.22-3
     "@types/jest": ^27.4.1
     jest: ^27.5.1
     jest-extended: ^2.0.0
@@ -1690,17 +1690,17 @@ __metadata:
     tsup: ^5.12.0
     typescript: ^4.6.2
   peerDependencies:
-    "@objectiv/tracker-core": ^0.0.22-2
+    "@objectiv/tracker-core": ^0.0.22-3
   languageName: unknown
   linkType: soft
 
-"@objectiv/queue-local-storage@^0.0.22-2, @objectiv/queue-local-storage@workspace:queues/local-storage":
+"@objectiv/queue-local-storage@^0.0.22-3, @objectiv/queue-local-storage@workspace:queues/local-storage":
   version: 0.0.0-use.local
   resolution: "@objectiv/queue-local-storage@workspace:queues/local-storage"
   dependencies:
-    "@objectiv/developer-tools": ^0.0.22-2
-    "@objectiv/testing-tools": ^0.0.22-2
-    "@objectiv/tracker-core": ~0.0.22-2
+    "@objectiv/developer-tools": ^0.0.22-3
+    "@objectiv/testing-tools": ^0.0.22-3
+    "@objectiv/tracker-core": ~0.0.22-3
     "@types/jest": ^27.4.1
     jest: ^27.5.1
     jest-standard-reporter: ^2.0.0
@@ -1711,7 +1711,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@objectiv/schema@^0.0.22-2, @objectiv/schema@workspace:core/schema":
+"@objectiv/schema@^0.0.22-3, @objectiv/schema@workspace:core/schema":
   version: 0.0.0-use.local
   resolution: "@objectiv/schema@workspace:core/schema"
   dependencies:
@@ -1720,11 +1720,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@objectiv/testing-tools@^0.0.22-2, @objectiv/testing-tools@workspace:core/testing-tools":
+"@objectiv/testing-tools@^0.0.22-3, @objectiv/testing-tools@workspace:core/testing-tools":
   version: 0.0.0-use.local
   resolution: "@objectiv/testing-tools@workspace:core/testing-tools"
   dependencies:
-    "@objectiv/tracker-core": ^0.0.22-2
+    "@objectiv/tracker-core": ^0.0.22-3
     prettier: ^2.5.1
     typescript: ^4.6.2
   languageName: unknown
@@ -1737,7 +1737,7 @@ __metadata:
     "@angular/compiler": ~9.1.13
     "@angular/compiler-cli": ~9.1.13
     "@angular/core": ~9.1.13
-    "@objectiv/tracker-browser": ^0.0.22-2
+    "@objectiv/tracker-browser": ^0.0.22-3
     ng-packagr: ^9.0.0
     prettier: ^2.5.1
     rxjs: ~6.5.4
@@ -1747,26 +1747,26 @@ __metadata:
   peerDependencies:
     "@angular/common": ^9.0.0
     "@angular/core": ^9.0.0
-    "@objectiv/tracker-browser": ^0.0.22-2
+    "@objectiv/tracker-browser": ^0.0.22-3
   languageName: unknown
   linkType: soft
 
-"@objectiv/tracker-browser@^0.0.22-2, @objectiv/tracker-browser@workspace:trackers/browser":
+"@objectiv/tracker-browser@^0.0.22-3, @objectiv/tracker-browser@workspace:trackers/browser":
   version: 0.0.0-use.local
   resolution: "@objectiv/tracker-browser@workspace:trackers/browser"
   dependencies:
-    "@objectiv/developer-tools": ^0.0.22-2
-    "@objectiv/plugin-application-context": ^0.0.22-2
-    "@objectiv/plugin-http-context": ^0.0.22-2
-    "@objectiv/plugin-path-context-from-url": ^0.0.22-2
-    "@objectiv/plugin-root-location-context-from-url": ^0.0.22-2
-    "@objectiv/queue-local-storage": ^0.0.22-2
-    "@objectiv/schema": ^0.0.22-2
-    "@objectiv/testing-tools": ^0.0.22-2
-    "@objectiv/tracker-core": ^0.0.22-2
-    "@objectiv/transport-debug": ^0.0.22-2
-    "@objectiv/transport-fetch": ^0.0.22-2
-    "@objectiv/transport-xhr": ^0.0.22-2
+    "@objectiv/developer-tools": ^0.0.22-3
+    "@objectiv/plugin-application-context": ^0.0.22-3
+    "@objectiv/plugin-http-context": ^0.0.22-3
+    "@objectiv/plugin-path-context-from-url": ^0.0.22-3
+    "@objectiv/plugin-root-location-context-from-url": ^0.0.22-3
+    "@objectiv/queue-local-storage": ^0.0.22-3
+    "@objectiv/schema": ^0.0.22-3
+    "@objectiv/testing-tools": ^0.0.22-3
+    "@objectiv/tracker-core": ^0.0.22-3
+    "@objectiv/transport-debug": ^0.0.22-3
+    "@objectiv/transport-fetch": ^0.0.22-3
+    "@objectiv/transport-xhr": ^0.0.22-3
     "@types/jest": ^27.4.1
     jest: ^27.5.1
     jest-fetch-mock: ^3.0.3
@@ -1779,13 +1779,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@objectiv/tracker-core@^0.0.22-2, @objectiv/tracker-core@workspace:core/tracker, @objectiv/tracker-core@~0.0.22-2":
+"@objectiv/tracker-core@^0.0.22-3, @objectiv/tracker-core@workspace:core/tracker, @objectiv/tracker-core@~0.0.22-3":
   version: 0.0.0-use.local
   resolution: "@objectiv/tracker-core@workspace:core/tracker"
   dependencies:
-    "@objectiv/developer-tools": ^0.0.22-2
-    "@objectiv/schema": ^0.0.22-2
-    "@objectiv/testing-tools": ^0.0.22-2
+    "@objectiv/developer-tools": ^0.0.22-3
+    "@objectiv/schema": ^0.0.22-3
+    "@objectiv/testing-tools": ^0.0.22-3
     "@types/jest": ^27.4.1
     "@types/uuid": ^8.3.4
     jest: ^27.5.1
@@ -1799,14 +1799,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@objectiv/tracker-react-core@^0.0.22-2, @objectiv/tracker-react-core@workspace:core/react, @objectiv/tracker-react-core@~0.0.22-2":
+"@objectiv/tracker-react-core@^0.0.22-3, @objectiv/tracker-react-core@workspace:core/react, @objectiv/tracker-react-core@~0.0.22-3":
   version: 0.0.0-use.local
   resolution: "@objectiv/tracker-react-core@workspace:core/react"
   dependencies:
-    "@objectiv/developer-tools": ^0.0.22-2
-    "@objectiv/schema": ^0.0.22-2
-    "@objectiv/testing-tools": ^0.0.22-2
-    "@objectiv/tracker-core": ~0.0.22-2
+    "@objectiv/developer-tools": ^0.0.22-3
+    "@objectiv/schema": ^0.0.22-3
+    "@objectiv/testing-tools": ^0.0.22-3
+    "@objectiv/tracker-core": ~0.0.22-3
     "@testing-library/react": ^12.1.4
     "@testing-library/react-hooks": ^7.0.2
     "@types/jest": ^27.4.1
@@ -1826,17 +1826,17 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@objectiv/tracker-react-native@^0.0.22-2, @objectiv/tracker-react-native@workspace:trackers/react-native":
+"@objectiv/tracker-react-native@^0.0.22-3, @objectiv/tracker-react-native@workspace:trackers/react-native":
   version: 0.0.0-use.local
   resolution: "@objectiv/tracker-react-native@workspace:trackers/react-native"
   dependencies:
-    "@objectiv/developer-tools": ^0.0.22-2
-    "@objectiv/plugin-application-context": ^0.0.22-2
-    "@objectiv/testing-tools": ^0.0.22-2
-    "@objectiv/tracker-core": ~0.0.22-2
-    "@objectiv/tracker-react-core": ~0.0.22-2
-    "@objectiv/transport-debug": ^0.0.22-2
-    "@objectiv/transport-fetch": ^0.0.22-2
+    "@objectiv/developer-tools": ^0.0.22-3
+    "@objectiv/plugin-application-context": ^0.0.22-3
+    "@objectiv/testing-tools": ^0.0.22-3
+    "@objectiv/tracker-core": ~0.0.22-3
+    "@objectiv/tracker-react-core": ~0.0.22-3
+    "@objectiv/transport-debug": ^0.0.22-3
+    "@objectiv/transport-fetch": ^0.0.22-3
     "@testing-library/react-native": ^9.0.0
     "@types/react-native": ^0.67.2
     jest: ^27.5.1
@@ -1854,22 +1854,22 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@objectiv/tracker-react@^0.0.22-2, @objectiv/tracker-react@workspace:trackers/react":
+"@objectiv/tracker-react@^0.0.22-3, @objectiv/tracker-react@workspace:trackers/react":
   version: 0.0.0-use.local
   resolution: "@objectiv/tracker-react@workspace:trackers/react"
   dependencies:
-    "@objectiv/developer-tools": ^0.0.22-2
-    "@objectiv/plugin-application-context": ^0.0.22-2
-    "@objectiv/plugin-http-context": ^0.0.22-2
-    "@objectiv/plugin-path-context-from-url": ^0.0.22-2
-    "@objectiv/plugin-root-location-context-from-url": ^0.0.22-2
-    "@objectiv/queue-local-storage": ^0.0.22-2
-    "@objectiv/testing-tools": ^0.0.22-2
-    "@objectiv/tracker-core": ~0.0.22-2
-    "@objectiv/tracker-react-core": ~0.0.22-2
-    "@objectiv/transport-debug": ^0.0.22-2
-    "@objectiv/transport-fetch": ^0.0.22-2
-    "@objectiv/transport-xhr": ^0.0.22-2
+    "@objectiv/developer-tools": ^0.0.22-3
+    "@objectiv/plugin-application-context": ^0.0.22-3
+    "@objectiv/plugin-http-context": ^0.0.22-3
+    "@objectiv/plugin-path-context-from-url": ^0.0.22-3
+    "@objectiv/plugin-root-location-context-from-url": ^0.0.22-3
+    "@objectiv/queue-local-storage": ^0.0.22-3
+    "@objectiv/testing-tools": ^0.0.22-3
+    "@objectiv/tracker-core": ~0.0.22-3
+    "@objectiv/tracker-react-core": ~0.0.22-3
+    "@objectiv/transport-debug": ^0.0.22-3
+    "@objectiv/transport-fetch": ^0.0.22-3
+    "@objectiv/transport-xhr": ^0.0.22-3
     "@testing-library/react": ^12.1.4
     "@types/jest": ^27.4.1
     "@types/react": ^17.0.39
@@ -1889,11 +1889,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@objectiv/transport-debug@^0.0.22-2, @objectiv/transport-debug@workspace:transports/debug":
+"@objectiv/transport-debug@^0.0.22-3, @objectiv/transport-debug@workspace:transports/debug":
   version: 0.0.0-use.local
   resolution: "@objectiv/transport-debug@workspace:transports/debug"
   dependencies:
-    "@objectiv/tracker-core": ~0.0.22-2
+    "@objectiv/tracker-core": ~0.0.22-3
     "@types/jest": ^27.4.1
     jest: ^27.5.1
     jest-standard-reporter: ^2.0.0
@@ -1904,13 +1904,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@objectiv/transport-fetch@^0.0.22-2, @objectiv/transport-fetch@workspace:transports/fetch":
+"@objectiv/transport-fetch@^0.0.22-3, @objectiv/transport-fetch@workspace:transports/fetch":
   version: 0.0.0-use.local
   resolution: "@objectiv/transport-fetch@workspace:transports/fetch"
   dependencies:
-    "@objectiv/developer-tools": ^0.0.22-2
-    "@objectiv/testing-tools": ^0.0.22-2
-    "@objectiv/tracker-core": ~0.0.22-2
+    "@objectiv/developer-tools": ^0.0.22-3
+    "@objectiv/testing-tools": ^0.0.22-3
+    "@objectiv/tracker-core": ~0.0.22-3
     "@types/jest": ^27.4.1
     jest: ^27.5.1
     jest-fetch-mock: ^3.0.3
@@ -1922,13 +1922,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@objectiv/transport-xhr@^0.0.22-2, @objectiv/transport-xhr@workspace:transports/xhr":
+"@objectiv/transport-xhr@^0.0.22-3, @objectiv/transport-xhr@workspace:transports/xhr":
   version: 0.0.0-use.local
   resolution: "@objectiv/transport-xhr@workspace:transports/xhr"
   dependencies:
-    "@objectiv/developer-tools": ^0.0.22-2
-    "@objectiv/testing-tools": ^0.0.22-2
-    "@objectiv/tracker-core": ~0.0.22-2
+    "@objectiv/developer-tools": ^0.0.22-3
+    "@objectiv/testing-tools": ^0.0.22-3
+    "@objectiv/tracker-core": ~0.0.22-3
     "@types/jest": ^27.4.1
     jest: ^27.5.1
     jest-standard-reporter: ^2.0.0


### PR DESCRIPTION
Our previous implementation only supported tracking HTMLInputElements. These changes add support to HTMLSelectElement as well. 

`tagInput` can be used for both inputs and selects now, including value tracking. 

Value tracking for selects will populate the InputValueContext with the selected option value, or if not present, the option text.

We also fixed a bug in the validation of the options which could cause unexpected options to pass through. Now the tagInput options are stricter.

**NOTE**: this version is on NPM as v0.0.22-3@next

**TIP**: filter out JSON files for a much easier to review diff