### PR TITLE
Set explicit start and end date for notebooks with doctests

### DIFF
--- a/bach/docs/source/example-notebooks/explore-data.rst
+++ b/bach/docs/source/example-notebooks/explore-data.rst
@@ -19,6 +19,21 @@ Get started
 -----------
 We first have to instantiate the model hub and an Objectiv DataFrame object.
 
+.. doctest::
+	:skipif: engine is None
+
+	>>> # set the timeframe of the analysis
+	>>> start_date = '2022-06-01'
+	>>> end_date = None
+
+.. we override the timeframe for the doctests below
+	
+.. testsetup:: explore-data
+	:skipif: engine is None
+
+	start_date = '2022-06-01'
+	end_date = '2022-06-30'
+
 .. doctest:: explore-data
 	:skipif: engine is None
 
@@ -26,7 +41,7 @@ We first have to instantiate the model hub and an Objectiv DataFrame object.
 	>>> from modelhub import ModelHub
 	>>> modelhub = ModelHub(time_aggregation='%Y-%m-%d')
 	>>> # get an Objectiv DataFrame within a defined timeframe
-	>>> df = modelhub.get_objectiv_dataframe(db_url=DB_URL, start_date='2022-06-01', end_date='2022-06-30')
+	>>> df = modelhub.get_objectiv_dataframe(db_url=DB_URL, start_date=start_date, end_date=end_date)
 
 .. admonition:: Reference
 	:class: api-reference

--- a/bach/docs/source/example-notebooks/funnel-discovery.rst
+++ b/bach/docs/source/example-notebooks/funnel-discovery.rst
@@ -4,16 +4,6 @@
 
 .. currentmodule:: bach
 
-.. testsetup:: funnel-discovery
-	:skipif: engine is None
-
-	df = modelhub.get_objectiv_dataframe(
-			db_url=DB_URL,
-			start_date='2022-02-01',
-			end_date='2022-06-30',
-			table_name='data')
-	pd.set_option('display.max_colwidth', 93)
-
 ================
 Funnel Discovery
 ================
@@ -47,6 +37,22 @@ Get started
 -----------
 We first have to instantiate the model hub and an Objectiv DataFrame object.
 
+.. doctest::
+	:skipif: engine is None
+
+	>>> # set the timeframe of the analysis
+	>>> start_date = '2022-02-01'
+	>>> end_date = None
+
+.. we override the timeframe for the doctests below
+	
+.. testsetup:: funnel-discovery
+	:skipif: engine is None
+
+	start_date = '2022-02-01'
+	end_date = '2022-06-30'
+	pd.set_option('display.max_colwidth', 93)
+
 .. doctest:: funnel-discovery
 	:skipif: engine is None
 
@@ -54,7 +60,7 @@ We first have to instantiate the model hub and an Objectiv DataFrame object.
 	>>> from modelhub import ModelHub
 	>>> modelhub = ModelHub(time_aggregation='%Y-%m-%d')
 	>>> # get an Objectiv DataFrame within a defined timeframe
-	>>> df = modelhub.get_objectiv_dataframe(db_url=DB_URL, start_date='2022-02-01', end_date='2022-06-30')
+	>>> df = modelhub.get_objectiv_dataframe(db_url=DB_URL, start_date=start_date, end_date=end_date)
 
 .. doctest:: funnel-discovery
 	:skipif: engine is None

--- a/bach/docs/source/example-notebooks/marketing-analytics.rst
+++ b/bach/docs/source/example-notebooks/marketing-analytics.rst
@@ -19,9 +19,20 @@ Get started
 -----------
 We first have to instantiate the model hub and an Objectiv DataFrame object.
 
+.. doctest::
+	:skipif: engine is None
+
+	>>> # set the timeframe of the analysis
+	>>> start_date = '2022-06-01'
+	>>> end_date = None
+
+.. we override the timeframe for the doctests below
+	
 .. testsetup:: marketing-analytics
 	:skipif: engine is None
 
+	start_date = '2022-06-01'
+	end_date = '2022-08-20'
 	pd.set_option('display.max_colwidth', 93)
 
 .. doctest:: marketing-analytics
@@ -34,7 +45,7 @@ We first have to instantiate the model hub and an Objectiv DataFrame object.
 	>>> import pandas as pd
 	>>> modelhub = ModelHub(time_aggregation='%Y-%m-%d')
 	>>> # get an Objectiv DataFrame within a defined timeframe
-	>>> df = modelhub.get_objectiv_dataframe(db_url=DB_URL, start_date='2022-06-01', end_date='2022-08-20')
+	>>> df = modelhub.get_objectiv_dataframe(db_url=DB_URL, start_date=start_date, end_date=end_date)
 
 .. doctest:: marketing-analytics
 	:skipif: engine is None

--- a/bach/docs/source/example-notebooks/product-analytics.rst
+++ b/bach/docs/source/example-notebooks/product-analytics.rst
@@ -19,9 +19,20 @@ Get started
 -----------
 We first have to instantiate the model hub and an Objectiv DataFrame object.
 
+.. doctest::
+	:skipif: engine is None
+
+	>>> # set the timeframe of the analysis
+	>>> start_date = '2022-03-01'
+	>>> end_date = None
+
+.. we override the timeframe for the doctests below
+	
 .. testsetup:: product-analytics
 	:skipif: engine is None
 
+	start_date = '2022-03-01'
+	end_date = '2022-07-30'
 	pd.set_option('display.max_colwidth', 93)
 
 .. doctest:: product-analytics
@@ -33,7 +44,7 @@ We first have to instantiate the model hub and an Objectiv DataFrame object.
 	>>> # instantiate the model hub and set the default time aggregation to daily
 	>>> modelhub = ModelHub(time_aggregation='%Y-%m-%d')
 	>>> # get a Bach DataFrame with Objectiv data within a defined timeframe
-	>>> df = modelhub.get_objectiv_dataframe(start_date='2022-03-01', end_date='2022-07-30')
+	>>> df = modelhub.get_objectiv_dataframe(start_date=start_date, end_date=end_date)
 
 .. doctest:: product-analytics
 	:skipif: engine is None

--- a/notebooks/basic-product-analytics.ipynb
+++ b/notebooks/basic-product-analytics.ipynb
@@ -36,6 +36,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "95a751dc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# set the timeframe of the analysis\n",
+    "start_date = '2022-03-01'\n",
+    "end_date = None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "4bd369f6",
    "metadata": {},
    "outputs": [],
@@ -47,7 +59,7 @@
     "# instantiate the model hub and set the default time aggregation to daily\n",
     "modelhub = ModelHub(time_aggregation='%Y-%m-%d')\n",
     "# get a Bach DataFrame with Objectiv data within a defined timeframe\n",
-    "df = modelhub.get_objectiv_dataframe(start_date='2022-03-01', end_date='2022-07-30')"
+    "df = modelhub.get_objectiv_dataframe(start_date=start_date, end_date=end_date)"
    ]
   },
   {
@@ -691,7 +703,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.10"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,

--- a/notebooks/explore-your-data.ipynb
+++ b/notebooks/explore-your-data.ipynb
@@ -31,6 +31,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "25dca285",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# set the timeframe of the analysis\n",
+    "start_date = '2022-06-01'\n",
+    "end_date = None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "3756a344-8072-4d6d-9c86-ea6bb8428ff8",
    "metadata": {},
    "outputs": [],
@@ -41,7 +53,7 @@
     "# instantiate the model hub and set the default time aggregation to daily\n",
     "modelhub = ModelHub(time_aggregation='%Y-%m-%d')\n",
     "# get a Bach DataFrame with Objectiv data within a defined timeframe\n",
-    "df = modelhub.get_objectiv_dataframe(start_date='2022-06-01', end_date='2022-06-30')"
+    "df = modelhub.get_objectiv_dataframe(start_date=start_date, end_date=end_date)"
    ]
   },
   {
@@ -296,7 +308,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.10"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,

--- a/notebooks/funnel-discovery.ipynb
+++ b/notebooks/funnel-discovery.ipynb
@@ -43,6 +43,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "id": "3959e6a6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# set the timeframe of the analysis\n",
+    "start_date = '2022-02-01'\n",
+    "end_date = None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "4bd369f6",
    "metadata": {},
    "outputs": [],
@@ -51,7 +63,7 @@
     "from modelhub import ModelHub\n",
     "modelhub = ModelHub(time_aggregation='%Y-%m-%d')\n",
     "# get an Objectiv DataFrame within a defined timeframe\n",
-    "df = modelhub.get_objectiv_dataframe(start_date='2022-02-01', end_date='2022-06-30')"
+    "df = modelhub.get_objectiv_dataframe(start_date=start_date, end_date=end_date)"
    ]
   },
   {
@@ -659,7 +671,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.10"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,

--- a/notebooks/marketing-analytics.ipynb
+++ b/notebooks/marketing-analytics.ipynb
@@ -29,6 +29,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# set the timeframe of the analysis\n",
+    "start_date = '2022-06-01'\n",
+    "end_date = None"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "from modelhub import ModelHub\n",
     "from bach import DataFrame, display_sql_as_markdown\n",
     "from datetime import datetime, timedelta\n",
@@ -37,7 +48,7 @@
     "# instantiate the model hub and set the default time aggregation to daily\n",
     "modelhub = ModelHub(time_aggregation='%Y-%m-%d')\n",
     "# get a Bach DataFrame with Objectiv data within a defined timeframe\n",
-    "df = modelhub.get_objectiv_dataframe(start_date='2022-06-01', end_date='2022-08-20')"
+    "df = modelhub.get_objectiv_dataframe(start_date=start_date, end_date=end_date)"
    ]
   },
   {


### PR DESCRIPTION
Set explicit start and end date for notebooks, which can be overridden in doctests to keep data results consistent.