### PR TITLE
replace `get_bt_with_test_data()` with `get_df_with_test_data()`

### DIFF
--- a/bach/tests/functional/bach/test_data_and_utils.py
+++ b/bach/tests/functional/bach/test_data_and_utils.py
@@ -134,15 +134,6 @@ def get_df_with_test_data(engine: Engine, full_data_set: bool = False) -> DataFr
     )
 
 
-def get_bt_with_test_data(full_data_set: bool = False) -> DataFrame:
-    """
-    DEPRECATED: Use get_df_with_test_data()
-    """
-    # This is probably a cause of the number of database connections increasing during testing
-    engine = sqlalchemy.create_engine(DB_PG_TEST_URL)
-    return get_df_with_test_data(engine=engine, full_data_set=full_data_set)
-
-
 def get_df_with_food_data(engine: Engine) -> DataFrame:
     return DataFrame.from_pandas(
         engine=engine,

--- a/bach/tests/functional/bach/test_data_and_utils.py
+++ b/bach/tests/functional/bach/test_data_and_utils.py
@@ -18,7 +18,6 @@ from bach import DataFrame, Series
 from bach.types import get_series_type_from_db_dtype
 from sql_models.constants import DBDialect
 from sql_models.util import is_bigquery, is_postgres
-from tests.conftest import DB_PG_TEST_URL
 from tests.unit.bach.util import get_pandas_df
 
 # Three data tables for testing are defined here that can be used in tests

--- a/bach/tests/functional/bach/test_df_describe.py
+++ b/bach/tests/functional/bach/test_df_describe.py
@@ -8,9 +8,7 @@ import pandas as pd
 
 from bach import DataFrame
 from sql_models.util import is_bigquery
-from tests.functional.bach.test_data_and_utils import (
-    get_bt_with_test_data, assert_equals_data, get_df_with_test_data,
-)
+from tests.functional.bach.test_data_and_utils import get_df_with_test_data, assert_equals_data
 from unittest.mock import ANY
 
 
@@ -79,8 +77,8 @@ def test_df_numerical_describe(engine) -> None:
     )
 
 
-def test_include_mixed() -> None:
-    df = get_bt_with_test_data()
+def test_include_mixed(pg_engine) -> None:
+    df = get_df_with_test_data(engine=pg_engine)
     # duplicate last row. This will make the `mode` well-defined for all columns
     df = df.append(df.sort_index()[2:3])
 

--- a/bach/tests/functional/bach/test_df_savepoints.py
+++ b/bach/tests/functional/bach/test_df_savepoints.py
@@ -5,13 +5,13 @@ import pytest
 
 from bach.savepoints import CreatedObject
 from sql_models.model import Materialization
-from tests.functional.bach.test_data_and_utils import get_bt_with_test_data, assert_equals_data
+from tests.functional.bach.test_data_and_utils import assert_equals_data, get_df_with_test_data
 from tests.functional.bach.test_savepoints import remove_created_db_objects
 
 
 @pytest.mark.xdist_group(name="db_writers")
-def test_savepoint_materialization():
-    df = get_bt_with_test_data()
+def test_savepoint_materialization(pg_engine):
+    df = get_df_with_test_data(engine=pg_engine)
 
     engine = df.engine
     df.set_savepoint("savepoint1")

--- a/bach/tests/functional/bach/test_df_scale.py
+++ b/bach/tests/functional/bach/test_df_scale.py
@@ -1,8 +1,8 @@
 from sklearn.preprocessing import StandardScaler, MinMaxScaler
 
 from tests.functional.bach.test_data_and_utils import (
-    get_df_with_test_data, assert_equals_data, \
-    get_bt_with_test_data, TEST_DATA_CITIES_FULL, CITIES_COLUMNS
+    get_df_with_test_data, assert_equals_data,
+    TEST_DATA_CITIES_FULL, CITIES_COLUMNS
 )
 import numpy as np
 
@@ -115,11 +115,11 @@ def test_standard_scale(engine) -> None:
     )
 
 
-def test_min_max_scale() -> None:
+def test_min_max_scale(pg_engine) -> None:
     numerical_cols = ['skating_order', 'inhabitants', 'founding']
     all_cols = ['city'] + numerical_cols
     pdf = get_pandas_df(TEST_DATA_CITIES_FULL, CITIES_COLUMNS)
-    bt = get_bt_with_test_data(full_data_set=True)[all_cols]
+    bt = get_df_with_test_data(engine=pg_engine, full_data_set=True)[all_cols]
     # bt = bt.sort_index()  # TODO: This breaks later on, it shouldn't.
                             #  Required to make this test deterministicly pass/fail
 

--- a/bach/tests/functional/bach/test_df_unstack.py
+++ b/bach/tests/functional/bach/test_df_unstack.py
@@ -1,11 +1,10 @@
 import pytest
 
-from tests.functional.bach.test_data_and_utils import get_bt_with_test_data, assert_equals_data, \
-    get_df_with_test_data
+from tests.functional.bach.test_data_and_utils import get_df_with_test_data, assert_equals_data
 
 
-def test_basic_unstack() -> None:
-    bt = get_bt_with_test_data(full_data_set=False)
+def test_basic_unstack(pg_engine) -> None:
+    bt = get_df_with_test_data(engine=pg_engine, full_data_set=False)
 
     with pytest.raises(NotImplementedError, match=r'index must be a multi level'):
         bt.unstack()
@@ -35,8 +34,8 @@ def test_basic_unstack() -> None:
     )
 
 
-def test_unstack_level() -> None:
-    bt = get_bt_with_test_data(full_data_set=False)
+def test_unstack_level(pg_engine) -> None:
+    bt = get_df_with_test_data(engine=pg_engine, full_data_set=False)
     bt = bt.set_index(keys=['city', 'skating_order', 'municipality'])
 
     result = bt.unstack(level=1)

--- a/bach/tests/functional/bach/test_savepoints.py
+++ b/bach/tests/functional/bach/test_savepoints.py
@@ -4,16 +4,15 @@ Copyright 2021 Objectiv B.V.
 from typing import List
 
 import pytest
-from sqlalchemy.dialects.postgresql.base import PGDialect
 from sqlalchemy.future import Engine
 
 from bach.savepoints import Savepoints, CreatedObject
 from sql_models.model import Materialization
-from tests.functional.bach.test_data_and_utils import get_bt_with_test_data, assert_equals_data
+from tests.functional.bach.test_data_and_utils import get_df_with_test_data, assert_equals_data
 
 
-def test_add_savepoint():
-    df = get_bt_with_test_data()
+def test_add_savepoint(pg_engine):
+    df = get_df_with_test_data(engine=pg_engine)
     sps = Savepoints()
     sps.add_savepoint('test', df, Materialization.TABLE)
     df2 = df.groupby('municipality').min()
@@ -29,8 +28,8 @@ def test_add_savepoint():
     assert len(sps.all) == 2
 
 
-def test_add_savepoint_double():
-    df = get_bt_with_test_data()
+def test_add_savepoint_double(pg_engine):
+    df = get_df_with_test_data(engine=pg_engine)
     sps = Savepoints()
     df = df.materialize()
     sps.add_savepoint('first', df, Materialization.TABLE)
@@ -38,8 +37,8 @@ def test_add_savepoint_double():
         sps.add_savepoint('second', df, Materialization.QUERY)
 
 
-def test_write_to_db_queries_only(testrun_uid):
-    df = get_bt_with_test_data()
+def test_write_to_db_queries_only(pg_engine, testrun_uid):
+    df = get_df_with_test_data(engine=pg_engine)
     engine = df.engine
     sps = Savepoints()
     sps.add_savepoint('the_name', df, Materialization.QUERY)
@@ -66,9 +65,10 @@ def test_write_to_db_queries_only(testrun_uid):
     )
 
 
-def test_write_to_db_create_objects(testrun_uid: str):
-    dialect = PGDialect()  # TODO: BigQuery
-    df = get_bt_with_test_data()
+def test_write_to_db_create_objects(pg_engine, testrun_uid: str):
+    engine = pg_engine
+    dialect = engine.dialect
+    df = get_df_with_test_data(engine)
     engine = df.engine
     sps = Savepoints()
 

--- a/bach/tests/functional/bach/test_series.py
+++ b/bach/tests/functional/bach/test_series.py
@@ -10,7 +10,7 @@ from bach.expression import Expression
 from sql_models.util import is_postgres, is_bigquery
 from tests.functional.bach.test_data_and_utils import (
     get_df_with_test_data, assert_equals_data, df_to_list,
-    get_df_with_railway_data, get_df_with_food_data, get_bt_with_test_data, TEST_DATA_CITIES_FULL, CITIES_COLUMNS,
+    get_df_with_railway_data, get_df_with_food_data, TEST_DATA_CITIES_FULL, CITIES_COLUMNS,
 )
 from tests.unit.bach.util import get_pandas_df
 
@@ -41,8 +41,8 @@ def test_series__getitem__(engine):
         non_existing_value_ref.value
 
 
-def test_positional_slicing():
-    bt = get_bt_with_test_data(full_data_set=True)['inhabitants'].sort_values()
+def test_positional_slicing(pg_engine):
+    bt = get_df_with_test_data(engine=pg_engine, full_data_set=True)['inhabitants'].sort_values()
 
     class ReturnSlice:
         def __getitem__(self, key):
@@ -236,8 +236,8 @@ def test_aggregation(engine):
         s.agg(['sum','sum'])
 
 
-def test_type_agnostic_aggregation_functions():
-    bt = get_bt_with_test_data(full_data_set=True)
+def test_type_agnostic_aggregation_functions(pg_engine):
+    bt = get_df_with_test_data(engine=pg_engine, full_data_set=True)
     btg = bt.groupby()
 
     # type agnostic aggregations
@@ -366,8 +366,8 @@ def test_series_inherit_flag(engine):
     assert not bts_derived.expression.has_aggregate_function
 
 
-def test_series_independant_subquery_any_value_all_values():
-    bt = get_bt_with_test_data(full_data_set=True)
+def test_series_independant_subquery_any_value_all_values(pg_engine):
+    bt = get_df_with_test_data(engine=pg_engine, full_data_set=True)
     s = bt.inhabitants.max() // 4
 
     bt[bt.inhabitants > s.any_value()].head()
@@ -488,8 +488,9 @@ def test_series_dropna(engine) -> None:
     )
 
 
-def test_series_unstack():
-    bt = get_bt_with_test_data(full_data_set=True)
+def test_series_unstack(pg_engine):
+    engine = pg_engine
+    bt = get_df_with_test_data(engine=engine, full_data_set=True)
 
     stacked_bt = bt.groupby(['city','municipality']).inhabitants.sum()
     unstacked_bt = stacked_bt.unstack()
@@ -541,7 +542,7 @@ def test_series_unstack():
     )
 
     # test with column that references another column and grouping on that column
-    bt = get_bt_with_test_data(full_data_set=False)
+    bt = get_df_with_test_data(engine=engine, full_data_set=False)
     bt['village'] = bt.city + ' village'
     unstacked_bt = bt.groupby(['skating_order', 'village']).inhabitants.sum().unstack()
     # unstacked_bt = bt.set_index(['skating_order', 'village']).inhabitants.unstack()


### PR DESCRIPTION
Instead of using `get_bt_with_test_data()` we use `get_df_with_test_data(engine=pg_engine)` in combination with the `pg_engine` fixture.

Without these change, the tests run against Postgres when running with `--big-query`, after this change they are skipped when running with `--big-query` (and in the future `--athena`)

This is something I noticed while working on `--athena`, I expected that to run one functional tests, but it ran actually more than that.