### PR TITLE
Bach tests athena 2 - Annotate tests with permanent skip marks

### DIFF
--- a/bach/tests/functional/bach/test_df_getitem.py
+++ b/bach/tests/functional/bach/test_df_getitem.py
@@ -199,7 +199,8 @@ def test_get_item_mixed_groupby(engine):
         grouped_other[grouped_sum > grouped_other_sum]
 
 
-@pytest.mark.skip_postgres
+@pytest.mark.skip_postgres('Test uses BigQuery-only Series type')
+@pytest.mark.skip_athena('Test uses BigQuery-only Series type')
 def test_get_item_w_dict_series(engine):
     df = get_df_with_test_data(engine)[['city']]
     struct = {

--- a/bach/tests/functional/bach/test_df_setitem.py
+++ b/bach/tests/functional/bach/test_df_setitem.py
@@ -204,8 +204,8 @@ def test_set_series_column(engine):
     assert filtered_bt.town == filtered_bt['town']
 
 
-@pytest.mark.skip_bigquery_todo('We do not yet support spaces in column names on BigQuery')
-@pytest.mark.skip_athena_todo('We do not yet support spaces in column names on Athena')
+@pytest.mark.skip_bigquery_todo('#1209 We do not yet support spaces in column names on BigQuery')
+@pytest.mark.skip_athena_todo('#1209 We do not yet support spaces in column names on Athena')
 def test_set_series_column_name_with_spaces(engine):
     bt = get_df_with_test_data(engine)
     bt['spaces in column'] = bt['founding']

--- a/bach/tests/functional/bach/test_df_setitem.py
+++ b/bach/tests/functional/bach/test_df_setitem.py
@@ -204,7 +204,8 @@ def test_set_series_column(engine):
     assert filtered_bt.town == filtered_bt['town']
 
 
-@pytest.mark.skip_bigquery("Bigquery doesn't support spaces in column names")
+@pytest.mark.skip_bigquery_todo('We do not yet support spaces in column names on BigQuery')
+@pytest.mark.skip_athena_todo('We do not yet support spaces in column names on Athena')
 def test_set_series_column_name_with_spaces(engine):
     bt = get_df_with_test_data(engine)
     bt['spaces in column'] = bt['founding']

--- a/bach/tests/functional/bach/test_injection_column_name_escaping.py
+++ b/bach/tests/functional/bach/test_injection_column_name_escaping.py
@@ -31,13 +31,10 @@ def test_column_names(engine):
     assert_equals_data(bt, expected_columns=expected_columns, expected_data=expected_data)
 
 
+@pytest.mark.skip_bigquery_todo('We do not yet support special characters in column names on BigQuery')
+@pytest.mark.skip_athena_todo('We do not yet support special characters in column names on Athena')
 def test_column_names_merge(engine):
     # When merging we construct a specific sql query that names each column, so test that separately here
-
-    # Don't test this for BigQuery, as it won't allow the weird names. See test_column_names() above.
-    if is_bigquery(engine):
-        return
-
     bt = _get_dataframe_with_weird_column_names(engine)
     bt2 = get_df_with_test_data(engine)[['city']]
     bt = bt.merge(bt2, on='city')

--- a/bach/tests/functional/bach/test_injection_column_name_escaping.py
+++ b/bach/tests/functional/bach/test_injection_column_name_escaping.py
@@ -31,8 +31,8 @@ def test_column_names(engine):
     assert_equals_data(bt, expected_columns=expected_columns, expected_data=expected_data)
 
 
-@pytest.mark.skip_bigquery_todo('We do not yet support special characters in column names on BigQuery')
-@pytest.mark.skip_athena_todo('We do not yet support special characters in column names on Athena')
+@pytest.mark.skip_bigquery_todo('#1209 We do not yet support special characters in column names on BigQuery')
+@pytest.mark.skip_athena_todo('#1209 We do not yet support special characters in column names on Athena')
 def test_column_names_merge(engine):
     # When merging we construct a specific sql query that names each column, so test that separately here
     bt = _get_dataframe_with_weird_column_names(engine)

--- a/bach/tests/functional/bach/test_series_date.py
+++ b/bach/tests/functional/bach/test_series_date.py
@@ -122,7 +122,8 @@ def test_date_format(engine, recwarn):
     )
 
 
-@pytest.mark.skip_bigquery
+@pytest.mark.skip_bigquery('Postgres specific test')
+@pytest.mark.skip_athena('Postgres specific test')
 def test_date_format_all_supported_pg_codes(engine, recwarn):
     # We use recwarn here, because some of the format codes we support on Postgres are not supported on other
     # databases. Those format codes will raise a warning.

--- a/bach/tests/functional/bach/test_series_dict.py
+++ b/bach/tests/functional/bach/test_series_dict.py
@@ -6,7 +6,10 @@ from bach.series import SeriesDict
 from tests.functional.bach.test_data_and_utils import get_df_with_test_data, assert_equals_data
 
 
-pytestmark = [pytest.mark.skip_postgres]  # SeriesDict is not supported on Postgres at all.
+pytestmark = [
+    pytest.mark.skip_postgres('SeriesDict is not supported on Postgres at all'),
+    pytest.mark.skip_athena(' SeriesDict is not supported on Athena at all')
+]
 
 
 def test_basic_value_to_expression(engine):

--- a/bach/tests/functional/bach/test_series_list.py
+++ b/bach/tests/functional/bach/test_series_list.py
@@ -7,7 +7,10 @@ from bach.series import SeriesList
 from tests.functional.bach.test_data_and_utils import get_df_with_test_data, assert_equals_data
 
 
-pytestmark = [pytest.mark.skip_postgres]  # SeriesList is not (yet) supported on Postgres.
+pytestmark = [
+    pytest.mark.skip_postgres('SeriesList is not (yet) supported on Postgres'),
+    pytest.mark.skip_athena(' SeriesList is not supported on Athena')
+]
 
 
 def test_basic_value_to_expression(engine):

--- a/bach/tests/functional/bach/test_series_timedelta.py
+++ b/bach/tests/functional/bach/test_series_timedelta.py
@@ -244,7 +244,8 @@ def test_timedelta_dt_components(engine) -> None:
     pd.testing.assert_frame_equal(expected, result, check_names=False)
 
 
-@pytest.mark.skip_postgres
+@pytest.mark.skip_postgres('BigQuery specific test')
+@pytest.mark.skip_athena('BigQuery specific test')
 def test_mean_bigquery_remove_nano_precision(engine) -> None:
     pdf = pd.DataFrame(
         {

--- a/bach/tests/unit/bach/test_series.py
+++ b/bach/tests/unit/bach/test_series.py
@@ -117,7 +117,8 @@ def test_equals(dialect):
     assert not sleft.equals(sright)
 
 
-@pytest.mark.skip_postgres
+@pytest.mark.skip_postgres('Only relevant with Dict and List types, which are not supported on Postgres')
+@pytest.mark.skip_athena('Only relevant with Dict and List types, which are not supported on Athena')
 def test_equals_instance_dtype(dialect):
     def get_df(index_names: List[str], data_names: List[str]):
         return get_fake_df(dialect=dialect, index_names=index_names, data_names=data_names)

--- a/bach/tests/unit/bach/test_series_json.py
+++ b/bach/tests/unit/bach/test_series_json.py
@@ -7,8 +7,8 @@ from bach.series.series_json import JsonBigQueryAccessorImpl
 from tests.unit.bach.util import get_fake_df
 
 
-
-@pytest.mark.skip_postgres
+@pytest.mark.skip_postgres('BigQuery specific test')
+@pytest.mark.skip_athena('BigQuery specific test')
 def test_bq_get_slice_partial_expr(dialect):
     # Here we test the _get_slice_partial_expr function of the BigQuery specific JsonBigQueryAccessor. So
     # skipping all other dialects

--- a/bach/tests/unit/bach/test_series_list.py
+++ b/bach/tests/unit/bach/test_series_list.py
@@ -9,7 +9,8 @@ from sql_models.util import is_bigquery, is_postgres, DatabaseNotSupportedExcept
 from tests.unit.bach.util import get_fake_df_test_data
 
 
-@pytest.mark.skip_postgres
+@pytest.mark.skip_postgres('SeriesList is not (yet) supported on Postgres')
+@pytest.mark.skip_athena(' SeriesList is not supported on Athena')
 def test_supported_value_to_literal(dialect):
 
     result_empty = SeriesList.supported_value_to_literal(dialect, [], ['string'])

--- a/bach/tests/unit/bach/test_series_time.py
+++ b/bach/tests/unit/bach/test_series_time.py
@@ -10,8 +10,8 @@ from bach import SeriesTime
 from bach.expression import Expression
 
 
-@pytest.mark.skip_bigquery
-@pytest.mark.skip_postgres
+@pytest.mark.skip_bigquery('Athena specific test; test_supported_value_to_literal() below covers BigQuery')
+@pytest.mark.skip_postgres('Athena specific test; test_supported_value_to_literal() below covers Postgres')
 @pytest.mark.athena_supported
 def test_supported_value_to_literal_athena(dialect):
     def assert_call(value, expected_token_value: float):
@@ -63,6 +63,7 @@ def test_supported_value_to_literal_athena(dialect):
     assert SeriesTime.supported_value_to_literal(dialect, None, dtype) == Expression.construct('NULL')
 
 
+@pytest.mark.skip_athena('Athena is skipped because time values are represented with floats.')
 def test_supported_value_to_literal(dialect):
     def assert_call(value, expected_token_value: str):
         result = SeriesTime.supported_value_to_literal(dialect=dialect, value=value, dtype='time')

--- a/bach/tests/unit/bach/test_series_timedelta.py
+++ b/bach/tests/unit/bach/test_series_timedelta.py
@@ -11,8 +11,8 @@ from bach import SeriesTimedelta
 from bach.expression import Expression
 
 
-@pytest.mark.skip_bigquery
-@pytest.mark.skip_postgres
+@pytest.mark.skip_bigquery('Athena specific test; test_supported_value_to_literal() below covers BigQuery')
+@pytest.mark.skip_postgres('Athena specific test; test_supported_value_to_literal() below covers Postgres')
 @pytest.mark.athena_supported
 def test_supported_value_to_literal_athena(dialect):
     def assert_call(value, expected_token_value: float):
@@ -41,6 +41,7 @@ def test_supported_value_to_literal_athena(dialect):
     assert SeriesTimedelta.supported_value_to_literal(dialect, None, dtype=dtype) == Expression.construct('NULL')
 
 
+@pytest.mark.skip_athena('Athena is skipped because timedelta values are represented with floats.')
 def test_supported_value_to_literal(dialect):
     def assert_call(value, expected_token_value: str):
         result = SeriesTimedelta.supported_value_to_literal(dialect, value, dtype=SeriesTimedelta.dtype)


### PR DESCRIPTION
Cutting up https://github.com/objectiv/objectiv-analytics/pull/1195/ into smaller pieces, and adding some stuff. This is step 2.

Change: Add marks to all tests that we want to skip for Athena, and that we are not going to fix later on.