### PR TITLE
Bach athena date formatting warnings

### DIFF
--- a/bach/bach/series/series_datetime.py
+++ b/bach/bach/series/series_datetime.py
@@ -14,9 +14,9 @@ from sqlalchemy.engine import Dialect
 from bach import DataFrame
 from bach.series import Series, SeriesString, SeriesBoolean, SeriesFloat64, SeriesInt64
 from bach.expression import Expression, join_expressions, StringValueToken
-from bach.series.series import WrappedPartition, ToPandasInfo, value_to_series
+from bach.series.series import WrappedPartition, ToPandasInfo
 from bach.series.utils.datetime_formats import parse_c_standard_code_to_postgres_code, \
-    parse_c_code_to_bigquery_code, parse_c_code_to_athena_code
+    parse_c_code_to_bigquery_code, parse_c_code_to_athena_code, warn_non_supported_format_codes
 from bach.types import DtypeOrAlias, StructuredDtype
 from sql_models.constants import DBDialect
 from sql_models.util import is_postgres, is_bigquery, DatabaseNotSupportedException, is_athena
@@ -112,6 +112,9 @@ class DateTimeOperation:
         """
         engine = self._series.engine
         series = self._series
+
+        # Warn user if he is using non-supported format codes
+        warn_non_supported_format_codes(format_str)
 
         if is_postgres(engine):
             parsed_format_str = parse_c_standard_code_to_postgres_code(format_str)

--- a/bach/bach/series/utils/datetime_formats.py
+++ b/bach/bach/series/utils/datetime_formats.py
@@ -296,10 +296,14 @@ def warn_non_supported_format_codes(date_format: str):
         # This is the start of a code sequence.
         # See if any of the STRINGS_SUPPORTED_IN_ALL_DIALECTS start at this character
         for supported_string in STRINGS_SUPPORTED_IN_ALL_DIALECTS:
-            sub_str = date_format[i-1:len(supported_string) + i]
+            # Get a string from date_format with the same length as supported_string starting at the current
+            # position.
+            sub_str_start = i - 1
+            sub_str_end = sub_str_start + len(supported_string)
+            sub_str = date_format[sub_str_start:sub_str_end]
             if sub_str == supported_string:
                 # Match: we know this string is good, and can skip to the end of it.
-                i += len(supported_string) - 1
+                i = sub_str_end
                 break  # skip the 'else:' clause of this for loop
         else:
             # If we get here, that means that none of the strings in STRINGS_SUPPORTED_IN_ALL_DIALECTS

--- a/bach/tests/unit/bach/test_series_utils_datetime_formats.py
+++ b/bach/tests/unit/bach/test_series_utils_datetime_formats.py
@@ -1,11 +1,12 @@
 """
 Copyright 2022 Objectiv B.V.
 """
+import warnings
+
 import pytest
 
 from bach.series.utils.datetime_formats import parse_c_standard_code_to_postgres_code, \
-    parse_c_code_to_bigquery_code, parse_c_code_to_athena_code
-
+    parse_c_code_to_bigquery_code, parse_c_code_to_athena_code, warn_non_supported_format_codes
 
 pytestmark = [pytest.mark.db_independent]  # mark all tests here as database independent.
 # Better would be to have a mark called 'db_specific' or something like that.
@@ -13,7 +14,7 @@ pytestmark = [pytest.mark.db_independent]  # mark all tests here as database ind
 # for all database dialects.
 
 
-def test_parse_c_standard_code_to_postgres_code(recwarn):
+def test_parse_c_standard_code_to_postgres_code():
     # single c-code
     assert parse_c_standard_code_to_postgres_code('%Y') == 'YYYY'
 
@@ -44,28 +45,13 @@ def test_parse_c_standard_code_to_postgres_code(recwarn):
     # regular postgres format
     assert parse_c_standard_code_to_postgres_code('YYYYMMDD') == '"YYYYMMDD"'
 
-    assert len(recwarn) == 2
 
-
-# https://docs.pytest.org/en/6.2.x/warnings.html#:~:text=The%20recwarn%20fixture%20will,assert%20w.lineno
-def test_parse_c_standard_code_to_postgres_code_warning(recwarn):
-    parse_c_standard_code_to_postgres_code('%Y-%m-%s-%d %t %g%%%')
-    assert len(recwarn) == 1
-    result = recwarn[0]
-    assert issubclass(result.category, UserWarning)
-    assert str(result.message) == "There are no equivalent codes for ['%%', '%s', '%t']."
-
-
-def test_parse_c_code_to_bigquery_code(recwarn):
+def test_parse_c_code_to_bigquery_code():
     assert parse_c_code_to_bigquery_code('%H:%M:%S.%f') == '%H:%M:%E6S'
     assert parse_c_code_to_bigquery_code('%H:%M:%S.%f %f %S.%f') == '%H:%M:%E6S %f %E6S'
-    assert len(recwarn) == 1
-    result = recwarn[0]
-    assert issubclass(result.category, UserWarning)
-    assert str(result.message) == "There are no equivalent codes for %f."
 
 
-def test_parse_c_code_to_athena_code(recwarn):
+def test_parse_c_code_to_athena_code():
     assert parse_c_code_to_athena_code('%Y-%m-%d') == '%Y-%m-%d'
     assert parse_c_code_to_athena_code('%M-%B') == '%i-%M'
     # Escape not supported codes:
@@ -73,4 +59,30 @@ def test_parse_c_code_to_athena_code(recwarn):
     assert parse_c_code_to_athena_code('%q %1 %_') == '%%q %%1 %%_'
     # Handle double quotes correctly
     assert parse_c_code_to_athena_code('%%%m') == '%%%m'
-    assert len(recwarn) == 0
+
+
+def test_warn_non_supported_format_codes():
+    # See https://docs.pytest.org/en/6.2.x/warnings.html#recwarn for docs on pytest.warns()
+
+    # Make sure there are no warning for these
+    with warnings.catch_warnings():
+        warn_non_supported_format_codes('%Y-%m-%d')
+        warn_non_supported_format_codes('%H:%M:%S.%f')
+        warn_non_supported_format_codes('test %H:%M:%S.%f test')
+
+    # Make sure we get the correct warnings for non-supported codes
+    expected_msg_match = "These formatting codes are not generally supported: %f"
+    with pytest.warns(UserWarning, match=expected_msg_match):
+        warn_non_supported_format_codes('S.%f')
+    with pytest.warns(UserWarning, match=expected_msg_match):
+        warn_non_supported_format_codes('%f')
+    with pytest.warns(UserWarning, match=expected_msg_match):
+        warn_non_supported_format_codes('test %f test')
+
+    expected_msg_match = "These formatting codes are not generally supported: %1, %_, %q"
+    with pytest.warns(UserWarning, match=expected_msg_match):
+        warn_non_supported_format_codes('%q, %1, %_ %q %H:%M:%S.%f')
+
+    expected_msg_match = "These formatting codes are not generally supported: %%, %n, %t"
+    with pytest.warns(UserWarning, match=expected_msg_match):
+        warn_non_supported_format_codes('%%%t%n')

--- a/bach/tests/unit/bach/test_series_utils_datetime_formats.py
+++ b/bach/tests/unit/bach/test_series_utils_datetime_formats.py
@@ -61,14 +61,18 @@ def test_parse_c_code_to_athena_code():
     assert parse_c_code_to_athena_code('%%%m') == '%%%m'
 
 
-def test_warn_non_supported_format_codes():
+def test_warn_non_supported_format_codes(recwarn):
     # See https://docs.pytest.org/en/6.2.x/warnings.html#recwarn for docs on pytest.warns()
 
-    # Make sure there are no warning for these
-    with warnings.catch_warnings():
-        warn_non_supported_format_codes('%Y-%m-%d')
-        warn_non_supported_format_codes('%H:%M:%S.%f')
-        warn_non_supported_format_codes('test %H:%M:%S.%f test')
+    # Make sure there are no warning for these, as they are all supported
+    warn_non_supported_format_codes('%Y-%m-%d')
+    warn_non_supported_format_codes('%H:%M:%S.%f')
+    warn_non_supported_format_codes('test %H:%M:%S.%f test')
+    warn_non_supported_format_codes('test %H:%M:%S.%f%S.%f%S.%f')
+    warn_non_supported_format_codes('%H:%M:%S.%f:%H')
+    warn_non_supported_format_codes('%S.%f')
+    warn_non_supported_format_codes('%S.%f.%S')
+    assert len(recwarn) == 0
 
     # Make sure we get the correct warnings for non-supported codes
     expected_msg_match = "These formatting codes are not generally supported: %f"
@@ -78,6 +82,12 @@ def test_warn_non_supported_format_codes():
         warn_non_supported_format_codes('%f')
     with pytest.warns(UserWarning, match=expected_msg_match):
         warn_non_supported_format_codes('test %f test')
+    with pytest.warns(UserWarning, match=expected_msg_match):
+        warn_non_supported_format_codes('%S:%f%f')
+    with pytest.warns(UserWarning, match=expected_msg_match):
+        warn_non_supported_format_codes('%M.%f')
+    with pytest.warns(UserWarning, match=expected_msg_match):
+        warn_non_supported_format_codes('%S%f')
 
     expected_msg_match = "These formatting codes are not generally supported: %1, %_, %q"
     with pytest.warns(UserWarning, match=expected_msg_match):


### PR DESCRIPTION
Refactor warnings about unsupported format codes in `strftime()`

Details:
* Removed generating warnings in database specific parse functions
* New generic function `warn_non_supported_format_codes`
  * Generate warning if format code is not supported on all databases
* Check warnings in functional test too


This is a follow-up to https://github.com/objectiv/objectiv-analytics/pull/1204