### PR TITLE
Bach: strict other dtypes in binary ops

### DIFF
--- a/bach/bach/series/series.py
+++ b/bach/bach/series/series.py
@@ -1146,18 +1146,22 @@ class Series(ABC):
         """
         The standard way to perform a binary operation
 
-        :param self: SeriesSubTypehe left hand side expression (lhs) in the operation
+        :param self: SeriesSubType: the left hand side expression (lhs) in the operation
         :param other: The right hand side expression (rhs) in the operation
         :param operation: A user-readable representation of the operation
         :param fmt_str: An Expression.construct format string, accepting lhs and rhs as the only parameters,
             in that order.
-        :param other_dtypes: The acceptable dtypes for the rhs expression
+        :param other_dtypes: The acceptable dtypes for the rhs expression. There will be
+            an explicit cast/astype to lhs; we accept the type as rhs for this operation. If the DB
+            does not know what to do with the types in the operation, explicit type conversions can be done
+            using the `strict_other_dtypes` parameter.
         :param dtype: The new dtype for the Series that results from this operation. Leave None for same
             as lhs, pass a string with the new explicit dtype, or pass a dict that maps rhs.dtype to the
             resulting dtype. If the dict does not contain the rhs.dtype, None is assumed, using the lhs
             dtype.
         :param strict_other_dtypes: list of dtypes that are accepted directly into the rhs, all other ones
-            will be cast to lhs.dtype before the operation. Defaults to `other_dtypes` if none given.
+            (from `other_dtypes`) will be cast to lhs.dtype before the operation. Defaults to
+            `other_dtypes` if none given.
         """
         if len(other_dtypes) == 0:
             raise NotImplementedError(f'binary operation {operation} not supported '

--- a/bach/bach/series/series_boolean.py
+++ b/bach/bach/series/series_boolean.py
@@ -76,8 +76,9 @@ class SeriesBoolean(Series, ABC):
         # Default case: do a regular cast
         return Expression.construct(f'cast({{}} as {cls.get_db_dtype(dialect)})', expression)
 
-    def _comparator_operation(self, other, comparator, other_dtypes=tuple(['bool'])) -> 'SeriesBoolean':
-        return super()._comparator_operation(other, comparator, other_dtypes)
+    def _comparator_operation(self, other, comparator, other_dtypes=tuple(['bool']),
+                              strict_other_dtypes=tuple()) -> 'SeriesBoolean':
+        return super()._comparator_operation(other, comparator, other_dtypes, strict_other_dtypes)
 
     def _boolean_operator(self, other, operator: str, other_dtypes=tuple(['bool'])) -> 'SeriesBoolean':
         fmt_str = f'({{}}) {operator} ({{}})'

--- a/bach/bach/series/series_datetime.py
+++ b/bach/bach/series/series_datetime.py
@@ -355,8 +355,9 @@ class SeriesAbstractDateTime(Series, ABC):
         return Expression.construct(f'cast({{}} as {cls.get_db_dtype(dialect)})', expression)
 
     def _comparator_operation(self, other, comparator,
-                              other_dtypes=('timestamp', 'date', 'time', 'string')) -> 'SeriesBoolean':
-        return super()._comparator_operation(other, comparator, other_dtypes)
+                              other_dtypes=('timestamp', 'date', 'time', 'string'),
+                              strict_other_dtypes=tuple()) -> 'SeriesBoolean':
+        return super()._comparator_operation(other, comparator, other_dtypes, strict_other_dtypes)
 
     @classmethod
     def _cast_to_date_if_dtype_date(cls, series: 'Series') -> 'Series':
@@ -505,14 +506,12 @@ class SeriesTimestamp(SeriesAbstractDateTime):
                                           dtype=type_mapping)
 
     def _comparator_operation(
-        self, other, comparator, other_dtypes=('timestamp', 'date', 'time', 'string')
+        self, other, comparator, other_dtypes=('timestamp', 'date', 'time', 'string'),
+        strict_other_dtypes=tuple()
     ) -> 'SeriesBoolean':
-        from bach import SeriesBoolean
-        other = value_to_series(base=self, value=other)
-        self_modified, other = self._get_supported(f"comparator '{comparator}'", other_dtypes, other)
-        other = other.astype(self.dtype)
-        expression = Expression.construct(f'({{}}) {comparator} ({{}})', self_modified, other)
-        return self_modified.copy_override_type(SeriesBoolean).copy_override(expression=expression)
+        # only comparison between timestamp and timestamp, force cast via strict_other_dtypes
+        return Series._comparator_operation(self, other, comparator, other_dtypes,
+                                            strict_other_dtypes=tuple('timestamp'))
 
 
 class SeriesDate(SeriesAbstractDateTime):
@@ -649,8 +648,9 @@ class SeriesTimedelta(SeriesAbstractDateTime):
         )
 
     def _comparator_operation(self, other, comparator,
-                              other_dtypes=('timedelta', 'string')) -> SeriesBoolean:
-        return super()._comparator_operation(other, comparator, other_dtypes)
+                              other_dtypes=('timedelta', 'string'),
+                              strict_other_dtypes=tuple()) -> SeriesBoolean:
+        return super()._comparator_operation(other, comparator, other_dtypes, strict_other_dtypes)
 
     def __add__(self, other) -> 'Series':
         type_mapping = {

--- a/bach/bach/series/series_json.py
+++ b/bach/bach/series/series_json.py
@@ -232,26 +232,24 @@ class SeriesJson(Series):
         self,
         other: Union['Series', AllSupportedLiteralTypes],
         comparator: str,
-        other_dtypes=tuple()
+        other_dtypes=tuple(),
+        strict_other_dtypes=tuple()
     ) -> 'SeriesBoolean':
         if is_postgres(self.engine):
             other_dtypes = ('json_postgres', 'json', 'string')
-            fmt_str = f'cast({{}} as jsonb) {comparator} cast({{}} as jsonb)'
+            strict_other_dtypes = tuple(['json_postgres'])
         elif is_athena(self.engine):
-            # TODO: support string here to for compatibility with other databases
-            #  https://github.com/objectiv/objectiv-analytics/issues/1142
-            other_dtypes = ('json')
-            fmt_str = f'{{}} {comparator} {{}}'
+            other_dtypes = ('json', 'string')
+            strict_other_dtypes = tuple(['json'])
         elif is_bigquery(self.engine):
             other_dtypes = ('json', 'string')
-            fmt_str = f'{{}} {comparator} {{}}'
         else:
             raise DatabaseNotSupportedException(self.engine)
 
         result = self._binary_operation(
             other, operation=f"comparator '{comparator}'",
-            fmt_str=fmt_str,
-            other_dtypes=other_dtypes, dtype='bool'
+            fmt_str=f'{{}} {comparator} {{}}',
+            other_dtypes=other_dtypes, dtype='bool', strict_other_dtypes=strict_other_dtypes
         )
         return cast('SeriesBoolean', result)  # we told _binary_operation to return dtype='bool'
 

--- a/bach/bach/series/series_numeric.py
+++ b/bach/bach/series/series_numeric.py
@@ -39,8 +39,9 @@ class SeriesAbstractNumeric(Series, ABC):
                               other_dtypes=('int64', 'float64'), dtype=None):
         return super()._arithmetic_operation(other, operation, fmt_str, other_dtypes, dtype)
 
-    def _comparator_operation(self, other, comparator, other_dtypes=('int64', 'float64')) -> 'SeriesBoolean':
-        return super()._comparator_operation(other, comparator, other_dtypes)
+    def _comparator_operation(self, other, comparator, other_dtypes=('int64', 'float64'),
+                              strict_other_dtypes=tuple()) -> 'SeriesBoolean':
+        return super()._comparator_operation(other, comparator, other_dtypes, strict_other_dtypes)
 
     def exp(self) -> 'SeriesAbstractNumeric':
         """

--- a/bach/bach/series/series_string.py
+++ b/bach/bach/series/series_string.py
@@ -258,8 +258,9 @@ class SeriesString(Series):
     def __add__(self, other) -> 'Series':
         return self._binary_operation(other, 'concat', '{} || {}', other_dtypes=('string',))
 
-    def _comparator_operation(self, other, comparator, other_dtypes=tuple(['string'])) -> 'SeriesBoolean':
-        return super()._comparator_operation(other, comparator, other_dtypes)
+    def _comparator_operation(self, other, comparator, other_dtypes=tuple(['string']),
+                              strict_other_dtypes=tuple()) -> 'SeriesBoolean':
+        return super()._comparator_operation(other, comparator, other_dtypes, strict_other_dtypes)
 
     def to_json_array(self, partition: Optional[WrappedPartition] = None) -> 'SeriesJson':
         """

--- a/bach/tests/functional/bach/test_series_json.py
+++ b/bach/tests/functional/bach/test_series_json.py
@@ -70,6 +70,23 @@ def test_json_get_single_value(engine, dtype):
     assert a == {'a': 'b', 'c': {'a': 'c'}}
 
 
+def test_json_equals(engine, dtype):
+    df = get_df_with_json_data(engine=engine, dtype=dtype)
+    df['j2j_dict'] = df['dict_column'] == df['dict_column']
+    df['j2literal'] = df['list_column'] == '[{"a": "b"}, {"c": "d"}]'
+    assert_equals_data(
+        df[['j2j_dict', 'j2literal']],
+        expected_columns=['_index_row', 'j2j_dict', 'j2literal'],
+        expected_data=[
+            [0, True, True],
+            [1, True, False],
+            [2, True, False],
+            [3, True, False],
+            [4, None, None]
+        ]
+    )
+
+
 def test_json_array_contains(engine, dtype):
     # Setting up custom test data
     # The data from `get_df_with_json_data` only contains one row with an array with scalars, so we use this


### PR DESCRIPTION
When doing binary operations, we sometimes need to cast RHS to a specific datatype before doing the operation. This suggest a way to do this, and shows two ways it is helpful.

Fixes #1142 in the process.