### PR TITLE
Bach athena date formatting cleanup

### DIFF
--- a/bach/bach/series/series_datetime.py
+++ b/bach/bach/series/series_datetime.py
@@ -2,7 +2,6 @@
 Copyright 2021 Objectiv B.V.
 """
 import datetime
-import warnings
 from abc import ABC
 from enum import Enum
 from typing import Union, cast, List, Tuple, Optional, Any

--- a/bach/bach/series/series_datetime.py
+++ b/bach/bach/series/series_datetime.py
@@ -60,34 +60,6 @@ class DateTimeOperation:
     def __init__(self, series: 'SeriesAbstractDateTime'):
         self._series = series
 
-    def sql_format(self, format_str: str) -> SeriesString:
-        """
-        Allow formatting of this Series (to a string type).
-
-        :param format_str: The format to apply to the date/time column.
-            Currently, this uses Postgres' data format string syntax:
-            https://www.postgresql.org/docs/14/functions-formatting.html
-
-        .. warning::
-            This method is deprecated, we recommend using :meth:`SeriesAbstractDateTime.dt.strftime` instead.
-
-        .. code-block:: python
-
-            df['year'] = df.some_date_series.dt.sql_format('YYYY')  # return year
-            df['date'] = df.some_date_series.dt.sql_format('YYYYMMDD')  # return date
-
-        :returns: a SeriesString containing the formatted date.
-        """
-        warnings.warn(
-            'Call to deprecated method, we recommend to use SeriesAbstractDateTime.dt.strftime instead',
-            category=DeprecationWarning,
-        )
-
-        expression = Expression.construct('to_char({}, {})',
-                                          self._series, Expression.string_value(format_str))
-        str_series = self._series.copy_override_type(SeriesString).copy_override(expression=expression)
-        return str_series
-
     def strftime(self, format_str: str) -> SeriesString:
         """
         Allow formatting of this Series (to a string type).

--- a/bach/tests/functional/bach/test_series_date.py
+++ b/bach/tests/functional/bach/test_series_date.py
@@ -7,7 +7,7 @@ import pandas as pd
 import pytest
 
 from bach import SeriesDate, DataFrame
-from sql_models.util import is_postgres, is_bigquery, is_athena
+from sql_models.util import is_postgres
 from tests.functional.bach.test_data_and_utils import assert_equals_data,\
     assert_postgres_type, get_df_with_test_data, get_df_with_food_data
 from tests.functional.bach.test_series_timestamp import types_plus_min
@@ -253,5 +253,5 @@ def test_date_arithmetic(engine):
 def test_to_pandas(engine):
     bt = get_df_with_test_data(engine)
     bt['d'] = datetime.date(2020, 3, 11)
-    bt[['d']].to_pandas()
-    assert bt[['d']].to_numpy()[0] == [datetime.date(2020, 3, 11)]
+    pdf_result = bt.to_pandas()
+    assert pdf_result[['d']].to_numpy()[0] == [datetime.date(2020, 3, 11)]

--- a/bach/tests/functional/bach/test_series_date.py
+++ b/bach/tests/functional/bach/test_series_date.py
@@ -71,7 +71,6 @@ def test_date_format(engine, recwarn):
         # tuple, types: (str, bool). Content: format, whether the format should raise a warning
         ('Year: %Y', False),
         ('%Y', False),
-        ('%g%Y', True),  # %g is not a supported code
         ('%Y-%m-%d', False),
         ('%Y%m%d-%Y%m-%m%d-%d', False),
         ('%Y%m-%d%d', False),
@@ -99,18 +98,12 @@ def test_date_format(engine, recwarn):
 
     # Some columns do not contain correct results on some databases. For now, we accept that.
     # Here we define the correct result, below we define exceptions per database
-    iso_week_year_date = '212022'
-    iso_week_year_timestamp = '212021'
     percentage_format_date = '2022-%01-01'
     percentage_format_timestamp = '2021-%05-03'
 
     if is_postgres(engine):
         percentage_format_date = '2022-%%01-01'  # %% is not supported for pg
         percentage_format_timestamp = '2021-%%05-03'
-    elif is_athena(engine):
-        # TODO: don't support %g? It's not listed on python's doc page
-        iso_week_year_date = '%g2022'
-        iso_week_year_timestamp = '%g2021'
 
     assert_equals_data(
         df[expected_columns],
@@ -119,7 +112,6 @@ def test_date_format(engine, recwarn):
             [
                 'Year: 2022', 'Year: 2021',
                 '2022', '2021',
-                iso_week_year_date, iso_week_year_timestamp,
                 '2022-01-01', '2021-05-03',
                 '20220101-202201-0101-01', '20210503-202105-0503-03',
                 '202201-0101', '202105-0303',

--- a/bach/tests/functional/bach/test_series_date.py
+++ b/bach/tests/functional/bach/test_series_date.py
@@ -71,6 +71,7 @@ def test_date_format(engine, recwarn):
         # tuple, types: (str, bool). Content: format, whether the format should raise a warning
         ('Year: %Y', False),
         ('%Y', False),
+        ('%y%Y', False),
         ('%Y-%m-%d', False),
         ('%Y%m%d-%Y%m-%m%d-%d', False),
         ('%Y%m-%d%d', False),
@@ -112,6 +113,7 @@ def test_date_format(engine, recwarn):
             [
                 'Year: 2022', 'Year: 2021',
                 '2022', '2021',
+                '222022', '212021',
                 '2022-01-01', '2021-05-03',
                 '20220101-202201-0101-01', '20210503-202105-0503-03',
                 '202201-0101', '202105-0303',


### PR DESCRIPTION
Changes:
* remove old `sql_format()` function
* remove test string format code `%g` from test
* small tweaks


@hendrik-obj can you double check that I am not cleaning up anything you rely on?

This is part of a series of PRs:
#1204
#1205
#1206 (this one)
#1207