### PR TITLE
Bach tests athena 5 - Run all tests against Athena

### DIFF
--- a/bach/tests/conftest.py
+++ b/bach/tests/conftest.py
@@ -201,7 +201,6 @@ def pytest_generate_tests(metafunc: Metafunc):
     skip_postgres = any(mark.name == MARK_SKIP_POSTGRES for mark in markers)
     skip_athena = any(mark.name == MARK_SKIP_ATHENA for mark in markers)
     skip_bigquery = any(mark.name == MARK_SKIP_BIGQUERY for mark in markers)
-    athena_supported = any(mark.name == MARK_ATHENA_SUPPORTED for mark in markers)
 
     skip_athena_todo = any(mark.name == MARK_SKIP_ATHENA_TODO for mark in markers)
     skip_bigquery_todo = any(mark.name == MARK_SKIP_BIGQUERY_TODO for mark in markers)
@@ -212,7 +211,7 @@ def pytest_generate_tests(metafunc: Metafunc):
             continue
         if name == DB.BIGQUERY and (skip_bigquery or skip_bigquery_todo):
             continue
-        if name == DB.ATHENA and (not athena_supported or skip_athena or skip_athena_todo):
+        if name == DB.ATHENA and (skip_athena or skip_athena_todo):
             continue
         engines.append(engine_dialect)
 

--- a/bach/tests/functional/bach/test_bt_custom_types.py
+++ b/bach/tests/functional/bach/test_bt_custom_types.py
@@ -35,6 +35,7 @@ class ReversedStringType(Series):
             return Expression.construct(f'reverse(cast({{}} as {cls.get_db_dtype(dialect)}))', expression)
 
 
+@pytest.mark.skip_athena_todo()  # TODO: Athena
 def test_custom_type(monkeypatch, engine):
     # make sure monkeypatch the type-registry, as it should be restored after this test finishes.
     monkeypatch.setattr('bach.types._registry', TypeRegistry())

--- a/bach/tests/functional/bach/test_cut.py
+++ b/bach/tests/functional/bach/test_cut.py
@@ -1,10 +1,13 @@
 import numpy as np
 import pandas as pd
+import pytest
 
 from bach import Series, DataFrame
 from bach.operations.cut import CutOperation, QCutOperation
 from sql_models.util import quote_identifier
 from tests.functional.bach.test_data_and_utils import assert_equals_data
+
+pytestmark = pytest.mark.skip_athena_todo()  # TODO: Athena
 
 PD_TESTING_SETTINGS = {
     'check_dtype': False,

--- a/bach/tests/functional/bach/test_df.py
+++ b/bach/tests/functional/bach/test_df.py
@@ -168,6 +168,7 @@ def test_round(engine):
     )
 
 
+@pytest.mark.skip_athena_todo()  # TODO: Athena
 def test_quantile(engine) -> None:
     pdf = pd.DataFrame(
         data={

--- a/bach/tests/functional/bach/test_df_astype.py
+++ b/bach/tests/functional/bach/test_df_astype.py
@@ -148,6 +148,7 @@ def test_astype_to_timestamp(engine):
     )
 
 
+@pytest.mark.skip_athena_todo()  # TODO: Athena
 def test_astype_to_time(engine):
     bt = get_df_with_test_data(engine)
     bt = bt[[]]

--- a/bach/tests/functional/bach/test_df_database_create.py
+++ b/bach/tests/functional/bach/test_df_database_create.py
@@ -9,6 +9,7 @@ from tests.functional.bach.test_data_and_utils import get_df_with_test_data, ass
 from sql_models.sql_generator import to_sql
 from sql_models.util import quote_identifier
 
+pytestmark = pytest.mark.skip_athena_todo()  # TODO: Athena
 
 def test_database_create_table(engine, unique_table_test_name: str):
     df = get_df_with_test_data(engine)

--- a/bach/tests/functional/bach/test_df_describe.py
+++ b/bach/tests/functional/bach/test_df_describe.py
@@ -5,11 +5,14 @@ import datetime
 
 import numpy as np
 import pandas as pd
+import pytest
 
 from bach import DataFrame
 from sql_models.util import is_bigquery
 from tests.functional.bach.test_data_and_utils import get_df_with_test_data, assert_equals_data
 from unittest.mock import ANY
+
+pytestmark = pytest.mark.skip_athena_todo()  # TODO: Athena
 
 
 def test_df_categorical_describe(engine) -> None:

--- a/bach/tests/functional/bach/test_df_fillna.py
+++ b/bach/tests/functional/bach/test_df_fillna.py
@@ -11,6 +11,10 @@ from bach import DataFrame
 from sql_models.util import is_bigquery
 from tests.functional.bach.test_data_and_utils import assert_equals_data
 
+
+pytestmark = pytest.mark.skip_athena_todo('https://github.com/objectiv/objectiv-analytics/issues/1209')
+
+
 DATA = [
     [None, None, None, None, None, 'a',   datetime(2022, 1, 1)],
     [3,    4,    None, 1,    1,     None, datetime(2022, 1, 2)],

--- a/bach/tests/functional/bach/test_df_from.py
+++ b/bach/tests/functional/bach/test_df_from.py
@@ -14,6 +14,7 @@ from sql_models.model import CustomSqlModelBuilder, SqlModel
 from sql_models.util import is_postgres, is_bigquery
 from tests.functional.bach.test_data_and_utils import assert_equals_data
 
+pytestmark = pytest.mark.skip_athena_todo()  # TODO: Athena
 
 def _create_test_table(engine: Engine, table_name: str):
     # TODO: insert data too, and check in the tests below that we get that data back in the DataFrame

--- a/bach/tests/functional/bach/test_df_from_pandas.py
+++ b/bach/tests/functional/bach/test_df_from_pandas.py
@@ -49,6 +49,8 @@ TYPES_COLUMNS = ['int_column', 'float_column', 'bool_column', 'datetime_column',
                  'dict_column', 'timedelta_column', 'mixed_column']
 
 
+pytestmark = pytest.mark.skip_athena_todo()  # TODO: Athena
+
 def test_from_pandas_table(pg_engine, unique_table_test_name):
     pdf = get_pandas_df(TEST_DATA_CITIES, CITIES_COLUMNS)
     bt = DataFrame.from_pandas(

--- a/bach/tests/functional/bach/test_df_get_dummies.py
+++ b/bach/tests/functional/bach/test_df_get_dummies.py
@@ -4,6 +4,8 @@ import pytest
 from bach import DataFrame
 from tests.functional.bach.test_data_and_utils import assert_equals_data
 
+pytestmark = pytest.mark.skip_athena_todo()  # TODO: Athena
+
 
 def test_basic_get_dummies(engine) -> None:
     pdf = pd.DataFrame(

--- a/bach/tests/functional/bach/test_df_groupby.py
+++ b/bach/tests/functional/bach/test_df_groupby.py
@@ -124,6 +124,7 @@ def test_group_by_multiple_syntax(engine):
         }
 
 
+@pytest.mark.skip_athena_todo()  # TODO: Athena
 def test_group_by_expression(engine):
     bt = get_df_with_test_data(engine, full_data_set=True)
     btg = bt.groupby(bt['city'].str[:1])
@@ -538,6 +539,7 @@ def test_grouping_set_basics(pg_engine):
     )
 
 
+@pytest.mark.skip_athena_todo()  # TODO: Athena
 def test_groupby_frame_split_series_aggregation(engine):
     bt = get_df_with_test_data(engine, full_data_set=False)[['municipality', 'inhabitants', 'founding']]
     btg1 = bt.groupby(['municipality'])
@@ -687,6 +689,7 @@ def test_materialize_on_double_aggregation(engine):
     numpy.testing.assert_almost_equal(value, 2413.5)
 
 
+@pytest.mark.skip_athena_todo()  # TODO: Athena
 def test_groupby_w_multi_level_series(engine):
     bt = get_df_with_test_data(engine, full_data_set=True)
     bt['lower'] = 0

--- a/bach/tests/functional/bach/test_df_indexing.py
+++ b/bach/tests/functional/bach/test_df_indexing.py
@@ -25,6 +25,7 @@ def indexing_dfs(engine) -> Tuple[pd.DataFrame, DataFrame]:
     return pdf, df
 
 
+@pytest.mark.skip_athena_todo('https://github.com/objectiv/objectiv-analytics/issues/1209')
 def test_basic_indexing(indexing_dfs: Tuple[pd.DataFrame, DataFrame]) -> None:
     pdf, df = indexing_dfs
 
@@ -53,6 +54,7 @@ def test_basic_indexing(indexing_dfs: Tuple[pd.DataFrame, DataFrame]) -> None:
     )
 
 
+@pytest.mark.skip_athena_todo('https://github.com/objectiv/objectiv-analytics/issues/1209')
 def test_basic_indexing_column_based(indexing_dfs: Tuple[pd.DataFrame, DataFrame]) -> None:
     pdf, df = indexing_dfs
 
@@ -74,6 +76,7 @@ def test_basic_indexing_column_based(indexing_dfs: Tuple[pd.DataFrame, DataFrame
     )
 
 
+@pytest.mark.skip_athena_todo('https://github.com/objectiv/objectiv-analytics/issues/1209')
 def test_index_slicing(indexing_dfs: Tuple[pd.DataFrame, DataFrame]) -> None:
     pdf, df = indexing_dfs
 
@@ -121,6 +124,7 @@ def test_index_slicing(indexing_dfs: Tuple[pd.DataFrame, DataFrame]) -> None:
     )
 
 
+@pytest.mark.skip_athena_todo('https://github.com/objectiv/objectiv-analytics/issues/1209')
 def test_basic_set_item_by_label(indexing_dfs: Tuple[pd.DataFrame, DataFrame]) -> None:
     pdf, df = indexing_dfs
 
@@ -148,6 +152,7 @@ def test_basic_set_item_by_label(indexing_dfs: Tuple[pd.DataFrame, DataFrame]) -
     )
 
 
+@pytest.mark.skip_athena_todo('https://github.com/objectiv/objectiv-analytics/issues/1209')
 def test_set_item_by_label_diff_node(indexing_dfs: Tuple[pd.DataFrame, DataFrame], engine) -> None:
     _, df = indexing_dfs
     extra_pdf = pd.DataFrame(
@@ -175,6 +180,7 @@ def test_set_item_by_label_diff_node(indexing_dfs: Tuple[pd.DataFrame, DataFrame
     )
 
 
+@pytest.mark.skip_athena_todo('https://github.com/objectiv/objectiv-analytics/issues/1209')
 def test_set_item_by_slicing(indexing_dfs: Tuple[pd.DataFrame, DataFrame], engine) -> None:
     pdf, df = indexing_dfs
     if is_bigquery(df.engine):

--- a/bach/tests/functional/bach/test_df_materialize.py
+++ b/bach/tests/functional/bach/test_df_materialize.py
@@ -17,6 +17,7 @@ from tests.functional.bach.test_data_and_utils import assert_equals_data, get_df
 
 @pytest.mark.parametrize("inplace", [False, True])
 @pytest.mark.parametrize("materialization", [Materialization.CTE, 'temp_table'])
+@pytest.mark.skip_athena_todo()  # TODO: Athena
 def test_materialize(inplace: bool, materialization: Union[Materialization, str], engine: Engine):
     bt = get_df_with_test_data(engine)[['city', 'founding']]
     bt['city'] = bt['city'] + ' '

--- a/bach/tests/functional/bach/test_df_merge.py
+++ b/bach/tests/functional/bach/test_df_merge.py
@@ -193,6 +193,7 @@ def test_merge_basic_on_indexes(engine):
         result = btr.merge(mtr, left_index=True, right_index=True)
 
 
+@pytest.mark.skip_athena_todo('https://github.com/objectiv/objectiv-analytics/issues/1209')
 def test_merge_suffixes(engine):
     bt = get_df_with_test_data(engine=engine, full_data_set=False)[['skating_order', 'city']]
     mt = get_df_with_food_data(engine)[['skating_order', 'food']]
@@ -529,6 +530,7 @@ def test_merge_non_materialized(engine):
         )
 
 
+@pytest.mark.skip_athena_todo('https://github.com/objectiv/objectiv-analytics/issues/1209')
 def test_merge_on_conditions(engine) -> None:
     pdf1 = pd.DataFrame({
         'A': ['a', 'b', 'c', 'd'],
@@ -554,6 +556,7 @@ def test_merge_on_conditions(engine) -> None:
     )
 
 
+@pytest.mark.skip_athena_todo('https://github.com/objectiv/objectiv-analytics/issues/1209')
 def test_merge_on_conditions_w_on_data_columns(engine) -> None:
     pdf1 = pd.DataFrame({
         'A': ['b', 'a', 'c', 'd'],
@@ -580,6 +583,7 @@ def test_merge_on_conditions_w_on_data_columns(engine) -> None:
     )
 
 
+@pytest.mark.skip_athena_todo('https://github.com/objectiv/objectiv-analytics/issues/1209')
 def test_merge_on_conditions_renamed_column(engine) -> None:
     pdf1 = pd.DataFrame({
         'A': ['b', 'a', 'c', 'd'],
@@ -599,6 +603,7 @@ def test_merge_on_conditions_renamed_column(engine) -> None:
     result = df1.merge(df2, on=on_condition)
 
 
+@pytest.mark.skip_athena_todo('https://github.com/objectiv/objectiv-analytics/issues/1209')
 def test_merge_on_conditions_w_index(engine) -> None:
     pdf1 = pd.DataFrame({
         'A': ['a', 'b', 'c', 'd'],

--- a/bach/tests/functional/bach/test_df_plot.py
+++ b/bach/tests/functional/bach/test_df_plot.py
@@ -3,15 +3,18 @@ Copyright 2022 Objectiv B.V.
 """
 from decimal import Decimal
 
+import pytest
 from matplotlib.testing.decorators import check_figures_equal
 from psycopg2._range import NumericRange
 
 from sql_models.util import is_bigquery, is_postgres
 from tests.functional.bach.test_data_and_utils import get_df_with_test_data, assert_equals_data
 
+pytestmark = pytest.mark.skip_athena_todo()  # TODO: Athena
 
 # generates and compares 2 matplotlib figures (png, pdf)
 # For more information https://matplotlib.org/3.5.0/api/testing_api.html#module-matplotlib.testing
+
 
 @check_figures_equal(extensions=['png', 'pdf'])
 def test_plot_hist_basic(engine, fig_test, fig_ref) -> None:

--- a/bach/tests/functional/bach/test_df_rename.py
+++ b/bach/tests/functional/bach/test_df_rename.py
@@ -1,7 +1,7 @@
 """
 Copyright 2021 Objectiv B.V.
 """
-from sql_models.util import is_bigquery
+from sql_models.util import is_bigquery, is_athena
 from tests.functional.bach.test_data_and_utils import assert_equals_data, get_df_with_test_data
 
 EXPECTED_DATA = [
@@ -30,8 +30,8 @@ def test_rename_complex(engine):
     bt = get_df_with_test_data(engine)
 
     new_name = 'stêd'
-    if is_bigquery(engine):
-        # BigQuery limits the allowed column names.
+    if is_athena(engine) or is_bigquery(engine):
+        # Athena and BigQuery limit the allowed column names.
         # See also tests.unit.bach.test_utils.test_is_valid_column_name
         new_name = 'stad'
 

--- a/bach/tests/functional/bach/test_df_sample.py
+++ b/bach/tests/functional/bach/test_df_sample.py
@@ -9,6 +9,7 @@ from sql_models.graph_operations import get_graph_nodes_info
 from sql_models.util import is_bigquery, is_postgres
 from tests.functional.bach.test_data_and_utils import assert_equals_data, get_df_with_test_data
 
+pytestmark = pytest.mark.skip_athena_todo()  # TODO: Athena
 
 def test_get_sample(engine, unique_table_test_name):
     # For reliable asserts (see below) we need more rows than the standard dataset of 11 rows has.

--- a/bach/tests/functional/bach/test_df_setitem.py
+++ b/bach/tests/functional/bach/test_df_setitem.py
@@ -132,7 +132,7 @@ def test_set_const_time(engine):
     check_set_const(engine, constants, SeriesTime)
 
 
-@pytest.mark.skip_athena()  # TODO: Athena
+@pytest.mark.skip_athena_todo()  # TODO: Athena
 def test_set_const_timedelta(engine):
     constants = [
         np.datetime64('2005-02-25T03:30') - np.datetime64('2005-01-25T03:30'),

--- a/bach/tests/functional/bach/test_df_setitem.py
+++ b/bach/tests/functional/bach/test_df_setitem.py
@@ -132,6 +132,7 @@ def test_set_const_time(engine):
     check_set_const(engine, constants, SeriesTime)
 
 
+@pytest.mark.skip_athena()  # TODO: Athena
 def test_set_const_timedelta(engine):
     constants = [
         np.datetime64('2005-02-25T03:30') - np.datetime64('2005-01-25T03:30'),

--- a/bach/tests/functional/bach/test_df_sort_values.py
+++ b/bach/tests/functional/bach/test_df_sort_values.py
@@ -62,6 +62,7 @@ def test_sort_values_expression(pg_engine):
     )
 
 
+@pytest.mark.skip_athena_todo('https://github.com/objectiv/objectiv-analytics/issues/1209')
 def test_sort_values_non_existing_column(engine):
     # Sort by an expression that is not in the DataFrame anymore
     bt = get_df_with_test_data(engine)[['city', 'inhabitants']]
@@ -101,6 +102,7 @@ def test_sort_values_parameters(engine):
     "ascending",  # generate all eight possible combinations of True/False for three parameters
     [list(asc) for asc in itertools.product((True, False), (True, False), (True, False))]
 )
+@pytest.mark.skip_athena_todo('https://github.com/objectiv/objectiv-analytics/issues/1209')
 def test_sorting_df_against_pandas(dataframes_sort, ascending) -> None:
     pdf, df = dataframes_sort
     sort_by = ['A', 'B', 'C']

--- a/bach/tests/functional/bach/test_df_stack.py
+++ b/bach/tests/functional/bach/test_df_stack.py
@@ -1,6 +1,9 @@
 import pandas as pd
+import pytest
 
 from tests.functional.bach.test_data_and_utils import assert_equals_data, get_df_with_test_data
+
+pytestmark = pytest.mark.skip_athena_todo()  # TODO: Athena (fix problem with upper case in column names)
 
 
 def test_stack(engine) -> None:

--- a/bach/tests/functional/bach/test_df_variables.py
+++ b/bach/tests/functional/bach/test_df_variables.py
@@ -197,6 +197,7 @@ def test_merge_variable_different_types(engine):
     )
 
 
+@pytest.mark.skip_athena_todo()  # TODO: Athena
 def test_get_all_variable_usage(engine):
     df1 = get_df_with_test_data(engine, full_data_set=False)[['skating_order', 'inhabitants']]
     assert df1.get_all_variable_usage() == []

--- a/bach/tests/functional/bach/test_df_window.py
+++ b/bach/tests/functional/bach/test_df_window.py
@@ -247,7 +247,6 @@ def test_windowing_functions_agg(engine):
         )
 
 
-
 def test_windowing_functions_basics_argument(engine):
     # just check the results in too many ways, first by calling the aggregation funcs with a window argument
     arg = get_df_with_test_data(engine, full_data_set=True)
@@ -595,6 +594,7 @@ def test_window_functions_not_in_where_having_groupby(engine):
         x = bt[bt.founding_min == 4]
 
 
+@pytest.mark.skip_athena_todo('https://github.com/objectiv/objectiv-analytics/issues/1209')
 def test_window_nav_functions_with_nulls(engine):
     pdf = pd.DataFrame(
         data={

--- a/bach/tests/functional/bach/test_revert_merge.py
+++ b/bach/tests/functional/bach/test_revert_merge.py
@@ -67,6 +67,7 @@ def test_revert_merge_basic_on_indexes(engine):
         _compare_source_with_replicate(expected, result)
 
 
+@pytest.mark.skip_athena_todo('https://github.com/objectiv/objectiv-analytics/issues/1209')
 def test_revert_merge_suffixes(engine):
     bt = get_df_with_test_data(engine, full_data_set=False)[['skating_order', 'city']]
     mt = get_df_with_food_data(engine)[['skating_order', 'food']]

--- a/bach/tests/functional/bach/test_series_append.py
+++ b/bach/tests/functional/bach/test_series_append.py
@@ -1,3 +1,5 @@
+import pytest
+
 from bach import Series
 from tests.functional.bach.test_data_and_utils import assert_equals_data, get_df_with_test_data
 
@@ -23,6 +25,7 @@ def test_series_append_same_dtype(engine) -> None:
     )
 
 
+@pytest.mark.skip_athena_todo()  # TODO: remove '.0' from stringified float
 def test_series_append_different_dtype(engine) -> None:
     bt = get_df_with_test_data(engine, full_data_set=False)[['city', 'inhabitants', 'founding']]
     bt['founding'] = bt['founding'].astype('float64')

--- a/bach/tests/functional/bach/test_series_describe.py
+++ b/bach/tests/functional/bach/test_series_describe.py
@@ -1,11 +1,13 @@
 import numpy as np
 import pandas as pd
+import pytest
 
 from bach import Series, DataFrame
 
 from tests.functional.bach.test_data_and_utils import get_df_with_test_data, assert_equals_data
 
 
+@pytest.mark.skip_athena_todo()  # TODO: Athena
 def test_categorical_describe(engine) -> None:
     series = get_df_with_test_data(engine, full_data_set=True)['municipality']
     result = series.describe()
@@ -26,6 +28,7 @@ def test_categorical_describe(engine) -> None:
     )
 
 
+@pytest.mark.skip_athena_todo()  # TODO: Athena  (does not support float as column name)
 def test_numerical_describe(engine) -> None:
     p_series = pd.Series(data=[1, 2, 3, 4, 5, 6, 7, 8, 1], name='numbers')
     series = DataFrame.from_pandas(engine=engine, df=p_series.to_frame(), convert_objects=True).numbers
@@ -46,7 +49,8 @@ def test_numerical_describe(engine) -> None:
 
 
 def test_describe_datetime(pg_engine) -> None:
-    engine = pg_engine  # TODO: BigQuery
+    # TODO: Athena and BigQuery. All engines have different string datetime formats
+    engine = pg_engine
     p_series = pd.Series(
         data=[np.datetime64("2000-01-01"), np.datetime64("2010-01-01"), np.datetime64("2010-01-01")],
         name='dt',

--- a/bach/tests/functional/bach/test_series_materialize.py
+++ b/bach/tests/functional/bach/test_series_materialize.py
@@ -11,6 +11,7 @@ from sql_models.util import is_bigquery, is_postgres, is_athena
 from tests.functional.bach.test_data_and_utils import assert_equals_data, get_df_with_test_data
 
 
+@pytest.mark.skip_athena_todo()  # TODO: Athena
 @pytest.mark.parametrize("materialization", [Materialization.CTE, 'temp_table'])
 def test_materialize(engine, materialization):
     bt = get_df_with_test_data(engine)['city'] + ' '

--- a/bach/tests/functional/bach/test_series_multi_level.py
+++ b/bach/tests/functional/bach/test_series_multi_level.py
@@ -4,6 +4,8 @@ import pytest
 from bach import DataFrame
 from bach.series.series_multi_level import SeriesNumericInterval
 
+pytestmark = pytest.mark.skip_athena_todo()  # TODO: Athena
+
 
 @pytest.fixture()
 def interval_data_pdf() -> pd.DataFrame:

--- a/bach/tests/functional/bach/test_series_numeric.py
+++ b/bach/tests/functional/bach/test_series_numeric.py
@@ -125,6 +125,7 @@ def test_aggregations_sum_mincount(engine):
         assert (math.isnan(pd_agg) and bt_agg_value is None) or bt_agg_value == pd_agg
 
 
+@pytest.mark.skip_athena_todo('https://github.com/objectiv/objectiv-analytics/issues/1209')
 def test_aggregations_quantile(engine):
     pdf = pd.DataFrame(data={'a': range(5), 'b': [1, 3, 5, 7, 9]})
     bt = DataFrame.from_pandas(engine=engine, df=pdf, convert_objects=True)
@@ -142,6 +143,7 @@ def test_aggregations_quantile(engine):
         pd.testing.assert_series_equal(expected_all_quantiles, result_all_quantiles.to_pandas(), check_names=False)
 
 
+@pytest.mark.skip_athena_todo('https://github.com/objectiv/objectiv-analytics/issues/1209')
 def test_grouped_quantile(engine):
     pdf = pd.DataFrame(data={'a': range(5), 'b': ['a', 'a', 'a', 'b', 'b']})
     bt = DataFrame.from_pandas(engine=engine, df=pdf, convert_objects=True)
@@ -153,6 +155,7 @@ def test_grouped_quantile(engine):
     pd.testing.assert_series_equal(expected, result.to_pandas(), check_names=False)
 
 
+@pytest.mark.skip_athena_todo()  # TODO: Athena
 def test_series_cut(engine) -> None:
     bins = 4
     inhabitants = get_df_with_test_data(engine, full_data_set=True)['inhabitants']
@@ -235,6 +238,7 @@ def test_series_cut(engine) -> None:
             np.testing.assert_almost_equal(exp.right, float(res.right), decimal=2)
 
 
+@pytest.mark.skip_athena_todo('https://github.com/objectiv/objectiv-analytics/issues/1209')
 def test_series_qcut(engine) -> None:
     bounds = '(]'
     inhabitants = get_df_with_test_data(engine, full_data_set=True)['inhabitants']

--- a/bach/tests/functional/bach/test_series_string.py
+++ b/bach/tests/functional/bach/test_series_string.py
@@ -33,6 +33,7 @@ def test_from_value(engine):
     )
 
 
+@pytest.mark.skip_athena_todo()  # TODO: Athena
 def test_string_slice(engine):
     bt = get_df_with_test_data(engine)[['city']]
 
@@ -96,6 +97,7 @@ def test_add_string_series(engine):
     )
 
 
+@pytest.mark.skip_athena_todo('https://github.com/objectiv/objectiv-analytics/issues/1209')
 def test_get_dummies(engine) -> None:
     bt = get_df_with_test_data(engine)
     result = bt['city'].get_dummies()
@@ -159,6 +161,7 @@ def test_string_lower_upper(engine) -> None:
     )
 
 
+@pytest.mark.skip_athena_todo()  # TODO: Athena
 def test_to_json_array(engine):
     df = get_df_with_test_data(engine, full_data_set=True)
     s_muni = df['municipality']
@@ -179,6 +182,7 @@ def test_to_json_array(engine):
     )
 
 
+@pytest.mark.skip_athena_todo()  # TODO: Athena
 def test_to_json_array_sorting_null(engine):
     data = [
         [1, 'x', 'aa'],
@@ -218,6 +222,7 @@ def test_to_json_array_sorting_null(engine):
     )
 
 
+@pytest.mark.skip_athena_todo()  # TODO: Athena
 def test_to_json_array_groupby(engine):
     df = get_df_with_test_data(engine, full_data_set=True)
     df = df.reset_index()

--- a/bach/tests/functional/bach/test_series_timedelta.py
+++ b/bach/tests/functional/bach/test_series_timedelta.py
@@ -121,6 +121,7 @@ def test_to_pandas(engine):
     assert bt[['td']].to_numpy()[0] == [27744277000000000]
 
 
+@pytest.mark.skip_athena_todo('https://github.com/objectiv/objectiv-analytics/issues/1209')
 def test_timedelta_operations(engine):
     pdf = pd.DataFrame(
         data={

--- a/bach/tests/functional/bach/test_series_value_counts.py
+++ b/bach/tests/functional/bach/test_series_value_counts.py
@@ -43,6 +43,7 @@ def test_value_counts_basic(engine):
     )
 
 
+@pytest.mark.skip_athena_todo()  # TODO: Athena
 def test_value_counts_w_bins(engine) -> None:
     bins = 4
     inhabitants = get_df_with_test_data(engine, full_data_set=True)['inhabitants']

--- a/bach/tests/unit/bach/test_series_multi_level.py
+++ b/bach/tests/unit/bach/test_series_multi_level.py
@@ -5,6 +5,8 @@ from bach.expression import Expression, MultiLevelExpression
 from sql_models.util import is_postgres, is_bigquery
 from tests.unit.bach.util import get_fake_df_test_data
 
+pytestmark = pytest.mark.skip_athena_todo()  # TODO: Athena
+
 
 def test_series_numeric_interval_levels_dtypes() -> None:
     supported_dtypes = SeriesNumericInterval.get_supported_level_dtypes()

--- a/bach/tests/unit/sql_models/test_sql_generator_materialization.py
+++ b/bach/tests/unit/sql_models/test_sql_generator_materialization.py
@@ -3,6 +3,8 @@ Copyright 2021 Objectiv B.V.
 """
 import re
 
+import pytest
+
 from sql_models.model import Materialization
 from sql_models.sql_generator import to_sql, to_sql_materialized_nodes, GeneratedSqlStatement
 from sql_models.util import is_bigquery
@@ -10,6 +12,7 @@ from tests.unit.sql_models.test_graph_operations import get_simple_test_graph
 from tests.unit.sql_models.util import ValueModel, RefModel, JoinModel, assert_roughly_equal_sql
 
 
+@pytest.mark.skip_athena_todo()  # TODO: Athena
 def test_simple_to_sql(dialect):
     # simple test that a simple graph compiles, and gets the expected sql with both
     # to_sql and to_sql_materialized_nodes

--- a/bach/tests/unit/sql_models/test_util.py
+++ b/bach/tests/unit/sql_models/test_util.py
@@ -46,6 +46,7 @@ def test_quote_identifier(dialect):
         raise Exception()
 
 
+@pytest.mark.skip_athena_todo()  # TODO: Athena research about syntax constants
 def test_quote_string(dialect):
     if is_postgres(dialect):
         # https://www.postgresql.org/docs/14/sql-syntax-lexical.html#SQL-SYNTAX-CONSTANTS


### PR DESCRIPTION
Cutting up https://github.com/objectiv/objectiv-analytics/pull/1195 into smaller pieces, and adding some stuff. This is step 5.

Changes:
* Marked all not-yet passing tests as `pytest.mark.skip_athena_todo()`
  * Different from PR [#1195](https://github.com/objectiv/objectiv-analytics/pull/1195): also marked tests that don't pass because of non-supported characters in column names with `skip_athena_todo()`, instead of changes the column names
* Invert logic: instead of only running tests against Athena that are marked as `athena_supported` now run all tests unless marked as `athena_skip` or `athena_skip_todo`