### PR TITLE
Bach optimize `test_positional_slicing()`, and enable for BigQuery and Athena

### DIFF
--- a/bach/tests/functional/bach/test_df_getitem.py
+++ b/bach/tests/functional/bach/test_df_getitem.py
@@ -70,6 +70,7 @@ def test_get_item_multiple(engine):
 @pytest.mark.athena_supported
 def test_positional_slicing(engine):
     bt = get_df_with_test_data(engine, full_data_set=True)
+    bt = bt.sort_index()
     base_expected_data = deepcopy(TEST_DATA_CITIES_FULL)
 
     class ReturnSlice:

--- a/bach/tests/functional/bach/test_df_getitem.py
+++ b/bach/tests/functional/bach/test_df_getitem.py
@@ -70,7 +70,7 @@ def test_get_item_multiple(engine):
 @pytest.mark.athena_supported
 def test_positional_slicing(engine):
     bt = get_df_with_test_data(engine, full_data_set=True)
-    base_exepcted_data = deepcopy(TEST_DATA_CITIES_FULL)
+    base_expected_data = deepcopy(TEST_DATA_CITIES_FULL)
 
     class ReturnSlice:
         def __getitem__(self, key):
@@ -101,7 +101,7 @@ def test_positional_slicing(engine):
         # distinguish each slice.
         bt_slice['slice'] = i
         all_dfs.append(bt_slice)
-        expected_data = [row + [i] for row in base_exepcted_data][s]
+        expected_data = [row + [i] for row in base_expected_data][s]
         all_expected_data.extend(expected_data)
 
     df = all_dfs[0].append(all_dfs[1:])


### PR DESCRIPTION
This addresses issue https://github.com/objectiv/objectiv-analytics/issues/1022 and makes sure the changes of PR https://github.com/objectiv/objectiv-analytics/pull/1211 are well tested on Athena and Postgres too.


Changes:
1. Make `test_positional_slicing()` use a single query
2. Enable `test_positional_slicing()` for Athena and BigQuery

Not changed, but something I wrote in the issue originally: We don't raise an exception if there is no sorting set. Even though limit doesn't make any sense if there is no order by, this might break `head()` in annoying ways. Maybe 'random' data is better then often. Let me know what you think