### PR TITLE
Bach: SeriesString.str.upper and SeriesString.str.lower

### DIFF
--- a/bach/bach/series/series_string.py
+++ b/bach/bach/series/series_string.py
@@ -138,6 +138,8 @@ class StringOperation:
     def upper(self) -> 'SeriesString':
         """
         converts string values into uppercase.
+
+        :return: SeriesString with all alphabetic characters in uppercase
         """
         return self._base.copy_override(
             expression=Expression.construct('upper({})', self._base)
@@ -146,6 +148,8 @@ class StringOperation:
     def lower(self) -> 'SeriesString':
         """
         converts string values into lowercase.
+
+        :return: SeriesString with all alphabetic characters in lowercase
         """
         return self._base.copy_override(
             expression=Expression.construct('lower({})', self._base)

--- a/bach/bach/series/series_string.py
+++ b/bach/bach/series/series_string.py
@@ -135,6 +135,16 @@ class StringOperation:
         )
         return self._base.copy_override(expression=expr)
 
+    def upper(self) -> 'SeriesString':
+        return self._base.copy_override(
+            expression=Expression.construct('upper({})', self._base)
+        )
+
+    def lower(self) -> 'SeriesString':
+        return self._base.copy_override(
+            expression=Expression.construct('lower({})', self._base)
+        )
+
 
 class SeriesString(Series):
     """

--- a/bach/bach/series/series_string.py
+++ b/bach/bach/series/series_string.py
@@ -136,11 +136,17 @@ class StringOperation:
         return self._base.copy_override(expression=expr)
 
     def upper(self) -> 'SeriesString':
+        """
+        converts string values into uppercase.
+        """
         return self._base.copy_override(
             expression=Expression.construct('upper({})', self._base)
         )
 
     def lower(self) -> 'SeriesString':
+        """
+        converts string values into lowercase.
+        """
         return self._base.copy_override(
             expression=Expression.construct('lower({})', self._base)
         )

--- a/bach/tests/functional/bach/test_series_string.py
+++ b/bach/tests/functional/bach/test_series_string.py
@@ -134,6 +134,29 @@ def test_string_replace(engine) -> None:
     assert_equals_data(result_df, expected_columns=expected_columns, expected_data=expected_data)
 
 
+def test_string_lower_upper(engine) -> None:
+    df = get_df_with_test_data(engine, full_data_set=True)
+    df['municipality_lower'] = df['municipality'].str.lower()
+    df['municipality_upper'] = df['municipality'].str.upper()
+    assert_equals_data(
+        df[['municipality', 'municipality_lower', 'municipality_upper']],
+        expected_columns=['_index_skating_order', 'municipality', 'municipality_lower', 'municipality_upper'],
+        expected_data=[
+            [1, 'Leeuwarden', 'leeuwarden', 'LEEUWARDEN'],
+            [2, 'Súdwest-Fryslân', 'súdwest-fryslân', 'SÚDWEST-FRYSLÂN'],
+            [3, 'Súdwest-Fryslân', 'súdwest-fryslân', 'SÚDWEST-FRYSLÂN'],
+            [4, 'De Friese Meren', 'de friese meren', 'DE FRIESE MEREN'],
+            [5, 'Súdwest-Fryslân', 'súdwest-fryslân', 'SÚDWEST-FRYSLÂN'],
+            [6, 'Súdwest-Fryslân', 'súdwest-fryslân', 'SÚDWEST-FRYSLÂN'],
+            [7, 'Súdwest-Fryslân', 'súdwest-fryslân', 'SÚDWEST-FRYSLÂN'],
+            [8, 'Súdwest-Fryslân', 'súdwest-fryslân', 'SÚDWEST-FRYSLÂN'],
+            [9, 'Harlingen', 'harlingen', 'HARLINGEN'],
+            [10, 'Waadhoeke', 'waadhoeke', 'WAADHOEKE'],
+            [11, 'Noardeast-Fryslân', 'noardeast-fryslân', 'NOARDEAST-FRYSLÂN'],
+        ]
+    )
+
+
 def test_to_json_array(engine):
     df = get_df_with_test_data(engine, full_data_set=True)
     s_muni = df['municipality']

--- a/bach/tests/functional/bach/test_series_string.py
+++ b/bach/tests/functional/bach/test_series_string.py
@@ -2,6 +2,7 @@
 Copyright 2021 Objectiv B.V.
 """
 import pandas as pd
+import pytest
 
 from bach import Series, SeriesString, DataFrame
 from tests.functional.bach.test_data_and_utils import assert_equals_data, get_df_with_test_data
@@ -134,6 +135,7 @@ def test_string_replace(engine) -> None:
     assert_equals_data(result_df, expected_columns=expected_columns, expected_data=expected_data)
 
 
+@pytest.mark.athena_supported
 def test_string_lower_upper(engine) -> None:
     df = get_df_with_test_data(engine, full_data_set=True)
     df['municipality_lower'] = df['municipality'].str.lower()


### PR DESCRIPTION
Support for both `upper` and `lower` for string values.