### PR TITLE
Fix annoying flaky test

### DIFF
--- a/tracker/core/tracker/src/TrackerTransportRetryAttempt.ts
+++ b/tracker/core/tracker/src/TrackerTransportRetryAttempt.ts
@@ -90,7 +90,6 @@ export class TrackerTransportRetryAttempt implements TrackerTransportRetryAttemp
     }
 
     // Stop if we reached maxRetryMs
-    console.log(Date.now(), this.startTime, Date.now() - this.startTime, this.maxRetryMs)
     if (Date.now() - this.startTime >= this.maxRetryMs) {
       this.errors.unshift(new Error('maxRetryMs reached'));
       return Promise.reject(this.errors);

--- a/tracker/core/tracker/src/TrackerTransportRetryAttempt.ts
+++ b/tracker/core/tracker/src/TrackerTransportRetryAttempt.ts
@@ -90,7 +90,8 @@ export class TrackerTransportRetryAttempt implements TrackerTransportRetryAttemp
     }
 
     // Stop if we reached maxRetryMs
-    if (this.startTime && Date.now() - this.startTime >= this.maxRetryMs) {
+    console.log(Date.now(), this.startTime, Date.now() - this.startTime, this.maxRetryMs)
+    if (Date.now() - this.startTime >= this.maxRetryMs) {
       this.errors.unshift(new Error('maxRetryMs reached'));
       return Promise.reject(this.errors);
     }

--- a/tracker/core/tracker/tests/TrackerTransport.test.ts
+++ b/tracker/core/tracker/tests/TrackerTransport.test.ts
@@ -380,30 +380,17 @@ describe('TrackerTransportRetry', () => {
   });
 
   it('should stop retrying if we reached maxRetryMs', async () => {
-    const slowFailingTransport = {
-      transportName: 'SlowFailingTransport',
-      handle: async () => new Promise((_, reject) => setTimeout(() => reject(makeTransportSendError()), 100)),
-      isUsable: () => true,
-    };
-    jest.spyOn(slowFailingTransport, 'handle');
-    const retryTransport = new TrackerTransportRetry({
-      transport: slowFailingTransport,
-      minTimeoutMs: 1,
-      maxTimeoutMs: 1,
-      retryFactor: 1,
-      maxRetryMs: 1,
-    });
+    const logTransport = new LogTransport();
+    const retryTransport = new TrackerTransportRetry({ transport: logTransport });
     const retryTransportAttempt = new TrackerTransportRetryAttempt(retryTransport, [testEvent]);
-    jest.spyOn(retryTransportAttempt, 'retry');
 
-    await expect(retryTransportAttempt.run()).rejects.toEqual(
-      expect.arrayContaining([new Error('maxRetryMs reached')])
-    );
+    // @ts-ignore Set the start time to yesterday
+    retryTransportAttempt.startTime = new Date(new Date().setDate(new Date().getDate() - 1));
 
-    expect(retryTransportAttempt.retry).toHaveBeenCalledTimes(1);
-    expect(slowFailingTransport.handle).toHaveBeenCalledTimes(1);
+    const result = await retryTransportAttempt.run();
+
+    expect(result[0]).toStrictEqual(retryTransportAttempt.errors[0]);
+    expect(result[0]).toStrictEqual(new Error('maxRetryMs reached'));
     expect(retryTransportAttempt.errors[0]).toStrictEqual(new Error('maxRetryMs reached'));
   });
-
-  // TODO write test to verify everything works as expected also when wrapped in a concurrency > 1 Queue
 });

--- a/tracker/core/tracker/tests/TrackerTransport.test.ts
+++ b/tracker/core/tracker/tests/TrackerTransport.test.ts
@@ -381,16 +381,16 @@ describe('TrackerTransportRetry', () => {
 
   it('should stop retrying if we reached maxRetryMs', async () => {
     const logTransport = new LogTransport();
-    const retryTransport = new TrackerTransportRetry({ transport: logTransport });
+    const retryTransport = new TrackerTransportRetry({ transport: logTransport, maxRetryMs: 1 });
     const retryTransportAttempt = new TrackerTransportRetryAttempt(retryTransport, [testEvent]);
 
     // @ts-ignore Set the start time to yesterday
-    retryTransportAttempt.startTime = new Date(new Date().setDate(new Date().getDate() - 1));
+    retryTransportAttempt.startTime = Date.now() - 1000;
 
-    const result = await retryTransportAttempt.run();
+    await expect(retryTransportAttempt.run()).rejects.toEqual(
+      expect.arrayContaining([new Error('maxRetryMs reached')])
+    );
 
-    expect(result[0]).toStrictEqual(retryTransportAttempt.errors[0]);
-    expect(result[0]).toStrictEqual(new Error('maxRetryMs reached'));
     expect(retryTransportAttempt.errors[0]).toStrictEqual(new Error('maxRetryMs reached'));
   });
 });


### PR DESCRIPTION
As the title says, this test has been failing randomly due to a dirty timer in it. Fixed it up with a different testing approach. Also simplified a conditional and removed a TODO that was long fixed.