### PR TITLE
Bach Support boolean, integer, and float for Athena

### DIFF
--- a/bach/bach/series/series_boolean.py
+++ b/bach/bach/series/series_boolean.py
@@ -11,7 +11,7 @@ from bach.expression import Expression
 from bach.series.series import WrappedPartition
 from bach.types import StructuredDtype
 from sql_models.constants import DBDialect
-from sql_models.util import is_postgres, is_bigquery, DatabaseNotSupportedException
+from sql_models.util import is_postgres, is_bigquery, DatabaseNotSupportedException, is_athena
 
 
 class SeriesBoolean(Series, ABC):
@@ -42,6 +42,7 @@ class SeriesBoolean(Series, ABC):
     dtype_aliases = ('boolean', '?', bool)
     supported_db_dtype = {
         DBDialect.POSTGRES: 'boolean',
+        DBDialect.ATHENA: 'boolean',
         DBDialect.BIGQUERY: 'BOOL',
     }
     supported_value_types = (bool, )
@@ -112,7 +113,7 @@ class SeriesBoolean(Series, ABC):
         :param skipna: only ``skipna=True`` supported. This means NULL values are ignored.
         :returns: a new Series with the aggregation applied
         """
-        if is_postgres(self.engine):
+        if is_postgres(self.engine) or is_athena(self.engine):
             return self._derived_agg_func(partition, 'bool_and', skipna=skipna)
         if is_bigquery(self.engine):
             return self._derived_agg_func(partition, 'logical_and', skipna=skipna)
@@ -127,7 +128,7 @@ class SeriesBoolean(Series, ABC):
         :param skipna: only ``skipna=True`` supported. This means NULL values are ignored.
         :returns: a new Series with the aggregation applied
         """
-        if is_postgres(self.engine):
+        if is_postgres(self.engine) or is_athena(self.engine):
             return self._derived_agg_func(partition, 'bool_or', skipna=skipna)
         if is_bigquery(self.engine):
             return self._derived_agg_func(partition, 'logical_or', skipna=skipna)

--- a/bach/bach/series/series_numeric.py
+++ b/bach/bach/series/series_numeric.py
@@ -1,6 +1,7 @@
 """
 Copyright 2021 Objectiv B.V.
 """
+import math
 from abc import ABC
 from typing import cast, Union, TYPE_CHECKING, Optional, List, Tuple
 
@@ -55,6 +56,10 @@ class SeriesAbstractNumeric(Series, ABC):
 
         :param decimals: The amount of decimals to round to
         """
+        if is_athena(self.engine):
+            return self.copy_override(
+                expression=Expression.construct(f'round({{}}, {decimals})', self)
+            )
         return self.copy_override(
             expression=Expression.construct(f'round(cast({{}} as numeric), {decimals})', self)
         )
@@ -295,6 +300,13 @@ class SeriesInt64(SeriesAbstractNumeric):
             # Postgres expects the argument to a bitshift to be a regular int, not bigint.
             return self._arithmetic_operation(other, 'rshift', '({}) >> cast({} as int)',
                                               other_dtypes=tuple(['int64']))
+        if is_athena(self.engine):
+            # Latest version of prestodb supports bitwise_logical_shift_right() [1], but the version that
+            # Athena uses, does not [2]. So we do some hackish thing here
+            # [1] https://prestodb.io/docs/current/functions/bitwise.html
+            # [2] https://prestodb.io/docs/0.217/functions/bitwise.html
+            return self._arithmetic_operation(other, 'rshift', 'cast(({}) / power(2, {}) as bigint)',
+                                              other_dtypes=tuple(['int64']))
         return self._arithmetic_operation(other, 'rshift', '({}) >> ({})', other_dtypes=tuple(['int64']))
 
     def __lshift__(self, other):
@@ -302,6 +314,11 @@ class SeriesInt64(SeriesAbstractNumeric):
             # Postgres expects the argument to a bitshift to be a regular int, not bigint.
             return self._arithmetic_operation(other, 'lshift', '({}) << cast({} as int)',
                                               other_dtypes=tuple(['int64']))
+        if is_athena(self.engine):
+            # hack around missing shift operator
+            return self._arithmetic_operation(other, 'lshift', 'cast(({}) * power(2, {}) as bigint)',
+                                              other_dtypes=tuple(['int64']))
+
         return self._arithmetic_operation(other, 'lshift', '({}) << ({})', other_dtypes=tuple(['int64']))
 
     def sum(self, partition: WrappedPartition = None, skipna: bool = True, min_count: int = None, **kwargs):
@@ -340,6 +357,7 @@ class SeriesFloat64(SeriesAbstractNumeric):
     dtype_aliases = ('float', 'double', 'f8', float, numpy.float64, 'double precision')
     supported_db_dtype = {
         DBDialect.POSTGRES: 'double precision',
+        DBDialect.ATHENA: 'double',
         DBDialect.BIGQUERY: 'FLOAT64'
     }
     supported_value_types = (float, numpy.float64)
@@ -369,6 +387,16 @@ class SeriesFloat64(SeriesAbstractNumeric):
         value: Union[float, numpy.float64],
         dtype: StructuredDtype
     ) -> Expression:
+        if is_athena(dialect) and not math.isfinite(value):
+            # see https://prestodb.io/docs/0.217/functions/math.html, under 'Floating Point functions'
+            if math.isnan(value):
+                return Expression.raw('nan()')
+            if math.isinf(value):
+                if value > 0:
+                    return Expression.raw('infinity()')
+                else:
+                    return Expression.raw('-infinity()')
+            raise Exception('value is not finite, but not nan or infinite')  # should never happen
         return Expression.string_value(str(value))
 
     @classmethod
@@ -407,7 +435,7 @@ class SeriesFloat64(SeriesAbstractNumeric):
         (using materialize()), before adding any columns that reference a column that's created with
         this function.
         """
-        if is_postgres(base.engine):
+        if is_postgres(base.engine) or is_athena(base.engine):
             expr_str = 'random()'
         elif is_bigquery(base.engine):
             expr_str = 'RAND()'

--- a/bach/tests/functional/bach/test_series_boolean.py
+++ b/bach/tests/functional/bach/test_series_boolean.py
@@ -4,7 +4,7 @@ import pytest
 from tests.functional.bach.test_data_and_utils import assert_equals_data, get_df_with_test_data
 
 
-pytestmark = pytest.mark.athena()
+pytestmark = pytest.mark.athena_supported()
 
 
 def test_from_const(engine):

--- a/bach/tests/functional/bach/test_series_boolean.py
+++ b/bach/tests/functional/bach/test_series_boolean.py
@@ -1,6 +1,10 @@
 import numpy
+import pytest
 
 from tests.functional.bach.test_data_and_utils import assert_equals_data, get_df_with_test_data
+
+
+pytestmark = pytest.mark.athena()
 
 
 def test_from_const(engine):

--- a/bach/tests/functional/bach/test_series_float.py
+++ b/bach/tests/functional/bach/test_series_float.py
@@ -5,9 +5,14 @@
 import math
 from unittest.mock import ANY
 
+import pytest
+
 from bach import SeriesFloat64
-from tests.functional.bach.test_data_and_utils import assert_equals_data, get_df_with_test_data, run_query
+from tests.functional.bach.test_data_and_utils import assert_equals_data, get_df_with_test_data
 from tests.functional.bach.test_series_numeric import helper_test_simple_arithmetic
+
+
+pytestmark = pytest.mark.athena()
 
 
 def test_from_value(engine):

--- a/bach/tests/functional/bach/test_series_float.py
+++ b/bach/tests/functional/bach/test_series_float.py
@@ -12,7 +12,7 @@ from tests.functional.bach.test_data_and_utils import assert_equals_data, get_df
 from tests.functional.bach.test_series_numeric import helper_test_simple_arithmetic
 
 
-pytestmark = pytest.mark.athena()
+pytestmark = pytest.mark.athena_supported()
 
 
 def test_from_value(engine):

--- a/bach/tests/functional/bach/test_series_int.py
+++ b/bach/tests/functional/bach/test_series_int.py
@@ -1,10 +1,15 @@
 """
 Copyright 2021 Objectiv B.V.
 """
+import pytest
+
 from bach import Series, SeriesInt64
 from tests.functional.bach.test_data_and_utils import assert_equals_data, assert_postgres_type,\
     get_df_with_test_data
 from tests.functional.bach.test_series_numeric import helper_test_simple_arithmetic
+
+
+pytestmark = pytest.mark.athena()
 
 
 def test_add_int_constant(engine):

--- a/bach/tests/functional/bach/test_series_int.py
+++ b/bach/tests/functional/bach/test_series_int.py
@@ -9,7 +9,7 @@ from tests.functional.bach.test_data_and_utils import assert_equals_data, assert
 from tests.functional.bach.test_series_numeric import helper_test_simple_arithmetic
 
 
-pytestmark = pytest.mark.athena()
+pytestmark = pytest.mark.athena_supported()
 
 
 def test_add_int_constant(engine):

--- a/bach/tests/functional/bach/test_series_numeric.py
+++ b/bach/tests/functional/bach/test_series_numeric.py
@@ -377,7 +377,6 @@ def test_series_minmax_scale(engine) -> None:
 def test_exp(engine) -> None:
     skating_order = get_df_with_test_data(engine, full_data_set=True)['skating_order']
     result = skating_order.exp()
-
     assert_equals_data(
         result,
         expected_columns=['_index_skating_order', 'skating_order'],
@@ -394,5 +393,12 @@ def test_exp(engine) -> None:
             [10, 22026.465794806718],
             [11, 59874.14171519782]
         ],
+        # on Athena exp(1) can evalaute to two different values:
+        # `2.718281828459045`
+        # `2.7182818284590455`
+        # This might be a result of the query being executed by servers with different in CPU architectures.
+        # Bottom-line: We don't really care about such precision, so we round to 14 decimals here.
+        round_decimals=True,
+        decimal=14
     )
 

--- a/bach/tests/functional/bach/test_series_numeric.py
+++ b/bach/tests/functional/bach/test_series_numeric.py
@@ -4,6 +4,7 @@ from typing import Union
 
 import numpy as np
 import pandas as pd
+import pytest
 from psycopg2._range import NumericRange
 from sqlalchemy.engine import Engine
 
@@ -47,6 +48,7 @@ def helper_test_simple_arithmetic(engine: Engine, a: Union[int, float], b: Union
     )
 
 
+@pytest.mark.athena_supported()
 def test_round(engine):
     values = [1.9, 3.0, 4.123, 6.425124, 2.00000000001, 2.1, np.nan, 7.]
     pdf = pd.DataFrame(data={'num': values})
@@ -68,6 +70,7 @@ def test_round(engine):
     )
 
 
+@pytest.mark.athena_supported()
 def test_round_integer(engine):
     values = [1, 3, 4, 6, 2, 2, 6, 7]
     pdf = pd.DataFrame(data={'num': values})
@@ -85,6 +88,7 @@ def test_round_integer(engine):
     )
 
 
+@pytest.mark.athena_supported()
 def test_aggregations_simple_tests(engine):
     values = [1, 3, 4, 6, 2, 2, np.nan, 7, 8]
     pdf = pd.DataFrame(data={'num': values})
@@ -101,6 +105,7 @@ def test_aggregations_simple_tests(engine):
         assert pd_agg == bt_agg.value
 
 
+@pytest.mark.athena_supported()
 def test_aggregations_sum_mincount(engine):
     pdf = pd.DataFrame(data={'num': [1, np.nan, 7, 8]})
     bt = DataFrame.from_pandas(engine=engine, df=pdf, convert_objects=True)
@@ -307,6 +312,7 @@ def test_series_qcut(engine) -> None:
             np.testing.assert_almost_equal(exp.right, float(res.right), decimal=2)
 
 
+@pytest.mark.athena_supported()
 def test_series_scale(engine) -> None:
     inhabitants = get_df_with_test_data(engine, full_data_set=True)['inhabitants']
     result = inhabitants.scale()
@@ -337,6 +343,7 @@ def test_series_scale(engine) -> None:
     )
 
 
+@pytest.mark.athena_supported()
 def test_series_minmax_scale(engine) -> None:
     inhabitants = get_df_with_test_data(engine, full_data_set=True)['inhabitants']
     result = inhabitants.minmax_scale()
@@ -366,6 +373,7 @@ def test_series_minmax_scale(engine) -> None:
     )
 
 
+@pytest.mark.athena_supported()
 def test_exp(engine) -> None:
     skating_order = get_df_with_test_data(engine, full_data_set=True)['skating_order']
     result = skating_order.exp()


### PR DESCRIPTION
Changes:
- support boolean, int64, float64 for athena
- mark tests for those series as supporting Athena