### PR TITLE
ModelHub: Limit retrieved elements from array subquery

### DIFF
--- a/modelhub/modelhub/series/series_objectiv.py
+++ b/modelhub/modelhub/series/series_objectiv.py
@@ -60,7 +60,7 @@ class ObjectivStack(JsonAccessor, Generic[TSeriesJson]):
             '''(
               select first_value(ctx) over (order by pos)
               from unnest(json_query_array({}, '$')) as ctx with offset as pos
-              where json_value(ctx, '$."_type"') = {}
+              where json_value(ctx, '$."_type"') = {} limit 1
             )''',
             self._series_object,
             Expression.string_value(type)


### PR DESCRIPTION
If having multiple contexts from the same type, subquery in `_bigquery_get_from_context_with_type_series` will return first element of the array for each element (generating multiple scalars)