### PR TITLE
Cleanup test data functions in test_data_and_utils.py

### DIFF
--- a/bach/README.md
+++ b/bach/README.md
@@ -43,46 +43,7 @@ make tests
 ```
 
 ### Running BigQuery-only tests
-Before running tests for BigQuery, please make sure you have the following tables in your dataset:
-
-**Cities**
-```sql
-insert into `<YOUR_PROJECT>.<YOUR_DATASET>.cities`(skating_order, city, municipality, inhabitants, founding)
-values
-    (1, 'Ljouwert', 'Leeuwarden', 93485, 1285),
-    (2, 'Snits', 'Súdwest-Fryslân', 33520, 1456),
-    (3, 'Drylts', 'Súdwest-Fryslân', 3055, 1268),
-    (4, 'Sleat', 'De Friese Meren', 700, 1426),
-    (5, 'Starum', 'Súdwest-Fryslân', 960, 1061),
-    (6, 'Hylpen', 'Súdwest-Fryslân', 870, 1225),
-    (7, 'Warkum', 'Súdwest-Fryslân', 4440, 1399),
-    (8, 'Boalsert', 'Súdwest-Fryslân', 10120, 1455),
-    (9, 'Harns', 'Harlingen', 14740, 1234),
-    (10, 'Frjentsjer', 'Waadhoeke', 12760, 1374),
-    (11, 'Dokkum', 'Noardeast-Fryslân', 12675, 1298);
-```
-**Foods**
-```sql
-insert into `<YOUR_PROJECT>.<YOUR_DATASET>.foods`(skating_order, food, moment, date)
-values
-    (1, 'Sûkerbôlle', '2021-05-03 11:28:36.388', '2021-05-03'),
-    (2, 'Dúmkes', '2021-05-04 23:28:36.388', '2021-05-04'),
-    (4, 'Grutte Pier Bier', '2022-05-03 14:13:13.388', '2022-05-03');
-```
-**Railways**
-```sql
-insert into `<YOUR_PROJECT>.<YOUR_DATASET>.railways`(station_id, town, station, platforms)
-values
-    (1, 'Drylts', 'IJlst', 1),
-    (2, 'It Hearrenfean', 'Heerenveen', 1),
-    (3, 'It Hearrenfean', 'Heerenveen IJsstadion', 2),
-    (4, 'Ljouwert', 'Leeuwarden', 4),
-    (5, 'Ljouwert', 'Camminghaburen', 1),
-    (6, 'Snits', 'Sneek', 2),
-    (7, 'Snits', 'Sneek Noord', 2);
-```
-
-After setting up your tables, run the following command:
+For running tests for BigQuery, run the following command:
 ```bash
 make tests-bigquery
 ```

--- a/bach/tests/functional/bach/test_data_and_utils.py
+++ b/bach/tests/functional/bach/test_data_and_utils.py
@@ -9,7 +9,7 @@ as a test file. This makes pytest rewrite the asserts to give clearer errors.
 import datetime
 import uuid
 from decimal import Decimal
-from typing import List, Union, Type, Dict, Any
+from typing import List, Union, Type, Any
 
 import sqlalchemy
 from sqlalchemy.engine import ResultProxy, Engine, Dialect
@@ -125,78 +125,38 @@ JSON_COLUMNS = ['row', 'dict_column', 'list_column', 'mixed_column']
 JSON_INDEX_AND_COLUMNS = ['_row_id'] + JSON_COLUMNS
 
 
-def get_bt(
-    dataset: List[List[Any]],
-    columns: List[str],
-    convert_objects: bool
-) -> DataFrame:
-    """
-    DEPRECATED: Call directly DataFrame.from_pandas instead
-    """
-    return DataFrame.from_pandas(
-        engine=sqlalchemy.create_engine(DB_PG_TEST_URL),
-        df=get_pandas_df(dataset, columns),
-        convert_objects=convert_objects,
-    )
-
-
 def get_df_with_test_data(engine: Engine, full_data_set: bool = False) -> DataFrame:
-    if is_postgres(engine):
-        if full_data_set:
-            return get_bt(TEST_DATA_CITIES_FULL, CITIES_COLUMNS, True)
-        return get_bt(TEST_DATA_CITIES, CITIES_COLUMNS, True)
-    if is_bigquery(engine):
-        df = _get_big_query_data(
-            engine=engine,
-            table_name='cities',
-            index='skating_order',
-            dtypes=CITIES_COLUMNS_X_DTYPES,
-        )
-        if full_data_set:
-            return df
-
-        # skating_orders in (1, 2, 3)
-        skating_orders = list(range(1, ROW_LIMIT + 1))
-        return df.loc[skating_orders]
-    raise ValueError(f'engine of type {engine.name} is not supported.')
+    dataset = TEST_DATA_CITIES_FULL if full_data_set else TEST_DATA_CITIES
+    return DataFrame.from_pandas(
+        engine=engine,
+        df=get_pandas_df(dataset, CITIES_COLUMNS),
+        convert_objects=True
+    )
 
 
 def get_bt_with_test_data(full_data_set: bool = False) -> DataFrame:
     """
     DEPRECATED: Use get_df_with_test_data()
     """
-    if full_data_set:
-        return get_bt(TEST_DATA_CITIES_FULL, CITIES_COLUMNS, True)
-    return get_bt(TEST_DATA_CITIES, CITIES_COLUMNS, True)
+    # This is probably a cause of the number of database connections increasing during testing
+    engine = sqlalchemy.create_engine(DB_PG_TEST_URL)
+    return get_df_with_test_data(engine=engine, full_data_set=full_data_set)
 
 
 def get_df_with_food_data(engine: Engine) -> DataFrame:
-    if is_postgres(engine):
-        return get_bt(TEST_DATA_FOOD, FOOD_COLUMNS, True)
-
-    if is_bigquery(engine):
-        return _get_big_query_data(
-            engine=engine,
-            table_name='foods',
-            index='skating_order',
-            dtypes=FOOD_COLUMNS_X_DTYPES,
-        )
-
-    raise ValueError(f'engine of type {engine.name} is not supported.')
+    return DataFrame.from_pandas(
+        engine=engine,
+        df=get_pandas_df(TEST_DATA_FOOD, FOOD_COLUMNS),
+        convert_objects=True,
+    )
 
 
 def get_df_with_railway_data(engine: Engine) -> DataFrame:
-    if is_postgres(engine):
-        return get_bt(TEST_DATA_RAILWAYS, RAILWAYS_COLUMNS, True)
-
-    if is_bigquery(engine):
-        return _get_big_query_data(
-            engine=engine,
-            table_name='railways',
-            index='station_id',
-            dtypes=RAILWAYS_COLUMNS_X_DTYPES,
-        )
-    raise ValueError(f'engine of type {engine.name} is not supported.')
+    return DataFrame.from_pandas(
+        engine=engine,
+        df=get_pandas_df(TEST_DATA_RAILWAYS, RAILWAYS_COLUMNS),
+        convert_objects=True,
+    )
 
 
 def get_df_with_json_data(engine: Engine, dtype='json') -> DataFrame:
@@ -313,22 +273,6 @@ def _get_to_pandas_data(df: DataFrame):
         db_values.append(value_row if df.index else value_row[1:])  # don't include default index value
     print(db_values)
     return column_names, db_values
-
-
-# todo: rename this function to a more generic name since we might need to use it for other engines
-def _get_big_query_data(engine: Engine, table_name: str, index: str, dtypes: Dict[str, str]) -> DataFrame:
-    df = DataFrame.from_table(
-        engine=engine,
-        table_name=table_name,
-        index=[index],
-        all_dtypes=dtypes
-    )
-    # todo: update actual table to match the postgres test data. so we don't need this magic here
-    df = df.reset_index()
-    df[f'_index_{index}'] = df[index]
-    df = df.set_index(f'_index_{index}')
-    df = df.materialize()
-    return df
 
 
 def assert_postgres_type(

--- a/bach/tests/functional/bach/test_df_from.py
+++ b/bach/tests/functional/bach/test_df_from.py
@@ -16,6 +16,8 @@ from tests.functional.bach.test_data_and_utils import assert_equals_data
 
 
 def _create_test_table(engine: Engine, table_name: str):
+    # TODO: insert data too, and check in the tests below that we get that data back in the DataFrame
+    #
     if is_postgres(engine):
         sql = f'drop table if exists {table_name}; ' \
               f'create table {table_name}(a bigint, b text, c double precision, d date, e timestamp, f boolean); '

--- a/bach/tests/functional/bach/test_df_from.py
+++ b/bach/tests/functional/bach/test_df_from.py
@@ -17,7 +17,7 @@ from tests.functional.bach.test_data_and_utils import assert_equals_data
 
 def _create_test_table(engine: Engine, table_name: str):
     # TODO: insert data too, and check in the tests below that we get that data back in the DataFrame
-    #
+    #  https://github.com/objectiv/objectiv-analytics/issues/1093
     if is_postgres(engine):
         sql = f'drop table if exists {table_name}; ' \
               f'create table {table_name}(a bigint, b text, c double precision, d date, e timestamp, f boolean); '


### PR DESCRIPTION
Bit of cleanup before introducing tests for Athena

Changes:
* Consistently use `DataFrame.from_pandas()` to create dataframes with test data
* No longer rely on tables existing in database for BigQuery (through `_get_big_query_data()`)

This does mean that we now have no tests anymore that query any actual data from a table. This was already the case for Postgres, but now also for BigQuery. Virtually all tests use `from_pandas()` that creates a CTE with the data. So we probably should add back at least one test that actually creates a table and queries the data, added a TODO for that and an [issue](https://github.com/objectiv/objectiv-analytics/issues/1093). This doesn't have the highest prio, as we do have such a test for modelhub so the behaviour is tested there.