### PR TITLE
Bach: Add BigQuery support in tests in functional/bach/test_df_window

### DIFF
--- a/bach/tests/functional/bach/test_df_window.py
+++ b/bach/tests/functional/bach/test_df_window.py
@@ -7,9 +7,9 @@ from bach.partitioning import WindowFrameMode, WindowFrameBoundary
 from tests.functional.bach.test_data_and_utils import assert_equals_data, get_bt_with_test_data, get_df_with_test_data
 
 
-def test_windowing_frame_clause(pg_engine):
-    engine = pg_engine  # TODO: BigQuery
+def test_windowing_frame_clause(engine):
     bt = get_df_with_test_data(engine, full_data_set=True)
+    bt = bt.sort_index()
     w = bt.window().group_by
     # Check the default
     assert (w.frame_clause == "RANGE BETWEEN UNBOUNDED PRECEDING AND CURRENT ROW")
@@ -154,8 +154,8 @@ def test_windowing_frame_clause(pg_engine):
                             end_boundary=WindowFrameBoundary.FOLLOWING,
                             end_value=2)
 
-def test_windowing_windows(pg_engine):
-    engine = pg_engine  # TODO: BigQuery
+
+def test_windowing_windows(engine):
     ## Just test that different windows don't generate SQL errors. Logic will be checked in different tests.
     bt = get_df_with_test_data(engine, full_data_set=True)
 
@@ -172,11 +172,11 @@ def test_windowing_windows(pg_engine):
     p3 = bt.groupby(['municipality', bt['inhabitants'] < 10000]).window()
 
     for w in [p0,p1,p2,p3]:
-        bt.inhabitants.window_first_value(window=w).to_pandas()
+        bt.inhabitants.window_row_number(window=w).to_pandas()
 
     with pytest.raises(ValueError):
         # Specific window functions should fail on being passed a groupby
-        bt.inhabitants.window_first_value(window=bt.groupby())
+        bt.inhabitants.window_row_number(window=bt.groupby())
 
 
 def test_windowing_functions_agg(engine):

--- a/bach/tests/functional/bach/test_df_window.py
+++ b/bach/tests/functional/bach/test_df_window.py
@@ -459,9 +459,9 @@ def test_expanding_variations():
             _test_series_vs_full_df(series, min_periods=min_periods)
 
 
-def test_window_functions_not_in_where_having_groupby():
+def test_window_functions_not_in_where_having_groupby(engine):
     # window functions are not allowed in where if constructed externally
-    bt = get_bt_with_test_data(full_data_set=True)
+    bt = get_df_with_test_data(engine, full_data_set=True)
     btg_min_fnd = bt.founding.min(bt.sort_values('inhabitants').window())
     with pytest.raises(ValueError,
                        match='Cannot apply a Boolean series containing a window function to DataFrame.'):


### PR DESCRIPTION
All tests for windowing should now work for BQ. Had to refactor a bunch of them because they were taking too long. 

Most of them were sort-related issues since BQ will raise an error if window specification has no order by and the function requires it (Postgres does not care)
Here the issue: https://github.com/objectiv/objectiv-analytics/issues/1063
|                | **Function Name** | **Requires Order By** |
|:--------------:|:-----------------:|:---------------------:|
| **Navigation** |                   |                       |
|                | FIRST_VALUE       |           ✔️           |
|                | LAST_VALUE        |           ✔️           |
|                | NTH_VALUE         |           ✔️           |
|                | LEAD              |           ✔️           |
|                | LAG               |           ✔️           |
|                | PERCENTILE_CONT   |           ❌           |
|                | PERCENTILE_DISC   |           ❌           |
|  **Numbering** |                   |                       |
|                | RANK              |           ✔️           |
|                | DENSE_RANK        |           ✔️           |
|                | PERCENT_RANK      |           ✔️           |
|                | CUME_DIST         |           ✔️           |
|                | NTILE             |           ✔️           |
|                | ROW_NUMBER        |           ❌           |
