### PR TITLE
Bach: Athena base Series `setitem` test

### DIFF
--- a/bach/bach/series/series_boolean.py
+++ b/bach/bach/series/series_boolean.py
@@ -36,6 +36,7 @@ class SeriesBoolean(Series, ABC):
     **Database support and types**
 
     * Postgres: utilizes the 'boolean' database type.
+    * Athena: : utilizes the 'boolean' database type.
     * BigQuery: utilizes the 'BOOL' database type.
     """
     dtype = 'bool'

--- a/bach/bach/series/series_numeric.py
+++ b/bach/bach/series/series_numeric.py
@@ -235,6 +235,7 @@ class SeriesInt64(SeriesAbstractNumeric):
     **Database support and types**
 
     * Postgres: utilizes the 'bigint' database type.
+    * Athena: utilizes the 'bigint' database type.
     * BigQuery: utilizes the 'INT64' database type.
     """
     dtype = 'int64'
@@ -351,6 +352,7 @@ class SeriesFloat64(SeriesAbstractNumeric):
     **Database support and types**
 
     * Postgres: utilizes the 'double precision' database type.
+    * Athena: utilizes the 'double' database type.
     * BigQuery: utilizes the 'FLOAT64' database type.
     """
     dtype = 'float64'

--- a/bach/bach/series/series_string.py
+++ b/bach/bach/series/series_string.py
@@ -157,6 +157,7 @@ class SeriesString(Series):
     **Database support and types**
 
     * Postgres: utilizes the 'text' database type.
+    * Athena: utilizes the 'varchar' database type.
     * BigQuery: utilizes the 'STRING' database type.
     """
 

--- a/bach/bach/series/series_uuid.py
+++ b/bach/bach/series/series_uuid.py
@@ -22,6 +22,7 @@ class SeriesUuid(Series):
     **Database support and types**
 
     * Postgres: utilizes the native 'uuid' database type.
+    * Athena: utilizes the generic 'varchar' database type.
     * BigQuery: utilizes the generic 'STRING' database type.
     """
     dtype = 'uuid'

--- a/bach/tests/functional/bach/test_data_and_utils.py
+++ b/bach/tests/functional/bach/test_data_and_utils.py
@@ -9,7 +9,7 @@ as a test file. This makes pytest rewrite the asserts to give clearer errors.
 import datetime
 import uuid
 from decimal import Decimal
-from typing import List, Union, Type, Any
+from typing import List, Union, Type, Any, Dict
 
 import sqlalchemy
 from sqlalchemy.engine import ResultProxy, Engine, Dialect
@@ -295,6 +295,77 @@ def assert_postgres_type(
         assert db_type == expected_db_type
     series_type = get_series_type_from_db_dtype(DBDialect.POSTGRES, db_type)
     assert series_type == expected_series_type
+
+
+def assert_postgres_types(
+        df: DataFrame,
+        series_expected_db_type: Dict[str, str],
+):
+    """
+    Check that the given series in the DataFrame have the expected data types in Postgres.
+
+    Fails if df.engine is not a Postgres connection.
+
+    :param df: DataFrame object for which to check the database types
+    :param series_expected_db_type: mapping of series-names, to database types.
+    """
+    if not is_postgres(df.engine):
+        raise Exception(f'df.engine is not a postgres connection, but {df.engine.name}')
+    return _assert_db_types(
+        df=df,
+        series_expected_db_type=series_expected_db_type,
+        typeof_function_name='pg_typeof'
+    )
+
+
+def assert_athena_types(
+        df: DataFrame,
+        series_expected_db_type: Dict[str, str],
+):
+    """
+    Check that the given series in the DataFrame have the expected data types in Athena.
+
+    Fails if df.engine is not an Athena connection.
+
+    :param df: DataFrame object for which to check the database types
+    :param series_expected_db_type: mapping of series-names, to database types.
+    """
+    if not is_athena(df.engine):
+        raise Exception(f'df.engine is not an Athena connection, but {df.engine.name}')
+    return _assert_db_types(
+        df=df,
+        series_expected_db_type=series_expected_db_type,
+        typeof_function_name='typeof'
+    )
+
+
+def _assert_db_types(
+        df: DataFrame,
+        series_expected_db_type: Dict[str, str],
+        typeof_function_name: str
+):
+    """
+    Check that the given series in the DataFrame have the expected data types in the database.
+
+    This uses df.engine as the connection.
+
+    :param df: DataFrame object for which to check the database types
+    :param series_expected_db_type: mapping of series-names, to database types.
+    """
+    df_sql = df.view_sql()
+    types_sql = ', '.join(
+        f'{typeof_function_name}("{series_name}")'for series_name in series_expected_db_type.keys()
+    )
+    sql = f'with check_type as ({df_sql}) select {types_sql} from check_type limit 1'
+    db_rows = run_query(engine=df.engine, sql=sql)
+    db_values = [list(row) for row in db_rows]
+    for i, series_name in enumerate(series_expected_db_type.keys()):
+        expected_db_type = series_expected_db_type[series_name]
+        db_type = db_values[0][i]
+        msg = f"expected type {expected_db_type} for {series_name}, found {db_type}"
+        assert db_type == expected_db_type, msg
+
+
 
 
 def convert_expected_data_timestamps(dialect: Dialect, data: List[List[Any]]) -> List[List[Any]]:

--- a/bach/tests/functional/bach/test_df_setitem.py
+++ b/bach/tests/functional/bach/test_df_setitem.py
@@ -13,8 +13,7 @@ from bach import SeriesInt64, SeriesString, SeriesFloat64, SeriesDate, SeriesTim
     SeriesTime, SeriesTimedelta, Series, SeriesJson, SeriesBoolean
 from sql_models.util import is_postgres, is_athena
 from tests.functional.bach.test_data_and_utils import assert_postgres_type, assert_equals_data, \
-    CITIES_INDEX_AND_COLUMNS, get_df_with_test_data, get_df_with_railway_data, assert_postgres_types, \
-    assert_athena_types
+    CITIES_INDEX_AND_COLUMNS, get_df_with_test_data, get_df_with_railway_data, assert_db_types
 
 
 def check_set_const(
@@ -56,10 +55,10 @@ def check_set_const(
 
     if is_postgres(engine):
         pg_types = {column_name: expected_pg_db_type for column_name in column_names}
-        assert_postgres_types(bt, pg_types)
+        assert_db_types(bt, pg_types)
     if is_athena(engine):
         athena_types = {column_name: expected_athena_db_type for column_name in column_names}
-        assert_athena_types(bt, athena_types)
+        assert_db_types(bt, athena_types)
     # we don't have an easy way to get the database type in BigQuery, so don't check type there
 
 

--- a/bach/tests/functional/bach/test_df_setitem.py
+++ b/bach/tests/functional/bach/test_df_setitem.py
@@ -27,9 +27,9 @@ def check_set_const(
     Checks:
     1. Assert that data is correct
     2. Assert that Series have the expected type
-    3. Assert that the data type in the database is the expected type, for supported database.
+    3. Assert that the data type in the database is the expected type, for supported databases.
         The expected type is based on Series.supported_db_dtype, or the parameter expected_db_type_override
-        if set.
+        if that is set.
     """
     bt = get_df_with_test_data(engine)
     column_names = []
@@ -60,12 +60,11 @@ def check_set_const(
         # For BigQuery we cannot check the data type of an expression, as it doesn't offer a function for
         # that. For all other databases, we check that the actual type in the database matches the type
         # we expect
-        dialect = engine.dialect
         db_dialect = DBDialect.from_engine(engine)
         if expected_db_type_override and db_dialect in expected_db_type_override:
             expected_db_type = expected_db_type_override[db_dialect]
         else:
-            expected_db_type = expected_series.get_db_dtype(dialect)
+            expected_db_type = expected_series.get_db_dtype(engine.dialect)
         db_types = {column_name: expected_db_type for column_name in column_names}
         assert_db_types(bt, db_types)
 


### PR DESCRIPTION
Changes:
1. Add the Athena database type to Series docstring. Had forgotten this earlier in #1116 and #1117
2. Converted some of the tests om `test_df_setitem.py` to work for Athena too. Specifically converted the tests for the data types that are already working.

This came up while working on SeriesJson support for Athena