### PR TITLE
Speed up tracker workflow

### DIFF
--- a/.github/workflows/tracker-tests.yml
+++ b/.github/workflows/tracker-tests.yml
@@ -9,17 +9,12 @@ on:
       - '.github/**'
 
 jobs:
-  run-tracker-tests:
+  install-dependencies:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '16'
-          check-latest: true
-
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
@@ -28,18 +23,34 @@ jobs:
         working-directory: tracker
         run: yarn install
 
-      - name: Run TypeScript check
-        working-directory: tracker
-        run: yarn tsc
-
-      - name: Run tests for all packages
-        working-directory: tracker
-        run: yarn test:ci
-
+  run-check-dependencies:
+    runs-on: ubuntu-latest
+    needs: [install-dependencies]
+    steps:
       - name: Check dependencies
         working-directory: tracker
         run: yarn check:dependencies
 
+  run-ts-check:
+    runs-on: ubuntu-latest
+    needs: [install-dependencies]
+    steps:
+      - name: Run TypeScript check
+        working-directory: tracker
+        run: yarn tsc
+
+  run-unit-tests:
+    runs-on: ubuntu-latest
+    needs: [install-dependencies]
+    steps:
+      - name: Run unit tests
+        working-directory: tracker
+        run: yarn test:ci
+
+  run-ts-schema-check:
+    runs-on: ubuntu-latest
+    needs: [install-dependencies]
+    steps:
       - name: Test if TS schema is up to date
         working-directory: tracker
         run: |

--- a/.github/workflows/tracker-tests.yml
+++ b/.github/workflows/tracker-tests.yml
@@ -38,10 +38,6 @@ jobs:
           path: '**/node_modules'
           key: node-modules-${{ hashFiles('**/yarn.lock') }}
 
-      - name: Install dependencies
-        working-directory: tracker
-        run: yarn install
-
       - name: Check dependencies
         working-directory: tracker
         run: yarn check:dependencies
@@ -58,10 +54,6 @@ jobs:
         with:
           path: '**/node_modules'
           key: node-modules-${{ hashFiles('**/yarn.lock') }}
-
-      - name: Install dependencies
-        working-directory: tracker
-        run: yarn install
 
       - name: Run TypeScript check
         working-directory: tracker
@@ -80,10 +72,6 @@ jobs:
           path: '**/node_modules'
           key: node-modules-${{ hashFiles('**/yarn.lock') }}
 
-      - name: Install dependencies
-        working-directory: tracker
-        run: yarn install
-
       - name: Run unit tests
         working-directory: tracker
         run: yarn test:ci
@@ -100,10 +88,6 @@ jobs:
         with:
           path: '**/node_modules'
           key: node-modules-${{ hashFiles('**/yarn.lock') }}
-
-      - name: Install dependencies
-        working-directory: tracker
-        run: yarn install
 
       - name: Test if TS schema is up to date
         working-directory: tracker

--- a/.github/workflows/tracker-tests.yml
+++ b/.github/workflows/tracker-tests.yml
@@ -27,6 +27,17 @@ jobs:
     runs-on: ubuntu-latest
     needs: [install-dependencies]
     steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/cache@v3
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Install dependencies
+        working-directory: tracker
+        run: yarn install
+
       - name: Check dependencies
         working-directory: tracker
         run: yarn check:dependencies
@@ -35,6 +46,17 @@ jobs:
     runs-on: ubuntu-latest
     needs: [install-dependencies]
     steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/cache@v3
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Install dependencies
+        working-directory: tracker
+        run: yarn install
+
       - name: Run TypeScript check
         working-directory: tracker
         run: yarn tsc
@@ -43,6 +65,17 @@ jobs:
     runs-on: ubuntu-latest
     needs: [install-dependencies]
     steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/cache@v3
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Install dependencies
+        working-directory: tracker
+        run: yarn install
+
       - name: Run unit tests
         working-directory: tracker
         run: yarn test:ci
@@ -51,6 +84,17 @@ jobs:
     runs-on: ubuntu-latest
     needs: [install-dependencies]
     steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/cache@v3
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Install dependencies
+        working-directory: tracker
+        run: yarn install
+
       - name: Test if TS schema is up to date
         working-directory: tracker
         run: |

--- a/.github/workflows/tracker-tests.yml
+++ b/.github/workflows/tracker-tests.yml
@@ -13,24 +13,33 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
       - uses: actions/setup-node@v2
         with:
           node-version: '16'
           check-latest: true
-          cache: 'yarn'
-          cache-dependency-path: tracker/yarn.lock
+
+      - uses: actions/cache@v2
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+
       - name: Install dependencies
         working-directory: tracker
         run: yarn install
+
       - name: Run TypeScript check
         working-directory: tracker
         run: yarn tsc
+
       - name: Run tests for all packages
         working-directory: tracker
         run: yarn test:ci
+
       - name: Check dependencies
         working-directory: tracker
         run: yarn check:dependencies
+
       - name: Test if TS schema is up to date
         working-directory: tracker
         run: |

--- a/.github/workflows/tracker-tests.yml
+++ b/.github/workflows/tracker-tests.yml
@@ -14,10 +14,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/cache@v3
+      - name: Cache node_modules
+        id: node-modules-cache
+        uses: actions/cache@v3
         with:
           path: '**/node_modules'
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+          key: node-modules-${{ hashFiles('**/yarn.lock') }}
 
       - name: Install dependencies
         working-directory: tracker
@@ -29,10 +31,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/cache@v3
+      - name: Use cached node_modules
+        id: node-modules-cache
+        uses: actions/cache@v3
         with:
           path: '**/node_modules'
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+          key: node-modules-${{ hashFiles('**/yarn.lock') }}
 
       - name: Install dependencies
         working-directory: tracker
@@ -48,10 +52,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/cache@v3
+      - name: Use cached node_modules
+        id: node-modules-cache
+        uses: actions/cache@v3
         with:
           path: '**/node_modules'
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+          key: node-modules-${{ hashFiles('**/yarn.lock') }}
 
       - name: Install dependencies
         working-directory: tracker
@@ -67,10 +73,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/cache@v3
+      - name: Use cached node_modules
+        id: node-modules-cache
+        uses: actions/cache@v3
         with:
           path: '**/node_modules'
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+          key: node-modules-${{ hashFiles('**/yarn.lock') }}
 
       - name: Install dependencies
         working-directory: tracker
@@ -86,10 +94,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/cache@v3
+      - name: Use cached node_modules
+        id: node-modules-cache
+        uses: actions/cache@v3
         with:
           path: '**/node_modules'
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+          key: node-modules-${{ hashFiles('**/yarn.lock') }}
 
       - name: Install dependencies
         working-directory: tracker


### PR DESCRIPTION
In this Pr:
- Update checkout action to v3 (defaults to node 16)
  - Remove unnecessary node 16 setup job
- Split installation and caching of the node_modules in its own job
- Make all other steps in separate jobs "needing" the installation one
- Modify steps to use cached node_modules

Apart from decreasing the run time, this also enables rerunning just one of the jobs, instead of the whole thing.