### PR TITLE
Support '%%' in strftime

### DIFF
--- a/bach/bach/series/series_datetime.py
+++ b/bach/bach/series/series_datetime.py
@@ -74,7 +74,8 @@ class DateTimeOperation:
         code semantics: https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes
 
         The subset of codes that are supported across all databases is:
-            `%A`, `%B`, `%F`, `%H`, `%I`, `%M`, `%R`, `%S`, `%T`, `%Y`, `%a`, `%b`, `%d`, `%j`, `%m`, `%y`
+            `%A`, `%B`, `%F`, `%H`, `%I`, `%M`, `%R`, `%S`, `%T`, `%Y`, `%a`, `%b`, `%d`, `%j`, `%m`, `%y`,
+            `%%`
         Additionally one specific combination is supported: `%S.%f`
 
         **Example**

--- a/bach/bach/series/utils/datetime_formats.py
+++ b/bach/bach/series/utils/datetime_formats.py
@@ -37,10 +37,8 @@ CODES_SUPPORTED_IN_ALL_DIALECTS = {
     '%R',  # HOUR_MINUTE
     '%T',  # HOUR_MINUTE_SECOND
 
-    # special characters - TODO
-    # '%n',  # NEW_LINE
-    # '%t',  # TAB
-    # '%%',  # PERCENT_CHAR
+    # special characters
+    '%%',  # PERCENT_CHAR
 }
 
 STRINGS_SUPPORTED_IN_ALL_DIALECTS = [
@@ -139,6 +137,7 @@ _C_STANDARD_CODES_X_POSTGRES_DATE_CODES = {
     "%Z": "TZ",
     "%R": "HH24:MI",
     "%T": "HH24:MI:SS",
+    "%%": "%",
 }
 
 
@@ -202,12 +201,8 @@ def parse_c_standard_code_to_postgres_code(date_format: str) -> str:
         codes_to_replace = single_c_code_regex.findall(token)
         replaced_codes = []
         for to_repl_code in codes_to_replace:
-            if to_repl_code not in _C_STANDARD_CODES_X_POSTGRES_DATE_CODES:
-                replaced_codes.append(to_repl_code)
-                continue
-
-            # get correspondent postgres code
-            replaced_codes.append(_C_STANDARD_CODES_X_POSTGRES_DATE_CODES[to_repl_code])
+            # get correspondent postgres code if it exists, otherwise include to_repl_code unchanged.
+            replaced_codes.append(_C_STANDARD_CODES_X_POSTGRES_DATE_CODES.get(to_repl_code, to_repl_code))
 
         new_date_format_tokens.append('""'.join(replaced_codes))
 
@@ -232,7 +227,6 @@ def parse_c_code_to_athena_code(date_format: str) -> str:
         # should yield '%'. So we want to generate '%%'
         '%': '%%',
         # List supported codes that are not in CODES_SUPPORTED_IN_ALL_DIALECTS
-        '%%': '%%',
         '%f': '%f',
         # Actual mappings
         '%A': '%W',


### PR DESCRIPTION
Support `%%` as code in `strftime()`.

Not very important, but now our `strftime()` is more in line with what other implementations do, and this allows us to remove an exception from the tests.