### PR TITLE
Add build job to tracker workflow

### DIFF
--- a/.github/workflows/tracker-tests.yml
+++ b/.github/workflows/tracker-tests.yml
@@ -21,11 +21,6 @@ jobs:
           path: '**/node_modules'
           key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
 
-      - if: ${{ steps.cache-npm.outputs.cache-hit == 'false' }}
-        name: List the state of node modules
-        continue-on-error: true
-        run: npm list
-
       - name: Install dependencies
         working-directory: tracker
         run: yarn install

--- a/.github/workflows/tracker-tests.yml
+++ b/.github/workflows/tracker-tests.yml
@@ -22,6 +22,7 @@ jobs:
           key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
 
       - name: Install dependencies
+        if: steps.node-modules-cache.outputs.cache-hit != 'true'
         working-directory: tracker
         run: yarn install
 

--- a/.github/workflows/tracker-tests.yml
+++ b/.github/workflows/tracker-tests.yml
@@ -21,6 +21,11 @@ jobs:
           path: '**/node_modules'
           key: node-modules-${{ hashFiles('**/yarn.lock') }}
 
+      - if: ${{ steps.cache-npm.outputs.cache-hit == 'false' }}
+        name: List the state of node modules
+        continue-on-error: true
+        run: npm list
+
       - name: Install dependencies
         working-directory: tracker
         run: yarn install
@@ -94,3 +99,21 @@ jobs:
         run: |
           yarn utils:generate
           test $(git status -s -uno | wc -l) -eq 0
+
+  run-test-build:
+    runs-on: ubuntu-latest
+    needs: [install-dependencies]
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Use cached node_modules
+        id: node-modules-cache
+        uses: actions/cache@v3
+        with:
+          path: '**/node_modules'
+          key: node-modules-${{ hashFiles('**/yarn.lock') }}
+
+      - name: Build all SDKs
+        working-directory: tracker
+        run: |
+          yarn build

--- a/.github/workflows/tracker-tests.yml
+++ b/.github/workflows/tracker-tests.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: '**/node_modules'
-          key: node-modules-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
 
       - if: ${{ steps.cache-npm.outputs.cache-hit == 'false' }}
         name: List the state of node modules
@@ -41,7 +41,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: '**/node_modules'
-          key: node-modules-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
 
       - name: Check dependencies
         working-directory: tracker
@@ -58,7 +58,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: '**/node_modules'
-          key: node-modules-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
 
       - name: Run TypeScript check
         working-directory: tracker
@@ -75,7 +75,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: '**/node_modules'
-          key: node-modules-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
 
       - name: Run unit tests
         working-directory: tracker
@@ -92,7 +92,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: '**/node_modules'
-          key: node-modules-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
 
       - name: Test if TS schema is up to date
         working-directory: tracker
@@ -111,7 +111,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: '**/node_modules'
-          key: node-modules-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('**/yarn.lock') }}
 
       - name: Build all SDKs
         working-directory: tracker


### PR DESCRIPTION
- Add a new parallel job to the Tracker workflow to build all SDKs
- Add runner operating system to cache key
- Skip generating new cache if one already exists for the os + yarn hash combination
