### PR TITLE
Bach: skip tests using pg_engine when running for bq only

### DIFF
--- a/bach/tests/conftest.py
+++ b/bach/tests/conftest.py
@@ -76,7 +76,11 @@ _RECORDED_TEST_TABLES_PER_ENGINE: [Engine, List[str]] = defaultdict(list)
 
 
 @pytest.fixture()
-def pg_engine() -> Engine:
+def pg_engine(request: SubRequest) -> Engine:
+    if request.config.getoption("big_query"):
+        # Skip tests using this fixture when running only for big_query
+        pytest.skip()
+
     # TODO: port all tests that use this to be multi-database. Or explicitly mark them as skip-bigquery
     return _ENGINE_CACHE[DB.POSTGRES]
 


### PR DESCRIPTION
Best fix is marking the tests as skip.bigquery, but we should do it when porting them. This just solves the problem of executing pytest for BQ only,