### PR TITLE
MH: Temporary change to make mypy green again.

### DIFF
--- a/.github/workflows/modelhub_tests.yml
+++ b/.github/workflows/modelhub_tests.yml
@@ -65,7 +65,7 @@ jobs:
           key: pip-${{ matrix.python-version }}-${{ hashFiles('bach/setup.cfg', 'modelhub/setup.cfg') }}
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install pip==20.0.2
           # These need to be seperate commands else pip confuses the bach flavours.
           pip install -e bach 
           pip install -e modelhub[dev]

--- a/modelhub/mypy.ini
+++ b/modelhub/mypy.ini
@@ -1,6 +1,6 @@
 [mypy]
 # mypy_path should have the same value as PYTHONPATH
-mypy_path=../bach:.
+mypy_path=.
 
 # Check the code in all functions, even if a function itself doesn't have type annotations.
 check_untyped_defs=True

--- a/modelhub/mypy.ini
+++ b/modelhub/mypy.ini
@@ -1,6 +1,6 @@
 [mypy]
 # mypy_path should have the same value as PYTHONPATH
-mypy_path=.
+mypy_path=../bach:.
 
 # Check the code in all functions, even if a function itself doesn't have type annotations.
 check_untyped_defs=True


### PR DESCRIPTION
On pip 22.2.2, mypy can not find bach source code even though it's installed via `pip -e bach`.
This is a temporary fix to make CI pass, while we work on a better fix.