### PR TITLE
Bach/MH: stricter package requirements to avoid BQ deps clash

### DIFF
--- a/bach/setup.cfg
+++ b/bach/setup.cfg
@@ -22,13 +22,14 @@ classifiers =
 
 [options]
 install_requires =
+    # sqlalchemy-bigquery is very specific about the following two deps. List them first to avoid pip getting confused
+    sqlalchemy<=1.4.27
+    pyarrow<7.0dev
     psycopg2-binary
-    sqlalchemy
     pandas>=1.3.1
     sqlparse
     sqlalchemy-bigquery
     google-cloud-bigquery-storage
-    pyarrow
 
 python_requires = >=3.7
 packages = find:

--- a/modelhub/setup.cfg
+++ b/modelhub/setup.cfg
@@ -22,10 +22,15 @@ classifiers =
 
 [options]
 install_requires =
+    # sqlalchemy-bigquery (through objectiv-bach) is very specific about the following two deps. List them first to avoid pip getting confused
+    sqlalchemy<=1.4.27
+    pyarrow<7.0dev
     objectiv-bach ==0.0.17
     requests
     matplotlib
     seaborn
+    # sklearn requires wheel to properly install
+    wheel
     sklearn
     typing-extensions
 python_requires = >=3.7


### PR DESCRIPTION
MH requires Bach (of course), and Bach requires `sqlalchemy-bigquery` which in turn has some pretty specific requirements. This PR makes sure pip knows about those before getting other dependencies, so in a clean env, everything installs without conflicts:

Observe the following to now be error-free.
```
python3 -m venv /tmp/venv-deps-test
. /tmp/venv-deps-test/bin/activate
pip install -e modelhub
```