### PR TITLE
Bach modelhub mypy

### DIFF
--- a/.github/workflows/bach-tests.yml
+++ b/.github/workflows/bach-tests.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Typecheck with mypy
         run: |
           cd bach
-          mypy --check-untyped-defs bach sql_models
+          mypy bach sql_models
       - name: Stylecheck with pycodestyle
         run: |
           cd bach

--- a/bach/Makefile
+++ b/bach/Makefile
@@ -1,7 +1,7 @@
 .PHONY: tests
 
 tests:
-	mypy --check-untyped-defs bach sql_models
+	mypy bach sql_models
 	pycodestyle bach sql_models
 	pytest tests/unit tests/functional tests/
 
@@ -10,7 +10,7 @@ tests-bigquery:
 # Similar to `tests`, but tests that can run against multiple databases will be run against BigQuery instead
 # of Postgres. Note that most of our test-suite is postgres-only. The postgres-only tests will still run
 # against Postgres
-	mypy --check-untyped-defs bach sql_models
+	mypy bach sql_models
 	pycodestyle bach sql_models
 	pytest -n 8 --dist loadgroup --big-query tests/unit tests/functional tests/
 
@@ -19,6 +19,6 @@ tests-all:
 # Similar to `tests`, but tests that can run against multiple databases will be run against both BigQuery
 # and Postgres. Note that most of our test-suite is postgres-only. The postgres-only tests will still only
 # run against Postgres
-	mypy --check-untyped-defs bach sql_models
+	mypy bach sql_models
 	pycodestyle bach sql_models
 	pytest -n 8 --dist loadgroup --all tests/unit tests/functional tests/

--- a/bach/mypy.ini
+++ b/bach/mypy.ini
@@ -2,6 +2,8 @@
 # mypy_path should have the same value as PYTHONPATH
 mypy_path=.
 
+# Check the code in all functions, even if a function itself doesn't have type annotations.
+check_untyped_defs=True
 
 # For a lot of libraries there are no stubs with typing information available. For those we'll just
 # tell mypy to ignore them. This does mean that calls to those libraries are not type-checked, but we do

--- a/modelhub/modelhub/py.typed
+++ b/modelhub/modelhub/py.typed
@@ -1,2 +1,3 @@
-# MyPy will not typecheck calls to modelhub.* if this file doesn't exist
+# MyPy will not typecheck calls to modelhub.*, if objectiv-modelhub is installed as a package with pip and
+# this file doesn't exist.
 # See https://mypy.readthedocs.io/en/stable/installed_packages.html#creating-pep-561-compatible-packages

--- a/modelhub/modelhub/series/series_objectiv.py
+++ b/modelhub/modelhub/series/series_objectiv.py
@@ -175,7 +175,8 @@ class SeriesLocationStack(SeriesJson):
 
             Returns the navigation stack from the location stack.
             """
-            return self[{'_type': 'NavigationContext'}: None]
+            # type ignore, as mypy doesn't like a dict in a Slice
+            return self[{'_type': 'NavigationContext'}: None]  # type: ignore
 
         @property
         def feature_stack(self) -> 'SeriesLocationStack':

--- a/modelhub/mypy.ini
+++ b/modelhub/mypy.ini
@@ -1,6 +1,9 @@
 [mypy]
-# mypy_path should have the same value as PYTHONPATH, but should include Bach
-mypy_path=../bach:.
+# mypy_path should have the same value as PYTHONPATH
+mypy_path=.
+
+# Check the code in all functions, even if a function itself doesn't have type annotations.
+check_untyped_defs=True
 
 # For a lot of libraries there are no stubs with typing information available. For those we'll just
 # tell mypy to ignore them. This does mean that calls to those libraries are not type-checked, but we do


### PR DESCRIPTION
Changes:
* Set mypy parameter `check_untyped_defs=True` for modelhub. This makes mypy check all code in modelhub. Without this it only checks functions that have at least one type-annotation.
  * Add an `type: ignore` in a place where we mistreat types on purpose that was previously not checked by mypy.
* Move check_untyped_defs parameter in bach from commandline to `mypy.ini`

This, together with #1019, resolves issue https://github.com/objectiv/objectiv-analytics/issues/854