### PR TITLE
Fix Sphinx error on Series docs

### DIFF
--- a/bach/docs/source/bach/api-reference/Series/index.rst
+++ b/bach/docs/source/bach/api-reference/Series/index.rst
@@ -41,6 +41,7 @@ Axes
     Series.name
     Series.index
     Series.group_by
+    Series.order_by
 
 Types
 +++++

--- a/bach/docs/source/bach/api-reference/Series/index.rst
+++ b/bach/docs/source/bach/api-reference/Series/index.rst
@@ -41,7 +41,6 @@ Axes
     Series.name
     Series.index
     Series.group_by
-    Series.sorted_ascending
 
 Types
 +++++


### PR DESCRIPTION
Latest `main` generated a Sphinx error on `Series.sorted_ascending`, so I changed it to `Series.order_by`:
```
WARNING: [autosummary] failed to import bach.Series.sorted_ascending.
Possible hints:
* ImportError:
* AttributeError: type object 'Series' has no attribute 'sorted_ascending'
* ModuleNotFoundError: No module named 'bach.Series'
```