### PR TITLE
Bach include types

### DIFF
--- a/bach/bach/py.typed
+++ b/bach/bach/py.typed
@@ -1,2 +1,3 @@
-# MyPy will not typecheck calls to bach.* if this file doesn't exist
+# MyPy will not typecheck calls to bach.*, if objectiv-bach is installed as a package with pip and
+# this file doesn't exist.
 # See https://mypy.readthedocs.io/en/stable/installed_packages.html#creating-pep-561-compatible-packages

--- a/bach/bach/py.typed
+++ b/bach/bach/py.typed
@@ -1,0 +1,2 @@
+# MyPy will not typecheck calls to bach.* if this file doesn't exist
+# See https://mypy.readthedocs.io/en/stable/installed_packages.html#creating-pep-561-compatible-packages

--- a/bach/setup.cfg
+++ b/bach/setup.cfg
@@ -34,6 +34,9 @@ include_package_data = True
 where = .
 exclude = tests, tests.*
 
+[options.package_data]
+* = py.typed
+
 [pycodestyle]
 count = True
 max-line-length = 110

--- a/bach/sql_models/py.typed
+++ b/bach/sql_models/py.typed
@@ -1,2 +1,3 @@
-# MyPy will not typecheck calls to sql_models.* if this file doesn't exist
+# MyPy will not typecheck calls to sql_models.*, if objectiv-bach is installed as a package with pip and
+# this file doesn't exist.
 # See https://mypy.readthedocs.io/en/stable/installed_packages.html#creating-pep-561-compatible-packages

--- a/bach/sql_models/py.typed
+++ b/bach/sql_models/py.typed
@@ -1,0 +1,2 @@
+# MyPy will not typecheck calls to sql_models.* if this file doesn't exist
+# See https://mypy.readthedocs.io/en/stable/installed_packages.html#creating-pep-561-compatible-packages

--- a/modelhub/modelhub/py.typed
+++ b/modelhub/modelhub/py.typed
@@ -1,0 +1,2 @@
+# MyPy will not typecheck calls to modelhub.* if this file doesn't exist
+# See https://mypy.readthedocs.io/en/stable/installed_packages.html#creating-pep-561-compatible-packages

--- a/modelhub/modelhub/py.typed
+++ b/modelhub/modelhub/py.typed
@@ -1,2 +1,3 @@
-# MyPy will not typecheck calls to modelhub.* if this file doesn't exist
+# MyPy will not typecheck calls to modelhub.*, if objectiv-modelhub is installed as a package with pip and
+# this file doesn't exist.
 # See https://mypy.readthedocs.io/en/stable/installed_packages.html#creating-pep-561-compatible-packages

--- a/modelhub/setup.cfg
+++ b/modelhub/setup.cfg
@@ -35,6 +35,9 @@ include_package_data = True
 where = .
 exclude = tests_modelhub, tests_modelhub.*
 
+[options.package_data]
+* = py.typed
+
 [pycodestyle]
 count = True
 max-line-length = 110


### PR DESCRIPTION
Change to tell mypy that it should type-check calls to bach and modelhub if these are installed as packages. By default mypy will not check external packages.

See https://mypy.readthedocs.io/en/stable/installed_packages.html#creating-pep-561-compatible-packages