### PR TITLE
Make docstring and implementation of get_db_dtype consistent

### DIFF
--- a/bach/bach/series/series.py
+++ b/bach/bach/series/series.py
@@ -383,15 +383,15 @@ class Series(ABC):
         """
         Give the database type used to store values of this Series, for the given database dialect.
 
-        ..note:
-            Multiple Series types might return the same db_dtype. For example on BigQuery
-        `SeriesUuid`, `SeriesJson`, and `SeriesString` will all return 'STRING'. As we use the STRING
-        database type to store all of those value types.
-
         :raises DatabaseNotSupportedException: If the Series subclass doesn't support the database dialect.
-        :return: database type as string, or None if this Series database type is a structural type whose
+        :return: Database type as string, or None if this Series database type is a structural type whose
             exact type depends on the data of the subtypes (e.g. SeriesList will return None on BigQuery,
             as it can handle all ARRAY<*> subtypes)
+
+        .. note::
+            Multiple Series types might return the same db_dtype. For example on BigQuery
+            :class:`SeriesUuid`, :class:`SeriesJson`, and :class:`SeriesString` will all return 'STRING'.
+            As we use the STRING database type to store all of those value types.
         """
         db_dialect = DBDialect.from_dialect(dialect)
         if db_dialect not in cls.supported_db_dtype:

--- a/bach/bach/series/series.py
+++ b/bach/bach/series/series.py
@@ -381,13 +381,16 @@ class Series(ABC):
     @classmethod
     def get_db_dtype(cls, dialect: Dialect) -> Optional[str]:
         """
-        Give the static db_dtype of this Series, for the given database dialect.
+        Give the static db_dtype used to store values of this Series, for the given database dialect.
+
+        Note: Multiple Series types might return the same db_dtype. For example on BigQuery
+        `SeriesUuid`, `SeriesJson`, and `SeriesString` will all return 'STRING'. As we use the STRING
+        database type to store all of those value types.
 
         :raises DatabaseNotSupportedException: If the Series subclass doesn't support the database dialect.
-        :return: database type as string, or None if this Series has no database type for which it is the
-            standard Series for that database, or if that type is a structural type whose exact type depends
-            on the data of the subtypes (e.g. SeriesList will return None on BigQuery, as it can handle all
-            ARRAY<*> subtypes)
+        :return: database type as string, or None if this Series database type is a structural type whose
+            exact type depends on the data of the subtypes (e.g. SeriesList will return None on BigQuery,
+            as it can handle all ARRAY<*> subtypes)
         """
         db_dialect = DBDialect.from_dialect(dialect)
         if db_dialect not in cls.supported_db_dtype:

--- a/bach/bach/series/series.py
+++ b/bach/bach/series/series.py
@@ -381,9 +381,10 @@ class Series(ABC):
     @classmethod
     def get_db_dtype(cls, dialect: Dialect) -> Optional[str]:
         """
-        Give the static db_dtype used to store values of this Series, for the given database dialect.
+        Give the database type used to store values of this Series, for the given database dialect.
 
-        Note: Multiple Series types might return the same db_dtype. For example on BigQuery
+        ..note:
+            Multiple Series types might return the same db_dtype. For example on BigQuery
         `SeriesUuid`, `SeriesJson`, and `SeriesString` will all return 'STRING'. As we use the STRING
         database type to store all of those value types.
 

--- a/bach/bach/series/series_json.py
+++ b/bach/bach/series/series_json.py
@@ -168,6 +168,13 @@ class SeriesJson(Series):
         return self.json
 
     @classmethod
+    def get_db_dtype(cls, dialect: Dialect) -> Optional[str]:
+        if is_bigquery(dialect):
+            from bach.series import SeriesString
+            return SeriesString.get_db_dtype(dialect)
+        return super().get_db_dtype(dialect)
+
+    @classmethod
     def supported_literal_to_expression(cls, dialect: Dialect, literal: Expression) -> Expression:
         if is_postgres(dialect):
             return super().supported_literal_to_expression(dialect=dialect, literal=literal)


### PR DESCRIPTION
Something I noticed in a review: What `get_db_dtype` does was not consistent with what the docstring said.

Changes:
1. Removed from the `:return:` explanation the part that said: `or None if this Series has no database type for which it is the standard Series for that database`
2. Added clarifcation to docstring 
3. Made implemenation of `SeriesJson` consistent