### PR TITLE
Replace PNGs in the readme for vectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,15 @@ pip install objectiv-modelhub
 * **An open model hub** with pre-built product analytics models & operations.
 * **A modeling library** to create reusable models that run on your full dataset.
 
-![objectiv_stack](https://user-images.githubusercontent.com/82152911/184355849-ee1c59af-068e-48e0-bcd3-b064633d2fa7.svg#gh-light-mode-only "Objectiv Stack")
-![objectiv_stack_dark](https://user-images.githubusercontent.com/82152911/184355794-4b957f62-210c-4a66-bda6-6405ab8f8a3e.svg#gh-dark-mode-only "Objectiv Stack")
+<a href="https://objectiv.io">
+
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://user-images.githubusercontent.com/82152911/184355794-4b957f62-210c-4a66-bda6-6405ab8f8a3e.svg">
+  <source media="(prefers-color-scheme: light)" srcset="https://user-images.githubusercontent.com/82152911/184355849-ee1c59af-068e-48e0-bcd3-b064633d2fa7.svg">
+  <img alt="Objectiv stack" src="https://user-images.githubusercontent.com/82152911/184355849-ee1c59af-068e-48e0-bcd3-b064633d2fa7.svg">
+</picture>
+
+</a>
 
 ### The open analytics taxonomy
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
-<img src="https://user-images.githubusercontent.com/82152911/159266790-19e0e3d4-0d10-4c58-9da7-16edde9ec05a.svg#gh-light-mode-only" alt="objectiv_logo_light" title="Objectiv Logo">
-<img src="https://user-images.githubusercontent.com/82152911/159266895-39f52604-83c1-438d-96bd-9a6d66e74b08.svg#gh-dark-mode-only" alt="objectiv_logo_dark" title="Objectiv Logo">
+<a href="https://objectiv.io">
 
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://user-images.githubusercontent.com/82152911/159266895-39f52604-83c1-438d-96bd-9a6d66e74b08.svg">
+  <source media="(prefers-color-scheme: light)" srcset="https://user-images.githubusercontent.com/82152911/159266790-19e0e3d4-0d10-4c58-9da7-16edde9ec05a.svg">
+  <img alt="Objectiv logo" src="https://user-images.githubusercontent.com/82152911/159266790-19e0e3d4-0d10-4c58-9da7-16edde9ec05a.svg">
+</picture>
+
+</a>
 
 [Objectiv](https://objectiv.io/) is an integrated set of data collection and modeling tools to quickly build & run models for any product analytics use case.
 

--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ pip install objectiv-modelhub
 * **An open model hub** with pre-built product analytics models & operations.
 * **A modeling library** to create reusable models that run on your full dataset.
 
-![objectiv_stack](https://user-images.githubusercontent.com/82152911/184146312-dca08dfc-33b9-4f3a-8356-2f0ff8563b1d.svg#gh-light-mode-only "Objectiv Stack")
-![objectiv_stack_dark](https://user-images.githubusercontent.com/82152911/184146420-92ac1db7-4b09-476c-abc5-c67d5a970c75.svg#gh-dark-mode-only "Objectiv Stack")
+![objectiv_stack](https://user-images.githubusercontent.com/82152911/184355849-ee1c59af-068e-48e0-bcd3-b064633d2fa7.svg#gh-light-mode-only "Objectiv Stack")
+![objectiv_stack_dark](https://user-images.githubusercontent.com/82152911/184355794-4b957f62-210c-4a66-bda6-6405ab8f8a3e.svg#gh-dark-mode-only "Objectiv Stack")
 
 ### The open analytics taxonomy
 


### PR DESCRIPTION
Fixes most of the image issues in the stack image related to the use of bitmap icons for the data cloud vendors. All have been replaced by vector shapes. The Bach icon cannot be fixed without a lot of work because it is not replaceable by a vector image.

The issue seems to be a bug on Github's side where PNG's that are included in SVGs have an incorrect path when viewing the file directly

before:
<img width="1066" alt="Screenshot 2022-08-11 at 19 50 56" src="https://user-images.githubusercontent.com/82152911/184356892-58dba6ba-89f9-45f5-abd1-3cb02f2a39db.png">


after:
![image](https://user-images.githubusercontent.com/82152911/184356821-c96c82ee-e046-4446-9bd7-0f19a41e7a68.png)
