### PR TITLE
React SDK: Name attribute support for radios and checkboxes

### DIFF
--- a/tracker/trackers/react/src/trackedContexts/TrackedInputContext/TrackedInputContextRadio.tsx
+++ b/tracker/trackers/react/src/trackedContexts/TrackedInputContext/TrackedInputContextRadio.tsx
@@ -2,13 +2,7 @@
  * Copyright 2022 Objectiv B.V.
  */
 
-import {
-  GlobalContexts,
-  LocationStack,
-  makeContentContext,
-  makeIdFromString,
-  makeInputValueContext,
-} from '@objectiv/tracker-core';
+import { GlobalContexts, LocationStack, makeIdFromString, makeInputValueContext } from '@objectiv/tracker-core';
 import {
   EventTrackerParameters,
   InputContextWrapper,
@@ -89,22 +83,6 @@ export const TrackedInputContextRadio = React.forwardRef<HTMLInputElement, Track
           ...trackingContext,
           globalContexts: [],
         };
-
-        // Add LocationContext representing the radio group, if the `name` attribute has been set
-        if (eventTarget.name) {
-          const nameContentContextId = makeIdFromString(eventTarget.name);
-          if (nameContentContextId) {
-            const locationStackClone = [...eventTrackerParameters.locationStack];
-            locationStackClone.splice(
-              eventTrackerParameters.locationStack.length - 1,
-              0,
-              makeContentContext({
-                id: nameContentContextId,
-              })
-            );
-            eventTrackerParameters.locationStack = locationStackClone;
-          }
-        }
 
         // Add InputValueContext if trackValue has been set
         if (inputId && trackValue) {

--- a/tracker/trackers/react/src/trackedElements/TrackedInputCheckbox.tsx
+++ b/tracker/trackers/react/src/trackedElements/TrackedInputCheckbox.tsx
@@ -33,13 +33,10 @@ export const TrackedInputCheckbox = React.forwardRef<HTMLInputElement, TrackedIn
     );
   }
 
-  return (
-    <TrackedInputContext
-      {...props}
-      id={props.id ?? (props.value ? props.value.toString() : '')}
-      Component={'input'}
-      type={'checkbox'}
-      ref={ref}
-    />
-  );
+  // Use the given `id` or attempt to automatically generate one with either `name` or `value`
+  const nameAttribute: string | null = props.name ? props.name : null;
+  const valueAttribute: string | null = props.value ? props.value.toString() : null;
+  const id: string = props.id ?? nameAttribute ?? valueAttribute ?? '';
+
+  return <TrackedInputContext {...props} id={id} Component={'input'} type={'checkbox'} ref={ref} />;
 });

--- a/tracker/trackers/react/src/trackedElements/TrackedInputRadio.tsx
+++ b/tracker/trackers/react/src/trackedElements/TrackedInputRadio.tsx
@@ -34,13 +34,10 @@ export const TrackedInputRadio = React.forwardRef<HTMLInputElement, TrackedInput
     );
   }
 
-  return (
-    <TrackedInputContext
-      {...props}
-      id={props.id ?? (props.value ? props.value.toString() : '')}
-      Component={'input'}
-      type={'radio'}
-      ref={ref}
-    />
-  );
+  // Use the given `id` or attempt to automatically generate one with either `name` or `value`
+  const nameAttribute: string | null = props.name ? props.name : null;
+  const valueAttribute: string | null = props.value ? props.value.toString() : null;
+  const id: string = props.id ?? nameAttribute ?? valueAttribute ?? '';
+
+  return <TrackedInputContext {...props} id={id} Component={'input'} type={'radio'} ref={ref} />;
 });

--- a/tracker/trackers/react/tests/TrackedInputCheckbox.test.tsx
+++ b/tracker/trackers/react/tests/TrackedInputCheckbox.test.tsx
@@ -81,16 +81,47 @@ describe('TrackedInputCheckbox', () => {
 
     render(
       <ObjectivProvider tracker={tracker}>
-        <TrackedInputCheckbox data-testid={'test-checkbox'} value={'value'} trackValue={true} />
+        <TrackedInputCheckbox data-testid={'test-checkbox-1'} name={'name'} trackValue={true} />
+        <TrackedInputCheckbox data-testid={'test-checkbox-2'} value={'value'} trackValue={true} />
       </ObjectivProvider>
     );
 
     jest.resetAllMocks();
 
-    fireEvent.click(screen.getByTestId('test-checkbox'));
+    fireEvent.click(screen.getByTestId('test-checkbox-1'));
+    fireEvent.click(screen.getByTestId('test-checkbox-2'));
 
-    expect(logTransport.handle).toHaveBeenCalledTimes(1);
-    expect(logTransport.handle).toHaveBeenCalledWith(
+    expect(logTransport.handle).toHaveBeenCalledTimes(2);
+    expect(logTransport.handle).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        _type: 'InputChangeEvent',
+        location_stack: expect.arrayContaining([
+          expect.objectContaining({
+            _type: LocationContextName.InputContext,
+            id: 'name',
+          }),
+        ]),
+        global_contexts: expect.arrayContaining([
+          expect.objectContaining({
+            _type: GlobalContextName.ApplicationContext,
+          }),
+          expect.objectContaining({
+            _type: GlobalContextName.PathContext,
+          }),
+          expect.objectContaining({
+            _type: GlobalContextName.HttpContext,
+          }),
+          expect.objectContaining({
+            _type: GlobalContextName.InputValueContext,
+            id: 'name',
+            value: '1',
+          }),
+        ]),
+      })
+    );
+    expect(logTransport.handle).toHaveBeenNthCalledWith(
+      2,
       expect.objectContaining({
         _type: 'InputChangeEvent',
         location_stack: expect.arrayContaining([

--- a/tracker/trackers/react/tests/TrackedInputRadio.test.tsx
+++ b/tracker/trackers/react/tests/TrackedInputRadio.test.tsx
@@ -81,16 +81,47 @@ describe('TrackedInputRadio', () => {
 
     render(
       <ObjectivProvider tracker={tracker}>
-        <TrackedInputRadio data-testid={'test-radio'} value={'value'} trackValue={true} />
+        <TrackedInputRadio data-testid={'test-radio-1'} name={'name'} trackValue={true} />
+        <TrackedInputRadio data-testid={'test-radio-2'} value={'value'} trackValue={true} />
       </ObjectivProvider>
     );
 
     jest.resetAllMocks();
 
-    fireEvent.click(screen.getByTestId('test-radio'));
+    fireEvent.click(screen.getByTestId('test-radio-1'));
+    fireEvent.click(screen.getByTestId('test-radio-2'));
 
-    expect(logTransport.handle).toHaveBeenCalledTimes(1);
-    expect(logTransport.handle).toHaveBeenCalledWith(
+    expect(logTransport.handle).toHaveBeenCalledTimes(2);
+    expect(logTransport.handle).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        _type: 'InputChangeEvent',
+        location_stack: expect.arrayContaining([
+          expect.objectContaining({
+            _type: LocationContextName.InputContext,
+            id: 'name',
+          }),
+        ]),
+        global_contexts: expect.arrayContaining([
+          expect.objectContaining({
+            _type: GlobalContextName.ApplicationContext,
+          }),
+          expect.objectContaining({
+            _type: GlobalContextName.PathContext,
+          }),
+          expect.objectContaining({
+            _type: GlobalContextName.HttpContext,
+          }),
+          expect.objectContaining({
+            _type: GlobalContextName.InputValueContext,
+            id: 'name',
+            value: '1',
+          }),
+        ]),
+      })
+    );
+    expect(logTransport.handle).toHaveBeenNthCalledWith(
+      2,
       expect.objectContaining({
         _type: 'InputChangeEvent',
         location_stack: expect.arrayContaining([
@@ -181,10 +212,6 @@ describe('TrackedInputRadio', () => {
       expect.objectContaining({
         _type: 'InputChangeEvent',
         location_stack: expect.arrayContaining([
-          expect.objectContaining({
-            _type: LocationContextName.ContentContext,
-            id: 'radios',
-          }),
           expect.objectContaining({
             _type: LocationContextName.InputContext,
             id: 'input-id-1',


### PR DESCRIPTION
Checkboxes and radios may omit name and/or value depending on their implementation. In this PR we add some logic to detect whatever is available. We use the given id, or pick either the name or value, respectively. If an input has neither, an error will be logged to console, as we don't have a way of assigning an identifier to InputContext and InputValueContext.