### PR TITLE
React SDK hooks QOL tweaks

### DIFF
--- a/tracker/core/developer-tools/package.json
+++ b/tracker/core/developer-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/developer-tools",
-  "version": "0.0.22",
+  "version": "0.0.23-2",
   "description": "Validation and logging utilities to help pinpoint instrumentation issues while developing",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -55,9 +55,9 @@
     "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
-    "@objectiv/developer-tools": "^0.0.22",
-    "@objectiv/testing-tools": "^0.0.22",
-    "@objectiv/tracker-core": "^0.0.22",
+    "@objectiv/developer-tools": "^0.0.23-2",
+    "@objectiv/testing-tools": "^0.0.23-2",
+    "@objectiv/tracker-core": "^0.0.23-2",
     "@types/jest": "^27.4.1",
     "jest": "^27.5.1",
     "jest-standard-reporter": "^2.0.0",
@@ -69,7 +69,7 @@
     "typescript": "^4.6.2"
   },
   "peerDependencies": {
-    "@objectiv/schema": "^0.0.22",
-    "@objectiv/tracker-core": "^0.0.22"
+    "@objectiv/schema": "^0.0.23-2",
+    "@objectiv/tracker-core": "^0.0.23-2"
   }
 }

--- a/tracker/core/react/package.json
+++ b/tracker/core/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/tracker-react-core",
-  "version": "0.0.22",
+  "version": "0.0.23-2",
   "description": "Objectiv tracker core module for React trackers",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -51,10 +51,10 @@
     "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
-    "@objectiv/developer-tools": "^0.0.22",
-    "@objectiv/plugin-application-context": "^0.0.22",
-    "@objectiv/plugin-path-context-from-url": "^0.0.22",
-    "@objectiv/testing-tools": "^0.0.22",
+    "@objectiv/developer-tools": "^0.0.23-2",
+    "@objectiv/plugin-application-context": "^0.0.23-2",
+    "@objectiv/plugin-path-context-from-url": "^0.0.23-2",
+    "@objectiv/testing-tools": "^0.0.23-2",
     "@testing-library/react": "^12.1.4",
     "@testing-library/react-hooks": "^7.0.2",
     "@types/jest": "^27.4.1",
@@ -69,8 +69,8 @@
     "typescript": "^4.6.2"
   },
   "dependencies": {
-    "@objectiv/schema": "^0.0.22",
-    "@objectiv/tracker-core": "~0.0.22"
+    "@objectiv/schema": "^0.0.23-2",
+    "@objectiv/tracker-core": "~0.0.23-2"
   },
   "peerDependencies": {
     "react": ">=16.8",

--- a/tracker/core/react/src/hooks/useOnToggle.ts
+++ b/tracker/core/react/src/hooks/useOnToggle.ts
@@ -8,12 +8,15 @@ import { OnToggleEffectCallback } from '../types';
 /**
  * Monitors a boolean variable, or a predicate, and runs the given `trueEffect` or
  * `falseEffect` depending on the state value.
+ *
+ * If `falseEffect` is omitted, `trueEffect` is used for both states.
  */
 export const useOnToggle = (
   state: boolean | (() => boolean),
   trueEffect: OnToggleEffectCallback,
-  falseEffect: OnToggleEffectCallback
+  maybeFalseEffect?: OnToggleEffectCallback
 ) => {
+  const falseEffect = maybeFalseEffect ?? trueEffect;
   const stateValue = typeof state === 'function' ? state() : state;
   let previousStateRef = useRef<boolean>(stateValue);
   let latestTrueEffectRef = useRef(trueEffect);

--- a/tracker/core/react/tests/useOnToggle.test.ts
+++ b/tracker/core/react/tests/useOnToggle.test.ts
@@ -52,6 +52,30 @@ describe('useOnToggle', () => {
       expect(mockFalseEffectCallback).not.toHaveBeenCalled();
     });
 
+    it('should execute the given side effect callback on re-render each time state changes', () => {
+      const newState1 = true;
+      const newState2 = false;
+      const { rerender } = renderHook((state) => useOnToggle(state, mockTrueEffectCallback), {
+        initialProps: initialState,
+      });
+
+      rerender(newState1);
+      rerender(newState1);
+      rerender(newState1);
+
+      expect(mockTrueEffectCallback).toHaveBeenCalledTimes(1);
+      expect(mockTrueEffectCallback).toHaveBeenCalledWith(initialState, newState1);
+
+      jest.resetAllMocks();
+
+      rerender(newState2);
+      rerender(newState2);
+      rerender(newState2);
+
+      expect(mockTrueEffectCallback).toHaveBeenCalledTimes(1);
+      expect(mockTrueEffectCallback).toHaveBeenCalledWith(newState1, newState2);
+    });
+
     it('should execute the correct side effect callback on re-render each time state changes', () => {
       const newState1 = true;
       const newState2 = false;
@@ -166,6 +190,30 @@ describe('useOnToggle', () => {
 
       expect(mockTrueEffectCallback).not.toHaveBeenCalled();
       expect(mockFalseEffectCallback).not.toHaveBeenCalled();
+    });
+
+    it('should execute the given side effect callback on re-render each time state changes', () => {
+      const newState1 = () => true;
+      const newState2 = () => false;
+      const { rerender } = renderHook((state) => useOnToggle(state, mockTrueEffectCallback), {
+        initialProps: initialState,
+      });
+
+      rerender(newState1);
+      rerender(newState1);
+      rerender(newState1);
+
+      expect(mockTrueEffectCallback).toHaveBeenCalledTimes(1);
+      expect(mockTrueEffectCallback).toHaveBeenCalledWith(false, true);
+
+      jest.resetAllMocks();
+
+      rerender(newState2);
+      rerender(newState2);
+      rerender(newState2);
+
+      expect(mockTrueEffectCallback).toHaveBeenCalledTimes(1);
+      expect(mockTrueEffectCallback).toHaveBeenCalledWith(true, false);
     });
 
     it('should execute the correct side effect callback on re-render each time state changes', () => {

--- a/tracker/core/schema/package.json
+++ b/tracker/core/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/schema",
-  "version": "0.0.22",
+  "version": "0.0.23-2",
   "description": "Objectiv TypeScript implementation of the open analytics taxonomy",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",

--- a/tracker/core/testing-tools/package.json
+++ b/tracker/core/testing-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/testing-tools",
-  "version": "0.0.22",
+  "version": "0.0.23-2",
   "private": true,
   "license": "Apache-2.0",
   "description": "Mocks and other testing utilities shared across Objectiv Trackers",
@@ -14,7 +14,7 @@
     "check:dependencies": "npx depcheck"
   },
   "devDependencies": {
-    "@objectiv/tracker-core": "^0.0.22",
+    "@objectiv/tracker-core": "^0.0.23-2",
     "prettier": "^2.5.1",
     "typescript": "^4.6.2"
   }

--- a/tracker/core/tracker/package.json
+++ b/tracker/core/tracker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/tracker-core",
-  "version": "0.0.22",
+  "version": "0.0.23-2",
   "description": "Core functionality for Objectiv JavaScript trackers",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -50,7 +50,7 @@
     "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
-    "@objectiv/testing-tools": "^0.0.22",
+    "@objectiv/testing-tools": "^0.0.23-2",
     "@types/jest": "^27.4.1",
     "@types/uuid": "^8.3.4",
     "jest": "^27.5.1",
@@ -62,8 +62,8 @@
     "typescript": "^4.6.2"
   },
   "dependencies": {
-    "@objectiv/developer-tools": "^0.0.22",
-    "@objectiv/schema": "^0.0.22",
+    "@objectiv/developer-tools": "^0.0.23-2",
+    "@objectiv/schema": "^0.0.23-2",
     "uuid": "^8.3.2"
   }
 }

--- a/tracker/core/tracker/src/isAbstractContext.ts
+++ b/tracker/core/tracker/src/isAbstractContext.ts
@@ -15,7 +15,7 @@ export const isAbstractContext = (context: AbstractContext): context is Abstract
   }
 
   // Attributes check
-  if (!context.__instance_id || !context._type || !context.id) {
+  if (!context._type || !context.id) {
     return false;
   }
 

--- a/tracker/core/tracker/src/isContextEqual.ts
+++ b/tracker/core/tracker/src/isContextEqual.ts
@@ -7,17 +7,13 @@ import { getObjectKeys } from './helpers';
 import { isAbstractContext } from './isAbstractContext';
 
 /**
- * A predicate to match a Context to another. The comparison purposely ignores instance identifiers.
+ * A predicate to match Context instances.
  */
-export const isContextEqual = (contextA: AbstractContext, contextB: AbstractContext) => {
+export const isContextEqual = (a: AbstractContext, b: AbstractContext) => {
   // Input check
-  if (!isAbstractContext(contextA) || !isAbstractContext(contextB)) {
+  if (!isAbstractContext(a) || !isAbstractContext(b)) {
     return false;
   }
-
-  // Discard __instance_id by destructuring it out, as it's always different by design
-  const { __instance_id: _a, ...a } = contextA;
-  const { __instance_id: _b, ...b } = contextB;
 
   // Gather context A keys and length, reused in multiple tests below
   const aKeys = getObjectKeys(a);

--- a/tracker/core/tracker/tests/isContextEqual.test.ts
+++ b/tracker/core/tracker/tests/isContextEqual.test.ts
@@ -34,34 +34,30 @@ describe('isContextEqual', () => {
   });
 
   it(`should return false: attribute count mismatch`, () => {
-    const contextA = makePressableContext({ id: 'pressable-id' });
-    const contextB = makePressableContext({ id: 'pressable-id' });
-    const mutatedContextA = { ...contextA, customAttributeA: 1 };
-    expect(isContextEqual(mutatedContextA, contextB)).toBe(false);
-    expect(isContextEqual(contextB, mutatedContextA)).toBe(false);
+    const context = makePressableContext({ id: 'pressable-id' });
+    const mutatedContext = { ...context, customAttributeA: 1 };
+    expect(isContextEqual(mutatedContext, context)).toBe(false);
+    expect(isContextEqual(context, mutatedContext)).toBe(false);
   });
 
   it(`should return false: attribute name mismatch`, () => {
-    const contextA = makePressableContext({ id: 'pressable-id' });
-    const contextB = makePressableContext({ id: 'pressable-id' });
-    const mutatedContextA = { ...contextA, customAttributeA: 1 };
-    const mutatedContextB = { ...contextB, customAttributeB: 1 };
+    const context = makePressableContext({ id: 'pressable-id' });
+    const mutatedContextA = { ...context, customAttributeA: 1 };
+    const mutatedContextB = { ...context, customAttributeB: 1 };
     expect(isContextEqual(mutatedContextA, mutatedContextB)).toBe(false);
     expect(isContextEqual(mutatedContextB, mutatedContextA)).toBe(false);
   });
 
   it(`should return false: attribute value mismatch`, () => {
-    const contextA = makePressableContext({ id: 'pressable-id' });
-    const contextB = makePressableContext({ id: 'pressable-id' });
-    const mutatedContextA = { ...contextA, customAttribute: 1 };
-    const mutatedContextB = { ...contextB, customAttribute: 2 };
+    const context = makePressableContext({ id: 'pressable-id' });
+    const mutatedContextA = { ...context, customAttribute: 1 };
+    const mutatedContextB = { ...context, customAttribute: 2 };
     expect(isContextEqual(mutatedContextA, mutatedContextB)).toBe(false);
     expect(isContextEqual(mutatedContextB, mutatedContextA)).toBe(false);
   });
 
   it(`should return true: different instances of identical contexts`, () => {
-    const contextA = makePressableContext({ id: 'pressable-id' });
-    const contextB = makePressableContext({ id: 'pressable-id' });
-    expect(isContextEqual(contextA, contextB)).toBe(true);
+    const context = makePressableContext({ id: 'pressable-id' });
+    expect(isContextEqual(context, context)).toBe(true);
   });
 });

--- a/tracker/core/utilities/package.json
+++ b/tracker/core/utilities/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/utilities",
-  "version": "0.0.22",
+  "version": "0.0.23-2",
   "private": true,
   "license": "Apache-2.0",
   "description": "Objectiv Core Utilities",

--- a/tracker/plugins/application-context/package.json
+++ b/tracker/plugins/application-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/plugin-application-context",
-  "version": "0.0.22",
+  "version": "0.0.23-2",
   "description": "Plugin for Objectiv trackers to automatically generate and attach ApplicationContext to all Events",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -52,9 +52,9 @@
     "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
-    "@objectiv/developer-tools": "^0.0.22",
-    "@objectiv/schema": "^0.0.22",
-    "@objectiv/testing-tools": "^0.0.22",
+    "@objectiv/developer-tools": "^0.0.23-2",
+    "@objectiv/schema": "^0.0.23-2",
+    "@objectiv/testing-tools": "^0.0.23-2",
     "@types/jest": "^27.4.1",
     "jest": "^27.5.1",
     "jest-standard-reporter": "^2.0.0",
@@ -64,6 +64,6 @@
     "typescript": "^4.6.2"
   },
   "peerDependencies": {
-    "@objectiv/tracker-core": "^0.0.22"
+    "@objectiv/tracker-core": "^0.0.23-2"
   }
 }

--- a/tracker/plugins/http-context/package.json
+++ b/tracker/plugins/http-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/plugin-http-context",
-  "version": "0.0.22",
+  "version": "0.0.23-2",
   "description": "Plugin for Objectiv trackers to automatically generate and attach HttpContext from document and navigator APIs",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -54,8 +54,8 @@
     "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
-    "@objectiv/developer-tools": "^0.0.22",
-    "@objectiv/testing-tools": "^0.0.22",
+    "@objectiv/developer-tools": "^0.0.23-2",
+    "@objectiv/testing-tools": "^0.0.23-2",
     "@types/jest": "^27.4.1",
     "jest": "^27.5.1",
     "jest-extended": "^2.0.0",
@@ -66,6 +66,6 @@
     "typescript": "^4.6.2"
   },
   "peerDependencies": {
-    "@objectiv/tracker-core": "^0.0.22"
+    "@objectiv/tracker-core": "^0.0.23-2"
   }
 }

--- a/tracker/plugins/identity-context/package.json
+++ b/tracker/plugins/identity-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/plugin-identity-context",
-  "version": "0.0.22",
+  "version": "0.0.23-2",
   "description": "Plugin for Objectiv trackers to generate IdentityContext instances",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -53,9 +53,9 @@
     "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
-    "@objectiv/developer-tools": "^0.0.22",
-    "@objectiv/plugin-identity-context": "^0.0.22",
-    "@objectiv/testing-tools": "^0.0.22",
+    "@objectiv/developer-tools": "^0.0.23-2",
+    "@objectiv/plugin-identity-context": "^0.0.23-2",
+    "@objectiv/testing-tools": "^0.0.23-2",
     "@types/jest": "^27.4.1",
     "jest": "^27.5.1",
     "jest-standard-reporter": "^2.0.0",
@@ -65,6 +65,6 @@
     "typescript": "^4.6.2"
   },
   "peerDependencies": {
-    "@objectiv/tracker-core": "^0.0.22"
+    "@objectiv/tracker-core": "^0.0.23-2"
   }
 }

--- a/tracker/plugins/locale-context/package.json
+++ b/tracker/plugins/locale-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/plugin-locale-context",
-  "version": "0.0.22",
+  "version": "0.0.23-2",
   "description": "Plugin for Objectiv trackers to automatically generate and attach LocaleContext",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -52,8 +52,8 @@
     "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
-    "@objectiv/developer-tools": "^0.0.22",
-    "@objectiv/testing-tools": "^0.0.22",
+    "@objectiv/developer-tools": "^0.0.23-2",
+    "@objectiv/testing-tools": "^0.0.23-2",
     "@types/jest": "^27.4.1",
     "jest": "^27.5.1",
     "jest-extended": "^2.0.0",
@@ -64,6 +64,6 @@
     "typescript": "^4.6.2"
   },
   "peerDependencies": {
-    "@objectiv/tracker-core": "^0.0.22"
+    "@objectiv/tracker-core": "^0.0.23-2"
   }
 }

--- a/tracker/plugins/path-context-from-url/package.json
+++ b/tracker/plugins/path-context-from-url/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/plugin-path-context-from-url",
-  "version": "0.0.22",
+  "version": "0.0.23-2",
   "description": "Plugin for Objectiv trackers to automatically generate and attach PathContext from URLs",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -52,8 +52,8 @@
     "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
-    "@objectiv/developer-tools": "^0.0.22",
-    "@objectiv/testing-tools": "^0.0.22",
+    "@objectiv/developer-tools": "^0.0.23-2",
+    "@objectiv/testing-tools": "^0.0.23-2",
     "@types/jest": "^27.4.1",
     "jest": "^27.5.1",
     "jest-extended": "^2.0.0",
@@ -64,6 +64,6 @@
     "typescript": "^4.6.2"
   },
   "peerDependencies": {
-    "@objectiv/tracker-core": "^0.0.22"
+    "@objectiv/tracker-core": "^0.0.23-2"
   }
 }

--- a/tracker/plugins/react-navigation/package.json
+++ b/tracker/plugins/react-navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/plugin-react-navigation",
-  "version": "0.0.22",
+  "version": "0.0.23-2",
   "description": "Automatically tracked React Navigation 6+ Components, listeners and state for Objectiv React Native Tracker",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -53,12 +53,12 @@
     "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "dependencies": {
-    "@objectiv/tracker-react-core": "^0.0.22",
-    "@objectiv/tracker-react-native": "^0.0.22"
+    "@objectiv/tracker-react-core": "^0.0.23-2",
+    "@objectiv/tracker-react-native": "^0.0.23-2"
   },
   "devDependencies": {
-    "@objectiv/developer-tools": "^0.0.22",
-    "@objectiv/testing-tools": "^0.0.22",
+    "@objectiv/developer-tools": "^0.0.23-2",
+    "@objectiv/testing-tools": "^0.0.23-2",
     "@react-navigation/bottom-tabs": "^6.2.0",
     "@react-navigation/core": "^6.1.1",
     "@react-navigation/native": "^6.0.8",

--- a/tracker/plugins/react-router-tracked-components/package.json
+++ b/tracker/plugins/react-router-tracked-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/plugin-react-router-tracked-components",
-  "version": "0.0.22",
+  "version": "0.0.23-2",
   "description": "React Router 6 automatically tracked Link and NavLink Components for Objectiv React Tracker",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -54,12 +54,12 @@
     "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "dependencies": {
-    "@objectiv/tracker-core": "^0.0.22",
-    "@objectiv/tracker-react": "^0.0.22"
+    "@objectiv/tracker-core": "^0.0.23-2",
+    "@objectiv/tracker-react": "^0.0.23-2"
   },
   "devDependencies": {
-    "@objectiv/developer-tools": "^0.0.22",
-    "@objectiv/testing-tools": "^0.0.22",
+    "@objectiv/developer-tools": "^0.0.23-2",
+    "@objectiv/testing-tools": "^0.0.23-2",
     "@testing-library/react": "^12.1.4",
     "@types/jest": "^27.4.1",
     "jest": "^27.5.1",

--- a/tracker/plugins/root-location-context-from-url/package.json
+++ b/tracker/plugins/root-location-context-from-url/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/plugin-root-location-context-from-url",
-  "version": "0.0.22",
+  "version": "0.0.23-2",
   "description": "Plugin for Objectiv trackers to automatically generate and attach RootLocationContext from URLs",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -53,8 +53,8 @@
     "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
-    "@objectiv/developer-tools": "^0.0.22",
-    "@objectiv/testing-tools": "^0.0.22",
+    "@objectiv/developer-tools": "^0.0.23-2",
+    "@objectiv/testing-tools": "^0.0.23-2",
     "@types/jest": "^27.4.1",
     "jest": "^27.5.1",
     "jest-extended": "^2.0.0",
@@ -65,6 +65,6 @@
     "typescript": "^4.6.2"
   },
   "peerDependencies": {
-    "@objectiv/tracker-core": "^0.0.22"
+    "@objectiv/tracker-core": "^0.0.23-2"
   }
 }

--- a/tracker/queues/local-storage/package.json
+++ b/tracker/queues/local-storage/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/queue-local-storage",
-  "version": "0.0.22",
+  "version": "0.0.23-2",
   "description": "A TrackerQueueStore based on localStorage API",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -51,8 +51,8 @@
     "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
-    "@objectiv/developer-tools": "^0.0.22",
-    "@objectiv/testing-tools": "^0.0.22",
+    "@objectiv/developer-tools": "^0.0.23-2",
+    "@objectiv/testing-tools": "^0.0.23-2",
     "@types/jest": "^27.4.1",
     "jest": "^27.5.1",
     "jest-standard-reporter": "^2.0.0",
@@ -62,6 +62,6 @@
     "typescript": "^4.6.2"
   },
   "dependencies": {
-    "@objectiv/tracker-core": "~0.0.22"
+    "@objectiv/tracker-core": "~0.0.23-2"
   }
 }

--- a/tracker/trackers/angular/package.json
+++ b/tracker/trackers/angular/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/tracker-angular",
-  "version": "0.0.22",
+  "version": "0.0.23-2",
   "description": "Objectiv Angular framework analytics tracker for the open analytics taxonomy",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -38,13 +38,13 @@
   "peerDependencies": {
     "@angular/common": "^9.0.0",
     "@angular/core": "^9.0.0",
-    "@objectiv/tracker-browser": "^0.0.22"
+    "@objectiv/tracker-browser": "^0.0.23-2"
   },
   "devDependencies": {
     "@angular/compiler": "~9.1.13",
     "@angular/compiler-cli": "~9.1.13",
     "@angular/core": "~9.1.13",
-    "@objectiv/tracker-browser": "^0.0.22",
+    "@objectiv/tracker-browser": "^0.0.23-2",
     "ng-packagr": "^9.0.0",
     "prettier": "^2.5.1",
     "rxjs": "~6.5.4",

--- a/tracker/trackers/browser/package.json
+++ b/tracker/trackers/browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/tracker-browser",
-  "version": "0.0.22",
+  "version": "0.0.23-2",
   "description": "Objectiv Web application analytics tracker for the open analytics taxonomy",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -50,8 +50,8 @@
     "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
-    "@objectiv/developer-tools": "^0.0.22",
-    "@objectiv/testing-tools": "^0.0.22",
+    "@objectiv/developer-tools": "^0.0.23-2",
+    "@objectiv/testing-tools": "^0.0.23-2",
     "@types/jest": "^27.4.1",
     "jest": "^27.5.1",
     "jest-fetch-mock": "^3.0.3",
@@ -63,15 +63,15 @@
     "typescript": "^4.6.2"
   },
   "dependencies": {
-    "@objectiv/plugin-application-context": "^0.0.22",
-    "@objectiv/plugin-http-context": "^0.0.22",
-    "@objectiv/plugin-path-context-from-url": "^0.0.22",
-    "@objectiv/plugin-root-location-context-from-url": "^0.0.22",
-    "@objectiv/queue-local-storage": "^0.0.22",
-    "@objectiv/schema": "^0.0.22",
-    "@objectiv/tracker-core": "^0.0.22",
-    "@objectiv/transport-debug": "^0.0.22",
-    "@objectiv/transport-fetch": "^0.0.22",
-    "@objectiv/transport-xhr": "^0.0.22"
+    "@objectiv/plugin-application-context": "^0.0.23-2",
+    "@objectiv/plugin-http-context": "^0.0.23-2",
+    "@objectiv/plugin-path-context-from-url": "^0.0.23-2",
+    "@objectiv/plugin-root-location-context-from-url": "^0.0.23-2",
+    "@objectiv/queue-local-storage": "^0.0.23-2",
+    "@objectiv/schema": "^0.0.23-2",
+    "@objectiv/tracker-core": "^0.0.23-2",
+    "@objectiv/transport-debug": "^0.0.23-2",
+    "@objectiv/transport-fetch": "^0.0.23-2",
+    "@objectiv/transport-xhr": "^0.0.23-2"
   }
 }

--- a/tracker/trackers/react-native/package.json
+++ b/tracker/trackers/react-native/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/tracker-react-native",
-  "version": "0.0.22",
+  "version": "0.0.23-2",
   "description": "Objectiv React Native application analytics tracker the open analytics taxonomy",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -50,10 +50,10 @@
     "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
-    "@objectiv/developer-tools": "^0.0.22",
-    "@objectiv/plugin-root-location-context-from-url": "^0.0.22",
-    "@objectiv/testing-tools": "^0.0.22",
-    "@objectiv/transport-debug": "^0.0.22",
+    "@objectiv/developer-tools": "^0.0.23-2",
+    "@objectiv/plugin-root-location-context-from-url": "^0.0.23-2",
+    "@objectiv/testing-tools": "^0.0.23-2",
+    "@objectiv/transport-debug": "^0.0.23-2",
     "@testing-library/react-native": "^9.0.0",
     "@types/react-native": "^0.67.2",
     "jest": "^27.5.1",
@@ -66,10 +66,10 @@
     "typescript": "^4.6.2"
   },
   "dependencies": {
-    "@objectiv/plugin-application-context": "^0.0.22",
-    "@objectiv/tracker-core": "~0.0.22",
-    "@objectiv/tracker-react-core": "~0.0.22",
-    "@objectiv/transport-fetch": "^0.0.22",
+    "@objectiv/plugin-application-context": "^0.0.23-2",
+    "@objectiv/tracker-core": "~0.0.23-2",
+    "@objectiv/tracker-react-core": "~0.0.23-2",
+    "@objectiv/transport-fetch": "^0.0.23-2",
     "react-native-get-random-values": "^1.7.2"
   },
   "peerDependencies": {

--- a/tracker/trackers/react/package.json
+++ b/tracker/trackers/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/tracker-react",
-  "version": "0.0.22",
+  "version": "0.0.23-2",
   "description": "Objectiv React application analytics tracker for the open analytics taxonomy",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -50,9 +50,9 @@
     "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
-    "@objectiv/developer-tools": "^0.0.22",
-    "@objectiv/testing-tools": "^0.0.22",
-    "@objectiv/transport-debug": "^0.0.22",
+    "@objectiv/developer-tools": "^0.0.23-2",
+    "@objectiv/testing-tools": "^0.0.23-2",
+    "@objectiv/transport-debug": "^0.0.23-2",
     "@testing-library/react": "^12.1.4",
     "@types/jest": "^27.4.1",
     "@types/react": "^17.0.39",
@@ -68,17 +68,17 @@
     "typescript": "^4.6.2"
   },
   "dependencies": {
-    "@objectiv/plugin-application-context": "^0.0.22",
-    "@objectiv/plugin-http-context": "^0.0.22",
-    "@objectiv/plugin-identity-context": "^0.0.22",
-    "@objectiv/plugin-path-context-from-url": "^0.0.22",
-    "@objectiv/plugin-root-location-context-from-url": "^0.0.22",
-    "@objectiv/queue-local-storage": "^0.0.22",
-    "@objectiv/schema": "^0.0.22",
-    "@objectiv/tracker-core": "~0.0.22",
-    "@objectiv/tracker-react-core": "~0.0.22",
-    "@objectiv/transport-fetch": "^0.0.22",
-    "@objectiv/transport-xhr": "^0.0.22"
+    "@objectiv/plugin-application-context": "^0.0.23-2",
+    "@objectiv/plugin-http-context": "^0.0.23-2",
+    "@objectiv/plugin-identity-context": "^0.0.23-2",
+    "@objectiv/plugin-path-context-from-url": "^0.0.23-2",
+    "@objectiv/plugin-root-location-context-from-url": "^0.0.23-2",
+    "@objectiv/queue-local-storage": "^0.0.23-2",
+    "@objectiv/schema": "^0.0.23-2",
+    "@objectiv/tracker-core": "~0.0.23-2",
+    "@objectiv/tracker-react-core": "~0.0.23-2",
+    "@objectiv/transport-fetch": "^0.0.23-2",
+    "@objectiv/transport-xhr": "^0.0.23-2"
   },
   "peerDependencies": {
     "react": ">=16.8",

--- a/tracker/transports/debug/package.json
+++ b/tracker/transports/debug/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/transport-debug",
-  "version": "0.0.22",
+  "version": "0.0.23-2",
   "description": "A TrackerTransport that logs incoming events to console.debug",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -61,6 +61,6 @@
     "typescript": "^4.6.2"
   },
   "dependencies": {
-    "@objectiv/tracker-core": "~0.0.22"
+    "@objectiv/tracker-core": "~0.0.23-2"
   }
 }

--- a/tracker/transports/fetch/package.json
+++ b/tracker/transports/fetch/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/transport-fetch",
-  "version": "0.0.22",
+  "version": "0.0.23-2",
   "description": "A TrackerTransport based on Fetch API",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -51,8 +51,8 @@
     "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
-    "@objectiv/developer-tools": "^0.0.22",
-    "@objectiv/testing-tools": "^0.0.22",
+    "@objectiv/developer-tools": "^0.0.23-2",
+    "@objectiv/testing-tools": "^0.0.23-2",
     "@types/jest": "^27.4.1",
     "jest": "^27.5.1",
     "jest-fetch-mock": "^3.0.3",
@@ -63,6 +63,6 @@
     "typescript": "^4.6.2"
   },
   "dependencies": {
-    "@objectiv/tracker-core": "~0.0.22"
+    "@objectiv/tracker-core": "~0.0.23-2"
   }
 }

--- a/tracker/transports/xhr/package.json
+++ b/tracker/transports/xhr/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@objectiv/transport-xhr",
-  "version": "0.0.22",
+  "version": "0.0.23-2",
   "description": "A TrackerTransport based on XMLHttpRequest API",
   "license": "Apache-2.0",
   "homepage": "https://objectiv.io",
@@ -52,8 +52,8 @@
     "npm-publish:verdaccio": "npm publish --tag=$TAG"
   },
   "devDependencies": {
-    "@objectiv/developer-tools": "^0.0.22",
-    "@objectiv/testing-tools": "^0.0.22",
+    "@objectiv/developer-tools": "^0.0.23-2",
+    "@objectiv/testing-tools": "^0.0.23-2",
     "@types/jest": "^27.4.1",
     "jest": "^27.5.1",
     "jest-standard-reporter": "^2.0.0",
@@ -64,6 +64,6 @@
     "xhr-mock": "^2.5.1"
   },
   "dependencies": {
-    "@objectiv/tracker-core": "~0.0.22"
+    "@objectiv/tracker-core": "~0.0.23-2"
   }
 }

--- a/tracker/yarn.lock
+++ b/tracker/yarn.lock
@@ -1505,13 +1505,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@objectiv/developer-tools@^0.0.22, @objectiv/developer-tools@workspace:core/developer-tools":
+"@objectiv/developer-tools@^0.0.23-2, @objectiv/developer-tools@workspace:core/developer-tools":
   version: 0.0.0-use.local
   resolution: "@objectiv/developer-tools@workspace:core/developer-tools"
   dependencies:
-    "@objectiv/developer-tools": ^0.0.22
-    "@objectiv/testing-tools": ^0.0.22
-    "@objectiv/tracker-core": ^0.0.22
+    "@objectiv/developer-tools": ^0.0.23-2
+    "@objectiv/testing-tools": ^0.0.23-2
+    "@objectiv/tracker-core": ^0.0.23-2
     "@types/jest": ^27.4.1
     jest: ^27.5.1
     jest-standard-reporter: ^2.0.0
@@ -1522,18 +1522,18 @@ __metadata:
     tsup: ^5.12.0
     typescript: ^4.6.2
   peerDependencies:
-    "@objectiv/schema": ^0.0.22
-    "@objectiv/tracker-core": ^0.0.22
+    "@objectiv/schema": ^0.0.23-2
+    "@objectiv/tracker-core": ^0.0.23-2
   languageName: unknown
   linkType: soft
 
-"@objectiv/plugin-application-context@^0.0.22, @objectiv/plugin-application-context@workspace:plugins/application-context":
+"@objectiv/plugin-application-context@^0.0.23-2, @objectiv/plugin-application-context@workspace:plugins/application-context":
   version: 0.0.0-use.local
   resolution: "@objectiv/plugin-application-context@workspace:plugins/application-context"
   dependencies:
-    "@objectiv/developer-tools": ^0.0.22
-    "@objectiv/schema": ^0.0.22
-    "@objectiv/testing-tools": ^0.0.22
+    "@objectiv/developer-tools": ^0.0.23-2
+    "@objectiv/schema": ^0.0.23-2
+    "@objectiv/testing-tools": ^0.0.23-2
     "@types/jest": ^27.4.1
     jest: ^27.5.1
     jest-standard-reporter: ^2.0.0
@@ -1542,16 +1542,16 @@ __metadata:
     tsup: ^5.12.0
     typescript: ^4.6.2
   peerDependencies:
-    "@objectiv/tracker-core": ^0.0.22
+    "@objectiv/tracker-core": ^0.0.23-2
   languageName: unknown
   linkType: soft
 
-"@objectiv/plugin-http-context@^0.0.22, @objectiv/plugin-http-context@workspace:plugins/http-context":
+"@objectiv/plugin-http-context@^0.0.23-2, @objectiv/plugin-http-context@workspace:plugins/http-context":
   version: 0.0.0-use.local
   resolution: "@objectiv/plugin-http-context@workspace:plugins/http-context"
   dependencies:
-    "@objectiv/developer-tools": ^0.0.22
-    "@objectiv/testing-tools": ^0.0.22
+    "@objectiv/developer-tools": ^0.0.23-2
+    "@objectiv/testing-tools": ^0.0.23-2
     "@types/jest": ^27.4.1
     jest: ^27.5.1
     jest-extended: ^2.0.0
@@ -1561,17 +1561,17 @@ __metadata:
     tsup: ^5.12.0
     typescript: ^4.6.2
   peerDependencies:
-    "@objectiv/tracker-core": ^0.0.22
+    "@objectiv/tracker-core": ^0.0.23-2
   languageName: unknown
   linkType: soft
 
-"@objectiv/plugin-identity-context@^0.0.22, @objectiv/plugin-identity-context@workspace:plugins/identity-context":
+"@objectiv/plugin-identity-context@^0.0.23-2, @objectiv/plugin-identity-context@workspace:plugins/identity-context":
   version: 0.0.0-use.local
   resolution: "@objectiv/plugin-identity-context@workspace:plugins/identity-context"
   dependencies:
-    "@objectiv/developer-tools": ^0.0.22
-    "@objectiv/plugin-identity-context": ^0.0.22
-    "@objectiv/testing-tools": ^0.0.22
+    "@objectiv/developer-tools": ^0.0.23-2
+    "@objectiv/plugin-identity-context": ^0.0.23-2
+    "@objectiv/testing-tools": ^0.0.23-2
     "@types/jest": ^27.4.1
     jest: ^27.5.1
     jest-standard-reporter: ^2.0.0
@@ -1580,7 +1580,7 @@ __metadata:
     tsup: ^5.12.0
     typescript: ^4.6.2
   peerDependencies:
-    "@objectiv/tracker-core": ^0.0.22
+    "@objectiv/tracker-core": ^0.0.23-2
   languageName: unknown
   linkType: soft
 
@@ -1588,8 +1588,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@objectiv/plugin-locale-context@workspace:plugins/locale-context"
   dependencies:
-    "@objectiv/developer-tools": ^0.0.22
-    "@objectiv/testing-tools": ^0.0.22
+    "@objectiv/developer-tools": ^0.0.23-2
+    "@objectiv/testing-tools": ^0.0.23-2
     "@types/jest": ^27.4.1
     jest: ^27.5.1
     jest-extended: ^2.0.0
@@ -1599,16 +1599,16 @@ __metadata:
     tsup: ^5.12.0
     typescript: ^4.6.2
   peerDependencies:
-    "@objectiv/tracker-core": ^0.0.22
+    "@objectiv/tracker-core": ^0.0.23-2
   languageName: unknown
   linkType: soft
 
-"@objectiv/plugin-path-context-from-url@^0.0.22, @objectiv/plugin-path-context-from-url@workspace:plugins/path-context-from-url":
+"@objectiv/plugin-path-context-from-url@^0.0.23-2, @objectiv/plugin-path-context-from-url@workspace:plugins/path-context-from-url":
   version: 0.0.0-use.local
   resolution: "@objectiv/plugin-path-context-from-url@workspace:plugins/path-context-from-url"
   dependencies:
-    "@objectiv/developer-tools": ^0.0.22
-    "@objectiv/testing-tools": ^0.0.22
+    "@objectiv/developer-tools": ^0.0.23-2
+    "@objectiv/testing-tools": ^0.0.23-2
     "@types/jest": ^27.4.1
     jest: ^27.5.1
     jest-extended: ^2.0.0
@@ -1618,7 +1618,7 @@ __metadata:
     tsup: ^5.12.0
     typescript: ^4.6.2
   peerDependencies:
-    "@objectiv/tracker-core": ^0.0.22
+    "@objectiv/tracker-core": ^0.0.23-2
   languageName: unknown
   linkType: soft
 
@@ -1626,10 +1626,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@objectiv/plugin-react-navigation@workspace:plugins/react-navigation"
   dependencies:
-    "@objectiv/developer-tools": ^0.0.22
-    "@objectiv/testing-tools": ^0.0.22
-    "@objectiv/tracker-react-core": ^0.0.22
-    "@objectiv/tracker-react-native": ^0.0.22
+    "@objectiv/developer-tools": ^0.0.23-2
+    "@objectiv/testing-tools": ^0.0.23-2
+    "@objectiv/tracker-react-core": ^0.0.23-2
+    "@objectiv/tracker-react-native": ^0.0.23-2
     "@react-navigation/bottom-tabs": ^6.2.0
     "@react-navigation/core": ^6.1.1
     "@react-navigation/native": ^6.0.8
@@ -1658,10 +1658,10 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@objectiv/plugin-react-router-tracked-components@workspace:plugins/react-router-tracked-components"
   dependencies:
-    "@objectiv/developer-tools": ^0.0.22
-    "@objectiv/testing-tools": ^0.0.22
-    "@objectiv/tracker-core": ^0.0.22
-    "@objectiv/tracker-react": ^0.0.22
+    "@objectiv/developer-tools": ^0.0.23-2
+    "@objectiv/testing-tools": ^0.0.23-2
+    "@objectiv/tracker-core": ^0.0.23-2
+    "@objectiv/tracker-react": ^0.0.23-2
     "@testing-library/react": ^12.1.4
     "@types/jest": ^27.4.1
     jest: ^27.5.1
@@ -1678,12 +1678,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@objectiv/plugin-root-location-context-from-url@^0.0.22, @objectiv/plugin-root-location-context-from-url@workspace:plugins/root-location-context-from-url":
+"@objectiv/plugin-root-location-context-from-url@^0.0.23-2, @objectiv/plugin-root-location-context-from-url@workspace:plugins/root-location-context-from-url":
   version: 0.0.0-use.local
   resolution: "@objectiv/plugin-root-location-context-from-url@workspace:plugins/root-location-context-from-url"
   dependencies:
-    "@objectiv/developer-tools": ^0.0.22
-    "@objectiv/testing-tools": ^0.0.22
+    "@objectiv/developer-tools": ^0.0.23-2
+    "@objectiv/testing-tools": ^0.0.23-2
     "@types/jest": ^27.4.1
     jest: ^27.5.1
     jest-extended: ^2.0.0
@@ -1693,17 +1693,17 @@ __metadata:
     tsup: ^5.12.0
     typescript: ^4.6.2
   peerDependencies:
-    "@objectiv/tracker-core": ^0.0.22
+    "@objectiv/tracker-core": ^0.0.23-2
   languageName: unknown
   linkType: soft
 
-"@objectiv/queue-local-storage@^0.0.22, @objectiv/queue-local-storage@workspace:queues/local-storage":
+"@objectiv/queue-local-storage@^0.0.23-2, @objectiv/queue-local-storage@workspace:queues/local-storage":
   version: 0.0.0-use.local
   resolution: "@objectiv/queue-local-storage@workspace:queues/local-storage"
   dependencies:
-    "@objectiv/developer-tools": ^0.0.22
-    "@objectiv/testing-tools": ^0.0.22
-    "@objectiv/tracker-core": ~0.0.22
+    "@objectiv/developer-tools": ^0.0.23-2
+    "@objectiv/testing-tools": ^0.0.23-2
+    "@objectiv/tracker-core": ~0.0.23-2
     "@types/jest": ^27.4.1
     jest: ^27.5.1
     jest-standard-reporter: ^2.0.0
@@ -1714,7 +1714,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@objectiv/schema@^0.0.22, @objectiv/schema@workspace:core/schema":
+"@objectiv/schema@^0.0.23-2, @objectiv/schema@workspace:core/schema":
   version: 0.0.0-use.local
   resolution: "@objectiv/schema@workspace:core/schema"
   dependencies:
@@ -1723,11 +1723,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@objectiv/testing-tools@^0.0.22, @objectiv/testing-tools@workspace:core/testing-tools":
+"@objectiv/testing-tools@^0.0.23-2, @objectiv/testing-tools@workspace:core/testing-tools":
   version: 0.0.0-use.local
   resolution: "@objectiv/testing-tools@workspace:core/testing-tools"
   dependencies:
-    "@objectiv/tracker-core": ^0.0.22
+    "@objectiv/tracker-core": ^0.0.23-2
     prettier: ^2.5.1
     typescript: ^4.6.2
   languageName: unknown
@@ -1740,7 +1740,7 @@ __metadata:
     "@angular/compiler": ~9.1.13
     "@angular/compiler-cli": ~9.1.13
     "@angular/core": ~9.1.13
-    "@objectiv/tracker-browser": ^0.0.22
+    "@objectiv/tracker-browser": ^0.0.23-2
     ng-packagr: ^9.0.0
     prettier: ^2.5.1
     rxjs: ~6.5.4
@@ -1750,26 +1750,26 @@ __metadata:
   peerDependencies:
     "@angular/common": ^9.0.0
     "@angular/core": ^9.0.0
-    "@objectiv/tracker-browser": ^0.0.22
+    "@objectiv/tracker-browser": ^0.0.23-2
   languageName: unknown
   linkType: soft
 
-"@objectiv/tracker-browser@^0.0.22, @objectiv/tracker-browser@workspace:trackers/browser":
+"@objectiv/tracker-browser@^0.0.23-2, @objectiv/tracker-browser@workspace:trackers/browser":
   version: 0.0.0-use.local
   resolution: "@objectiv/tracker-browser@workspace:trackers/browser"
   dependencies:
-    "@objectiv/developer-tools": ^0.0.22
-    "@objectiv/plugin-application-context": ^0.0.22
-    "@objectiv/plugin-http-context": ^0.0.22
-    "@objectiv/plugin-path-context-from-url": ^0.0.22
-    "@objectiv/plugin-root-location-context-from-url": ^0.0.22
-    "@objectiv/queue-local-storage": ^0.0.22
-    "@objectiv/schema": ^0.0.22
-    "@objectiv/testing-tools": ^0.0.22
-    "@objectiv/tracker-core": ^0.0.22
-    "@objectiv/transport-debug": ^0.0.22
-    "@objectiv/transport-fetch": ^0.0.22
-    "@objectiv/transport-xhr": ^0.0.22
+    "@objectiv/developer-tools": ^0.0.23-2
+    "@objectiv/plugin-application-context": ^0.0.23-2
+    "@objectiv/plugin-http-context": ^0.0.23-2
+    "@objectiv/plugin-path-context-from-url": ^0.0.23-2
+    "@objectiv/plugin-root-location-context-from-url": ^0.0.23-2
+    "@objectiv/queue-local-storage": ^0.0.23-2
+    "@objectiv/schema": ^0.0.23-2
+    "@objectiv/testing-tools": ^0.0.23-2
+    "@objectiv/tracker-core": ^0.0.23-2
+    "@objectiv/transport-debug": ^0.0.23-2
+    "@objectiv/transport-fetch": ^0.0.23-2
+    "@objectiv/transport-xhr": ^0.0.23-2
     "@types/jest": ^27.4.1
     jest: ^27.5.1
     jest-fetch-mock: ^3.0.3
@@ -1782,13 +1782,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@objectiv/tracker-core@^0.0.22, @objectiv/tracker-core@workspace:core/tracker, @objectiv/tracker-core@~0.0.22":
+"@objectiv/tracker-core@^0.0.23-2, @objectiv/tracker-core@workspace:core/tracker, @objectiv/tracker-core@~0.0.23-2":
   version: 0.0.0-use.local
   resolution: "@objectiv/tracker-core@workspace:core/tracker"
   dependencies:
-    "@objectiv/developer-tools": ^0.0.22
-    "@objectiv/schema": ^0.0.22
-    "@objectiv/testing-tools": ^0.0.22
+    "@objectiv/developer-tools": ^0.0.23-2
+    "@objectiv/schema": ^0.0.23-2
+    "@objectiv/testing-tools": ^0.0.23-2
     "@types/jest": ^27.4.1
     "@types/uuid": ^8.3.4
     jest: ^27.5.1
@@ -1802,16 +1802,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@objectiv/tracker-react-core@^0.0.22, @objectiv/tracker-react-core@workspace:core/react, @objectiv/tracker-react-core@~0.0.22":
+"@objectiv/tracker-react-core@^0.0.23-2, @objectiv/tracker-react-core@workspace:core/react, @objectiv/tracker-react-core@~0.0.23-2":
   version: 0.0.0-use.local
   resolution: "@objectiv/tracker-react-core@workspace:core/react"
   dependencies:
-    "@objectiv/developer-tools": ^0.0.22
-    "@objectiv/plugin-application-context": ^0.0.22
-    "@objectiv/plugin-path-context-from-url": ^0.0.22
-    "@objectiv/schema": ^0.0.22
-    "@objectiv/testing-tools": ^0.0.22
-    "@objectiv/tracker-core": ~0.0.22
+    "@objectiv/developer-tools": ^0.0.23-2
+    "@objectiv/plugin-application-context": ^0.0.23-2
+    "@objectiv/plugin-path-context-from-url": ^0.0.23-2
+    "@objectiv/schema": ^0.0.23-2
+    "@objectiv/testing-tools": ^0.0.23-2
+    "@objectiv/tracker-core": ~0.0.23-2
     "@testing-library/react": ^12.1.4
     "@testing-library/react-hooks": ^7.0.2
     "@types/jest": ^27.4.1
@@ -1830,18 +1830,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@objectiv/tracker-react-native@^0.0.22, @objectiv/tracker-react-native@workspace:trackers/react-native":
+"@objectiv/tracker-react-native@^0.0.23-2, @objectiv/tracker-react-native@workspace:trackers/react-native":
   version: 0.0.0-use.local
   resolution: "@objectiv/tracker-react-native@workspace:trackers/react-native"
   dependencies:
-    "@objectiv/developer-tools": ^0.0.22
-    "@objectiv/plugin-application-context": ^0.0.22
-    "@objectiv/plugin-root-location-context-from-url": ^0.0.22
-    "@objectiv/testing-tools": ^0.0.22
-    "@objectiv/tracker-core": ~0.0.22
-    "@objectiv/tracker-react-core": ~0.0.22
-    "@objectiv/transport-debug": ^0.0.22
-    "@objectiv/transport-fetch": ^0.0.22
+    "@objectiv/developer-tools": ^0.0.23-2
+    "@objectiv/plugin-application-context": ^0.0.23-2
+    "@objectiv/plugin-root-location-context-from-url": ^0.0.23-2
+    "@objectiv/testing-tools": ^0.0.23-2
+    "@objectiv/tracker-core": ~0.0.23-2
+    "@objectiv/tracker-react-core": ~0.0.23-2
+    "@objectiv/transport-debug": ^0.0.23-2
+    "@objectiv/transport-fetch": ^0.0.23-2
     "@testing-library/react-native": ^9.0.0
     "@types/react-native": ^0.67.2
     jest: ^27.5.1
@@ -1859,24 +1859,24 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@objectiv/tracker-react@^0.0.22, @objectiv/tracker-react@workspace:trackers/react":
+"@objectiv/tracker-react@^0.0.23-2, @objectiv/tracker-react@workspace:trackers/react":
   version: 0.0.0-use.local
   resolution: "@objectiv/tracker-react@workspace:trackers/react"
   dependencies:
-    "@objectiv/developer-tools": ^0.0.22
-    "@objectiv/plugin-application-context": ^0.0.22
-    "@objectiv/plugin-http-context": ^0.0.22
-    "@objectiv/plugin-identity-context": ^0.0.22
-    "@objectiv/plugin-path-context-from-url": ^0.0.22
-    "@objectiv/plugin-root-location-context-from-url": ^0.0.22
-    "@objectiv/queue-local-storage": ^0.0.22
-    "@objectiv/schema": ^0.0.22
-    "@objectiv/testing-tools": ^0.0.22
-    "@objectiv/tracker-core": ~0.0.22
-    "@objectiv/tracker-react-core": ~0.0.22
-    "@objectiv/transport-debug": ^0.0.22
-    "@objectiv/transport-fetch": ^0.0.22
-    "@objectiv/transport-xhr": ^0.0.22
+    "@objectiv/developer-tools": ^0.0.23-2
+    "@objectiv/plugin-application-context": ^0.0.23-2
+    "@objectiv/plugin-http-context": ^0.0.23-2
+    "@objectiv/plugin-identity-context": ^0.0.23-2
+    "@objectiv/plugin-path-context-from-url": ^0.0.23-2
+    "@objectiv/plugin-root-location-context-from-url": ^0.0.23-2
+    "@objectiv/queue-local-storage": ^0.0.23-2
+    "@objectiv/schema": ^0.0.23-2
+    "@objectiv/testing-tools": ^0.0.23-2
+    "@objectiv/tracker-core": ~0.0.23-2
+    "@objectiv/tracker-react-core": ~0.0.23-2
+    "@objectiv/transport-debug": ^0.0.23-2
+    "@objectiv/transport-fetch": ^0.0.23-2
+    "@objectiv/transport-xhr": ^0.0.23-2
     "@testing-library/react": ^12.1.4
     "@types/jest": ^27.4.1
     "@types/react": ^17.0.39
@@ -1896,11 +1896,11 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@objectiv/transport-debug@^0.0.22, @objectiv/transport-debug@workspace:transports/debug":
+"@objectiv/transport-debug@^0.0.23-2, @objectiv/transport-debug@workspace:transports/debug":
   version: 0.0.0-use.local
   resolution: "@objectiv/transport-debug@workspace:transports/debug"
   dependencies:
-    "@objectiv/tracker-core": ~0.0.22
+    "@objectiv/tracker-core": ~0.0.23-2
     "@types/jest": ^27.4.1
     jest: ^27.5.1
     jest-standard-reporter: ^2.0.0
@@ -1911,13 +1911,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@objectiv/transport-fetch@^0.0.22, @objectiv/transport-fetch@workspace:transports/fetch":
+"@objectiv/transport-fetch@^0.0.23-2, @objectiv/transport-fetch@workspace:transports/fetch":
   version: 0.0.0-use.local
   resolution: "@objectiv/transport-fetch@workspace:transports/fetch"
   dependencies:
-    "@objectiv/developer-tools": ^0.0.22
-    "@objectiv/testing-tools": ^0.0.22
-    "@objectiv/tracker-core": ~0.0.22
+    "@objectiv/developer-tools": ^0.0.23-2
+    "@objectiv/testing-tools": ^0.0.23-2
+    "@objectiv/tracker-core": ~0.0.23-2
     "@types/jest": ^27.4.1
     jest: ^27.5.1
     jest-fetch-mock: ^3.0.3
@@ -1929,13 +1929,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@objectiv/transport-xhr@^0.0.22, @objectiv/transport-xhr@workspace:transports/xhr":
+"@objectiv/transport-xhr@^0.0.23-2, @objectiv/transport-xhr@workspace:transports/xhr":
   version: 0.0.0-use.local
   resolution: "@objectiv/transport-xhr@workspace:transports/xhr"
   dependencies:
-    "@objectiv/developer-tools": ^0.0.22
-    "@objectiv/testing-tools": ^0.0.22
-    "@objectiv/tracker-core": ~0.0.22
+    "@objectiv/developer-tools": ^0.0.23-2
+    "@objectiv/testing-tools": ^0.0.23-2
+    "@objectiv/tracker-core": ~0.0.23-2
     "@types/jest": ^27.4.1
     jest: ^27.5.1
     jest-standard-reporter: ^2.0.0


### PR DESCRIPTION
Two small changes that came up from manual testing:

### useOnToggle
- Can now be used without having to specify a callback for each boolean state. This makes it friendlier to execute when dealing with global states

### isContextEqual
- Strict by default: removed logic for cleaning up the internal property `__instance_id` from it. The same functionality can be achieved by using the `cleanObjectFromInternalProperties` helper. This makes the predicate simpler and faster.