### PR TITLE
Bach athena date formatting

### DIFF
--- a/bach/bach/series/series_datetime.py
+++ b/bach/bach/series/series_datetime.py
@@ -102,6 +102,7 @@ class DateTimeOperation:
 
         The subset of codes that are supported across all databases is:
             %A, %B, %F, %H, %I, %M, %R, %S, %T, %Y, %a, %b, %d, %j, %m, %y
+        Additionally one specific combination is supported: '%S.%f'
 
         .. code-block:: python
 

--- a/bach/bach/series/series_datetime.py
+++ b/bach/bach/series/series_datetime.py
@@ -2,7 +2,6 @@
 Copyright 2021 Objectiv B.V.
 """
 import datetime
-import warnings
 from abc import ABC
 from enum import Enum
 from typing import Union, cast, List, Tuple, Optional, Any
@@ -92,24 +91,26 @@ class DateTimeOperation:
         """
         Allow formatting of this Series (to a string type).
 
-        :param format_str: The format to apply to the date/time column. See Format Codes below for more
-        information on what is supported.
+        :param format_str: The format to apply to the date/time column. See Supported Format Codes below for
+        more information on what is supported.
 
+        :returns: a SeriesString containing the formatted date.
 
-        Format Codes
-        A subset of the 1989 C standard format codes is supported. See the python documentation for the
+        **Supported Format Codes**
+
+        A subset of the C standard format codes is supported. See the python documentation for the
         code semantics: https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes
 
         The subset of codes that are supported across all databases is:
-            %A, %B, %F, %H, %I, %M, %R, %S, %T, %Y, %a, %b, %d, %j, %m, %y
-        Additionally one specific combination is supported: '%S.%f'
+            `%A`, `%B`, `%F`, `%H`, `%I`, `%M`, `%R`, `%S`, `%T`, `%Y`, `%a`, `%b`, `%d`, `%j`, `%m`, `%y`
+        Additionally one specific combination is supported: `%S.%f`
+
+        **Example**
 
         .. code-block:: python
 
-            df['year'] = df.some_date_series.dt.sql_format('%Y')  # return year
-            df['date'] = df.some_date_series.dt.sql_format('%Y%m%d')  # return date
-
-        :returns: a SeriesString containing the formatted date.
+            df['year'] = df.some_date_series.dt.strftime('%Y')  # return year
+            df['date'] = df.some_date_series.dt.strftime('%Y%m%d')  # return date
         """
         engine = self._series.engine
         series = self._series

--- a/bach/bach/series/series_datetime.py
+++ b/bach/bach/series/series_datetime.py
@@ -2,6 +2,7 @@
 Copyright 2021 Objectiv B.V.
 """
 import datetime
+import warnings
 from abc import ABC
 from enum import Enum
 from typing import Union, cast, List, Tuple, Optional, Any

--- a/bach/bach/series/utils/datetime_formats.py
+++ b/bach/bach/series/utils/datetime_formats.py
@@ -225,7 +225,7 @@ def parse_c_code_to_athena_code(date_format: str) -> str:
     Parses a date format string, and return a string that's compatible with Athena's date_format() function.
 
     Some python format codes are different on Athena, or might even raise an error. Such codes are converted
-    or escaped; using the returned string with Athena's data_format will never raise an error.
+    or escaped; using the returned string with Athena's date_format will never raise an error.
 
     Codes in CODES_SUPPORTED_IN_ALL_DIALECTS are guaranteed to be correctly represented in the returned
     format string. If date_format contains codes that are not in that set, then the returned format might

--- a/bach/bach/series/utils/datetime_formats.py
+++ b/bach/bach/series/utils/datetime_formats.py
@@ -43,7 +43,7 @@ CODES_SUPPORTED_IN_ALL_DIALECTS = {
     # '%%',  # PERCENT_CHAR
 }
 
-_STRINGS_SUPPORTED_IN_ALL_DIALECTS = {
+STRINGS_SUPPORTED_IN_ALL_DIALECTS = {
     '%S.%f',  # <seconds>.<microsecnds>
 }
 

--- a/bach/bach/series/utils/datetime_formats.py
+++ b/bach/bach/series/utils/datetime_formats.py
@@ -44,6 +44,9 @@ CODES_SUPPORTED_IN_ALL_DIALECTS = {
 }
 
 STRINGS_SUPPORTED_IN_ALL_DIALECTS = {
+    # These are the combinations of codes that we support for all database dialects, even if some of the
+    # individual codes are not supported.
+
     '%S.%f',  # <seconds>.<microsecnds>
 }
 

--- a/bach/tests/functional/bach/test_data_and_utils.py
+++ b/bach/tests/functional/bach/test_data_and_utils.py
@@ -237,6 +237,7 @@ def assert_equals_data(
     _date_freq = 'ms' if is_athena(bt.engine) else 'us'
     for i, df_row in enumerate(db_values):
         expected_row = expected_data[i]
+        assert len(df_row) == len(expected_row)
         for j, val in enumerate(df_row):
             actual = copy(val)
             expected = copy(expected_row[j])

--- a/bach/tests/functional/bach/test_series_date.py
+++ b/bach/tests/functional/bach/test_series_date.py
@@ -13,7 +13,7 @@ from tests.functional.bach.test_data_and_utils import assert_equals_data,\
 from tests.functional.bach.test_series_timestamp import types_plus_min
 
 from bach.series.utils.datetime_formats import _C_STANDARD_CODES_X_POSTGRES_DATE_CODES, \
-    CODES_SUPPORTED_IN_ALL_DIALECTS
+    CODES_SUPPORTED_IN_ALL_DIALECTS, STRINGS_SUPPORTED_IN_ALL_DIALECTS
 
 
 @pytest.mark.athena_supported()
@@ -64,6 +64,8 @@ def test_date_format(engine, recwarn):
         f'{c[1]}: {c}'
         for c in sorted(CODES_SUPPORTED_IN_ALL_DIALECTS)
     )
+    # Create format string that contains all strings that we claim to support in addition to the codes above.
+    format_str_all_supported_strings = ' | '.join(STRINGS_SUPPORTED_IN_ALL_DIALECTS)
 
     all_formats = [
         'Year: %Y',
@@ -74,6 +76,7 @@ def test_date_format(engine, recwarn):
         '%q %1 %_',
         # all codes that we claim to support for all databases
         format_str_all_supported_codes,
+        format_str_all_supported_strings
     ]
 
     for idx, fmt in enumerate(all_formats):
@@ -117,6 +120,7 @@ def test_date_format(engine, recwarn):
                 '%q %1 %_', '%q %1 %_',
                 'A: Saturday | B: January | F: 2022-01-01 | H: 00 | I: 12 | M: 00 | R: 00:00 | S: 00 | T: 00:00:00 | Y: 2022 | a: Sat | b: Jan | d: 01 | j: 001 | m: 01 | y: 22',
                 'A: Monday | B: May | F: 2021-05-03 | H: 11 | I: 11 | M: 28 | R: 11:28 | S: 36 | T: 11:28:36 | Y: 2021 | a: Mon | b: May | d: 03 | j: 123 | m: 05 | y: 21',
+                '00.000000', '36.388000'
             ],
         ],
     )

--- a/bach/tests/unit/bach/test_series_utils_datetime_formats.py
+++ b/bach/tests/unit/bach/test_series_utils_datetime_formats.py
@@ -1,7 +1,16 @@
 """
 Copyright 2022 Objectiv B.V.
 """
-from bach.series.utils.datetime_formats import parse_c_standard_code_to_postgres_code, parse_c_code_to_bigquery_code
+import pytest
+
+from bach.series.utils.datetime_formats import parse_c_standard_code_to_postgres_code, \
+    parse_c_code_to_bigquery_code, parse_c_code_to_athena_code
+
+
+pytestmark = [pytest.mark.db_independent]  # mark all tests here as database independent.
+# Better would be to have a mark called 'db_specific' or something like that.
+# The point is that all tests in this file run are specific to a database dialect, and don't need to be run
+# for all database dialects.
 
 
 def test_parse_c_standard_code_to_postgres_code(recwarn):
@@ -54,3 +63,14 @@ def test_parse_c_code_to_bigquery_code(recwarn):
     result = recwarn[0]
     assert issubclass(result.category, UserWarning)
     assert str(result.message) == "There are no equivalent codes for %f."
+
+
+def test_parse_c_code_to_athena_code(recwarn):
+    assert parse_c_code_to_athena_code('%Y-%m-%d') == '%Y-%m-%d'
+    assert parse_c_code_to_athena_code('%M-%B') == '%i-%M'
+    # Escape not supported codes:
+    assert parse_c_code_to_athena_code('%V') == '%%V'
+    assert parse_c_code_to_athena_code('%q %1 %_') == '%%q %%1 %%_'
+    # Handle double quotes correctly
+    assert parse_c_code_to_athena_code('%%%m') == '%%%m'
+    assert len(recwarn) == 0


### PR DESCRIPTION
Changes:
* Support `strftime()` for Athena
  * Only support a subset of format codes
* Clearly define which format strings we support on all platforms
* Expand functional test: test all codes that we support on all platforms
* Fix issue on BigQuery where strftime() with time related format codes didn't work correctly `SeriesDate`. Fixed by converting to `SeriesTimestamp`


Missing here: Warnings for unsupported codes. See the follow-up PR https://github.com/objectiv/objectiv-analytics/pull/1205 that makes warnings consistent on all databases.