### PR TITLE
[Bach] Support Materialization.SOURCE 

### DIFF
--- a/bach/bach/dataframe.py
+++ b/bach/bach/dataframe.py
@@ -22,7 +22,7 @@ from bach.utils import (
 )
 from sql_models.constants import NotSet, not_set
 from sql_models.graph_operations import update_placeholders_in_graph, get_all_placeholders
-from sql_models.model import SqlModel, Materialization, CustomSqlModelBuilder, RefPath, BaseTableModelBuilder
+from sql_models.model import SqlModel, Materialization, RefPath, SourceTableModelBuilder
 
 from sql_models.sql_generator import to_sql
 from sql_models.util import quote_identifier, is_bigquery, DatabaseNotSupportedException, is_postgres
@@ -565,7 +565,7 @@ class DataFrame:
             )
 
         # We just generate a reference to the base table
-        sql_model = BaseTableModelBuilder(table_name)()
+        sql_model = SourceTableModelBuilder(table_name)()
         return cls._from_node(
             engine=engine,
             model=sql_model,

--- a/bach/bach/dataframe.py
+++ b/bach/bach/dataframe.py
@@ -22,7 +22,7 @@ from bach.utils import (
 )
 from sql_models.constants import NotSet, not_set
 from sql_models.graph_operations import update_placeholders_in_graph, get_all_placeholders
-from sql_models.model import SqlModel, Materialization, CustomSqlModelBuilder, RefPath
+from sql_models.model import SqlModel, Materialization, CustomSqlModelBuilder, RefPath, BaseTableModelBuilder
 
 from sql_models.sql_generator import to_sql
 from sql_models.util import quote_identifier, is_bigquery, DatabaseNotSupportedException, is_postgres
@@ -564,21 +564,8 @@ class DataFrame:
                 table_name=table_name,
             )
 
-        # We generate sql of the form (with quote characters depending on the database):
-        # 'SELECT "column_1", ... , "column_N" FROM "table_name"'
-        sql_params = {'table_name': quote_identifier(engine.dialect, table_name)}
-        # use placeholders for columns in order to avoid conflicts when extracting spec references
-        column_stmt = ','.join(f'{{col_{col_index}}}' for col_index in range(len(dtypes)))
-        column_placeholders = {
-            f'col_{col_index}': quote_identifier(engine.dialect, col_name)
-            for col_index, col_name in enumerate(dtypes.keys())
-        }
-        sql_params.update(column_placeholders)
-
-        sql = f'SELECT {column_stmt} FROM {{table_name}}'
-        model_builder = CustomSqlModelBuilder(sql=sql, name='from_table')
-        sql_model = model_builder(**sql_params)
-
+        # We just generate a reference to the base table
+        sql_model = BaseTableModelBuilder(table_name)()
         return cls._from_node(
             engine=engine,
             model=sql_model,

--- a/bach/sql_models/model.py
+++ b/bach/sql_models/model.py
@@ -48,6 +48,7 @@ class Materialization(Enum):
     """ A QUERY can be used as a CTE, but is also a stand-alone query."""
     QUERY = MaterializationType('query', is_statement=True, is_cte=True, has_lasting_effect=False)
     VIEW = MaterializationType('view', is_statement=True, is_cte=False, has_lasting_effect=True)
+    SOURCE = MaterializationType('source', is_statement=False, is_cte=False, has_lasting_effect=False)
     TABLE = MaterializationType('table', is_statement=True, is_cte=False, has_lasting_effect=True)
     """
     TEMP TABLE is a temporary table that is limited to the current session, or a table that is guaranteed to
@@ -684,17 +685,17 @@ class SqlModel(Generic[T]):
         return hash(self.hash)
 
 
-class BaseTableModelBuilder(SqlModelBuilder):
+class SourceTableModelBuilder(SqlModelBuilder):
     def __init__(self,name: str):
-        self._sql = None
-        self._generic_name = name
         super().__init__()
-
+        self._sql = ''
+        self._generic_name = name
         self.set_materialization_name(name)
+        self.set_materialization(Materialization.SOURCE)
 
     @property
     def sql(self):
-        return ""
+        return ''
 
 class CustomSqlModelBuilder(SqlModelBuilder):
     """

--- a/bach/sql_models/model.py
+++ b/bach/sql_models/model.py
@@ -686,7 +686,11 @@ class SqlModel(Generic[T]):
 
 
 class SourceTableModelBuilder(SqlModelBuilder):
-    def __init__(self,name: str):
+    """
+    Builder that instantiates a SqlModel with SOURCE materialization to refer to source data tables
+    """
+
+    def __init__(self, name: str):
         super().__init__()
         self._sql = ''
         self._generic_name = name
@@ -696,6 +700,7 @@ class SourceTableModelBuilder(SqlModelBuilder):
     @property
     def sql(self):
         return ''
+
 
 class CustomSqlModelBuilder(SqlModelBuilder):
     """

--- a/bach/sql_models/model.py
+++ b/bach/sql_models/model.py
@@ -684,6 +684,18 @@ class SqlModel(Generic[T]):
         return hash(self.hash)
 
 
+class BaseTableModelBuilder(SqlModelBuilder):
+    def __init__(self,name: str):
+        self._sql = None
+        self._generic_name = name
+        super().__init__()
+
+        self.set_materialization_name(name)
+
+    @property
+    def sql(self):
+        return ""
+
 class CustomSqlModelBuilder(SqlModelBuilder):
     """
     Builder that instantiates a SqlModel that can run custom sql and refer custom tables.

--- a/bach/sql_models/sql_generator.py
+++ b/bach/sql_models/sql_generator.py
@@ -128,9 +128,9 @@ def _to_sql_materialized_node(
     queries = _to_cte_sql(dialect=dialect, compiler_cache=compiler_cache, model=model)
     queries = _filter_duplicate_ctes(queries)
     if len(queries) == 0:
-        # _to_cte_sql only returns an empty list in synthetic test scenarios, where there is a source node,
-        # but it's not referenced.
-        return ''
+        # _to_cte_sql only returns an empty list when there is a source node,
+        # but it's not referenced. We can't generate anything in that scenario.
+        raise Exception('No models to compile')
 
     if len(queries) == 1:
         return _materialize(dialect=dialect, sql_query=queries[0].sql, model=model)

--- a/bach/sql_models/sql_generator.py
+++ b/bach/sql_models/sql_generator.py
@@ -261,8 +261,13 @@ def model_to_name(dialect: Dialect, model: SqlModel):
     """
     Get the name for the cte/table/view that will be generated from this model, quoted and escaped.
     """
-    # max length of an identifier name in Postgres is normally 63 characters. We'll use that as a cutoff
-    # if we don't know better
+    if model.materialization == Materialization.SOURCE:
+        if model.materialization_name is None:
+            raise Exception('SqlModel with SOURCE materialization must have materialization_name set.')
+        return model.materialization_name
+
+    # max length of an identifier name in Postgres is normally 63 characters.
+    # We'll use that as a cutoff if we don't know better
     if is_bigquery(dialect):
         max_length = 1023
     else:

--- a/bach/sql_models/sql_query_parser.py
+++ b/bach/sql_models/sql_query_parser.py
@@ -24,11 +24,14 @@ def raw_sql_to_selects(sql: str) -> List[CteTuple]:
     """
     # TODO: refactor function
     stmts = sqlparse.parse(sql)
-    if len(stmts) != 1:
+    if len(stmts) == 0:
         return []
+
+    # if len(stmts) > 1
     #     raise ValueError(f'Expected sql with a single statement, found {len(stmts)} statements.')
     # todo: check that there is one real statement. make sure this check works even if the statement
     #  ends with a semicolon
+
     stmt = stmts[0]
     tokens = list(stmt.flatten())
     token_list = TokenList(tokens)

--- a/bach/sql_models/sql_query_parser.py
+++ b/bach/sql_models/sql_query_parser.py
@@ -24,7 +24,8 @@ def raw_sql_to_selects(sql: str) -> List[CteTuple]:
     """
     # TODO: refactor function
     stmts = sqlparse.parse(sql)
-    # if len(stmts) != 1:
+    if len(stmts) != 1:
+        return []
     #     raise ValueError(f'Expected sql with a single statement, found {len(stmts)} statements.')
     # todo: check that there is one real statement. make sure this check works even if the statement
     #  ends with a semicolon

--- a/bach/tests/functional/bach/test_df_database_create.py
+++ b/bach/tests/functional/bach/test_df_database_create.py
@@ -35,13 +35,12 @@ def test_database_create_table(engine, unique_table_test_name: str):
     )
     assert_equals_data(df_from_table, expected_columns=expected_columns, expected_data=expected_data)
 
-    # check that df_from_table actually queries the table
+    # check that df_from_table does not query the table
     dialect = engine.dialect
     assert df_from_table.base_node != df.base_node
     assert len(df_from_table.base_node.references) == 0
     new_sql = to_sql(dialect=dialect, model=df_from_table.base_node)
-    quoted_table_name = quote_identifier(dialect, table_name)
-    expected_sql_fragment = f'FROM {quoted_table_name}'
+    expected_sql_fragment = f''
     assert expected_sql_fragment in new_sql
 
     # Second test: try to write table, but with overwrite=False. We expect an error

--- a/bach/tests/functional/bach/test_df_database_create.py
+++ b/bach/tests/functional/bach/test_df_database_create.py
@@ -41,9 +41,7 @@ def test_database_create_table(engine, unique_table_test_name: str):
     assert df_from_table.base_node != df.base_node
     assert len(df_from_table.base_node.references) == 0
     assert df_from_table.base_node.materialization == Materialization.SOURCE
-    new_sql = to_sql(dialect=dialect, model=df_from_table.base_node)
-    expected_sql_fragment = f''
-    assert expected_sql_fragment in new_sql
+    assert to_sql(dialect=dialect, model=df_from_table.base_node) == ''
 
     # Second test: try to write table, but with overwrite=False. We expect an error
     df['y'] = random_value

--- a/bach/tests/functional/bach/test_df_database_create.py
+++ b/bach/tests/functional/bach/test_df_database_create.py
@@ -5,6 +5,7 @@ from random import randrange
 
 import pytest
 
+from sql_models.model import Materialization
 from tests.functional.bach.test_data_and_utils import get_df_with_test_data, assert_equals_data
 from sql_models.sql_generator import to_sql
 from sql_models.util import quote_identifier
@@ -39,6 +40,7 @@ def test_database_create_table(engine, unique_table_test_name: str):
     dialect = engine.dialect
     assert df_from_table.base_node != df.base_node
     assert len(df_from_table.base_node.references) == 0
+    assert df_from_table.base_node.materialization == Materialization.SOURCE
     new_sql = to_sql(dialect=dialect, model=df_from_table.base_node)
     expected_sql_fragment = f''
     assert expected_sql_fragment in new_sql

--- a/bach/tests/functional/bach/test_df_database_create.py
+++ b/bach/tests/functional/bach/test_df_database_create.py
@@ -41,7 +41,8 @@ def test_database_create_table(engine, unique_table_test_name: str):
     assert df_from_table.base_node != df.base_node
     assert len(df_from_table.base_node.references) == 0
     assert df_from_table.base_node.materialization == Materialization.SOURCE
-    assert to_sql(dialect=dialect, model=df_from_table.base_node) == ''
+    with pytest.raises(Exception, match="No models to compile"):
+        to_sql(dialect=dialect, model=df_from_table.base_node)
 
     # Second test: try to write table, but with overwrite=False. We expect an error
     df['y'] = random_value

--- a/bach/tests/functional/bach/test_df_from.py
+++ b/bach/tests/functional/bach/test_df_from.py
@@ -10,7 +10,8 @@ import pytest
 from sqlalchemy.engine import Engine
 
 from bach import DataFrame
-from sql_models.model import CustomSqlModelBuilder, SqlModel
+from sql_models.model import CustomSqlModelBuilder, SqlModel, Materialization
+from sql_models.sql_generator import to_sql
 from sql_models.util import is_postgres, is_bigquery
 from tests.functional.bach.test_data_and_utils import assert_equals_data
 
@@ -65,8 +66,9 @@ def test_from_table_basic(engine, unique_table_test_name):
     assert df.is_materialized
     assert df.base_node.columns == ('a', 'b', 'c', 'd', 'e', 'f')
     # there should only be a single model that selects from the table, not a whole tree
-    # todo: in the future introduce a special SqlModel type 'source', so we don't even need a first model
-    # with a query and we can just query directly from the source table.
+    assert df.base_node.materialization == Materialization.SOURCE
+    # no query needed to create this data
+    assert to_sql(dialect=engine.dialect, model=df.base_node) == ''
     assert df.base_node.references == {}
     df.to_pandas()  # test that the main function works on the created DataFrame
 
@@ -92,8 +94,6 @@ def test_from_model_basic(pg_engine, unique_table_test_name):
     assert df.is_materialized
     assert df.base_node.columns == ('a', 'b', 'c', 'd', 'e', 'f')
     # there should only be a single model that selects from the table, not a whole tree
-    # todo: in the future introduce a special SqlModel type 'source', so we don't even need a first model
-    # with a query and we can just query directly from the source table.
     assert df.base_node.references == {}
     df.to_pandas()  # test that the main function works on the created DataFrame
 

--- a/bach/tests/functional/bach/test_df_from.py
+++ b/bach/tests/functional/bach/test_df_from.py
@@ -67,8 +67,8 @@ def test_from_table_basic(engine, unique_table_test_name):
     assert df.base_node.columns == ('a', 'b', 'c', 'd', 'e', 'f')
     # there should only be a single model that selects from the table, not a whole tree
     assert df.base_node.materialization == Materialization.SOURCE
-    # no query needed to create this data
-    assert to_sql(dialect=engine.dialect, model=df.base_node) == ''
+    with pytest.raises(Exception, match="No models to compile"):
+        to_sql(dialect=engine.dialect, model=df.base_node)
     assert df.base_node.references == {}
     df.to_pandas()  # test that the main function works on the created DataFrame
 


### PR DESCRIPTION
Previously, every df.from_table('table_name') would create a first SQL node like 
```sql
WITH someCTE AS (SELECT fieldA, fieldB from `table_name`)
```
This wasted the partitioning on BQ, as well as did unnecessary processing. 
This PR aims to resolve that by making the first sql node just a reference to the source table, with `Materialization.SOURCE`