### PR TITLE
Bach tests athena 6 - Remove pg_engine

### DIFF
--- a/bach/tests/functional/bach/test_df_describe.py
+++ b/bach/tests/functional/bach/test_df_describe.py
@@ -80,8 +80,9 @@ def test_df_numerical_describe(engine) -> None:
     )
 
 
-def test_include_mixed(pg_engine) -> None:
-    df = get_df_with_test_data(engine=pg_engine)
+@pytest.mark.skip_bigquery_todo()
+def test_include_mixed(engine) -> None:
+    df = get_df_with_test_data(engine=engine)
     # duplicate last row. This will make the `mode` well-defined for all columns
     df = df.append(df.sort_index()[2:3])
 

--- a/bach/tests/functional/bach/test_df_from.py
+++ b/bach/tests/functional/bach/test_df_from.py
@@ -79,10 +79,10 @@ def test_from_table_basic(engine, unique_table_test_name):
     assert df == df_all_dtypes
 
 
-def test_from_model_basic(pg_engine, unique_table_test_name):
+@pytest.mark.skip_bigquery_todo()
+def test_from_model_basic(engine, unique_table_test_name):
     # This is essentially the same test as test_from_table_basic(), but tests creating the dataframe with
     # from_model instead of from_table
-    engine = pg_engine
     table_name = unique_table_test_name
     _create_test_table(engine, table_name)
     sql_model: SqlModel = CustomSqlModelBuilder(sql=f'select * from {table_name}')()
@@ -129,12 +129,12 @@ def test_from_table_column_ordering(engine, unique_table_test_name):
     assert df == df_all_dtypes
 
 
-def test_from_model_column_ordering(pg_engine, unique_table_test_name):
+@pytest.mark.skip_bigquery_todo()
+def test_from_model_column_ordering(engine, unique_table_test_name):
     # This is essentially the same test as test_from_table_model_ordering(), but tests creating the dataframe with
     # from_model instead of from_table
 
     # Create a Dataframe in which the index is not the first column in the table.
-    engine = pg_engine
     table_name = unique_table_test_name
     _create_test_table(engine, table_name)
     sql_model: SqlModel = CustomSqlModelBuilder(sql=f'select * from {table_name}')()

--- a/bach/tests/functional/bach/test_df_from_pandas.py
+++ b/bach/tests/functional/bach/test_df_from_pandas.py
@@ -51,10 +51,11 @@ TYPES_COLUMNS = ['int_column', 'float_column', 'bool_column', 'datetime_column',
 
 pytestmark = pytest.mark.skip_athena_todo()  # TODO: Athena
 
-def test_from_pandas_table(pg_engine, unique_table_test_name):
+
+def test_from_pandas_table(engine, unique_table_test_name):
     pdf = get_pandas_df(TEST_DATA_CITIES, CITIES_COLUMNS)
     bt = DataFrame.from_pandas(
-        engine=pg_engine,
+        engine=engine,
         df=pdf,
         convert_objects=True,
         name=unique_table_test_name,
@@ -133,13 +134,13 @@ def test_from_pandas_ephemeral_injection(engine):
         raise Exception(f'Test does not support {engine.dialect}')
 
 
-def test_from_pandas_non_happy_path(pg_engine, unique_table_test_name):
+def test_from_pandas_non_happy_path(engine, unique_table_test_name):
     pdf = get_pandas_df(TEST_DATA_CITIES, CITIES_COLUMNS)
     with pytest.raises(TypeError):
         # if convert_objects is false, we'll get an error, because pdf's dtype for 'city' and 'municipality'
         # is 'object'
         DataFrame.from_pandas(
-            engine=pg_engine,
+            engine=engine,
             df=pdf,
             convert_objects=False,
             name=unique_table_test_name,
@@ -150,14 +151,14 @@ def test_from_pandas_non_happy_path(pg_engine, unique_table_test_name):
     # Might fail on either the first or second try. As we don't clean up between tests.
     with pytest.raises(ValueError, match=f"Table '{unique_table_test_name}' already exists"):
         DataFrame.from_pandas(
-            engine=pg_engine,
+            engine=engine,
             df=pdf,
             convert_objects=True,
             name=unique_table_test_name,
             materialization='table',
         )
         DataFrame.from_pandas(
-            engine=pg_engine,
+            engine=engine,
             df=pdf,
             convert_objects=True,
             name=unique_table_test_name,
@@ -165,12 +166,13 @@ def test_from_pandas_non_happy_path(pg_engine, unique_table_test_name):
         )
 
 
+@pytest.mark.skip_bigquery_todo()
 @pytest.mark.parametrize("materialization", ['cte', 'table'])
-def test_from_pandas_index(materialization: str, pg_engine, unique_table_test_name):
+def test_from_pandas_index(materialization: str, engine, unique_table_test_name):
     # test multilevel index
     pdf = get_pandas_df(TEST_DATA_CITIES, CITIES_COLUMNS).set_index(['skating_order', 'city'])
     bt = DataFrame.from_pandas(
-        engine=pg_engine,
+        engine=engine,
         df=pdf,
         convert_objects=True,
         name=unique_table_test_name,
@@ -190,7 +192,7 @@ def test_from_pandas_index(materialization: str, pg_engine, unique_table_test_na
     # test nameless index
     pdf.reset_index(inplace=True)
     bt = DataFrame.from_pandas(
-        engine=pg_engine,
+        engine=engine,
         df=pdf,
         convert_objects=True,
         name=unique_table_test_name,
@@ -209,12 +211,13 @@ def test_from_pandas_index(materialization: str, pg_engine, unique_table_test_na
         expected_data=[[idx] + x[1:] for idx, x in enumerate(EXPECTED_DATA)])
 
 
+@pytest.mark.skip_bigquery_todo()
 @pytest.mark.parametrize("materialization", ['cte', 'table'])
-def test_from_pandas_types(materialization: str, pg_engine, unique_table_test_name):
+def test_from_pandas_types(materialization: str, engine, unique_table_test_name):
     pdf = pd.DataFrame.from_records(TYPES_DATA, columns=TYPES_COLUMNS)
     pdf.set_index(pdf.columns[0], drop=True, inplace=True)
     df = DataFrame.from_pandas(
-        engine=pg_engine,
+        engine=engine,
         df=pdf.loc[:, :'string_column'],
         convert_objects=True,
         name=unique_table_test_name,
@@ -242,7 +245,7 @@ def test_from_pandas_types(materialization: str, pg_engine, unique_table_test_na
     pdf.set_index(pdf.columns[0], drop=False, inplace=True)
     pdf['int32_column'] = pdf.int_column.astype(np.int32)
     df = DataFrame.from_pandas(
-        engine=pg_engine,
+        engine=engine,
         df=pdf[['int32_column']],
         convert_objects=True,
         name=unique_table_test_name,
@@ -263,11 +266,12 @@ def test_from_pandas_types(materialization: str, pg_engine, unique_table_test_na
     )
 
 
-def test_from_pandas_types_cte(pg_engine, unique_table_test_name):
+@pytest.mark.skip_bigquery_todo()
+def test_from_pandas_types_cte(engine, unique_table_test_name):
     pdf = pd.DataFrame.from_records(TYPES_DATA, columns=TYPES_COLUMNS)
     pdf.set_index(pdf.columns[0], drop=True, inplace=True)
     df = DataFrame.from_pandas(
-        engine=pg_engine,
+        engine=engine,
         df=pdf.loc[:, :'timedelta_column'],
         convert_objects=True,
         materialization='cte'
@@ -301,7 +305,7 @@ def test_from_pandas_types_cte(pg_engine, unique_table_test_name):
 
     with pytest.raises(TypeError, match="unsupported dtype for"):
         DataFrame.from_pandas(
-            engine=pg_engine,
+            engine=engine,
             df=pdf.loc[:, :'timedelta_column'],
             convert_objects=True,
             name=unique_table_test_name,
@@ -311,7 +315,7 @@ def test_from_pandas_types_cte(pg_engine, unique_table_test_name):
 
     with pytest.raises(TypeError, match="multiple types found in column"):
         DataFrame.from_pandas(
-            engine=pg_engine,
+            engine=engine,
             df=pdf.loc[:, :'mixed_column'],
             convert_objects=True,
             materialization='cte'

--- a/bach/tests/functional/bach/test_df_groupby.py
+++ b/bach/tests/functional/bach/test_df_groupby.py
@@ -378,11 +378,10 @@ def test_dataframe_agg_numeric_only(engine):
             'inhabitants_sum': 'int64'
         }
 
-
-def test_cube_basics(pg_engine):
+@pytest.mark.skip_bigquery_todo()
+def test_cube_basics(engine):
     # TODO: BigQuery
-    bt = get_df_with_test_data(pg_engine, full_data_set=False)
-    engine = bt.engine
+    bt = get_df_with_test_data(engine, full_data_set=False)
 
     # instant stonks through variable naming
     btc = bt.cube(['municipality', 'city'])
@@ -448,11 +447,11 @@ def test_rollup_basics(engine):
     )
 
 
-def test_grouping_list_basics(pg_engine):
+@pytest.mark.skip_bigquery_todo()
+def test_grouping_list_basics(engine):
     # TODO: BigQuery
     # This is not the greatest test, but at least it tests the interface.
-    bt = get_df_with_test_data(pg_engine, full_data_set=False)
-    engine = bt.engine
+    bt = get_df_with_test_data(engine, full_data_set=False)
     btl1 = bt.groupby([['municipality'], ['city']])
     btl2 = bt.groupby([['municipality'], 'city'])
     btl3 = bt.groupby(['municipality', ['city']])
@@ -482,11 +481,11 @@ def test_grouping_list_basics(pg_engine):
     )
 
 
-def test_grouping_set_basics(pg_engine):
+@pytest.mark.skip_bigquery_todo()
+def test_grouping_set_basics(engine):
     # TODO: BigQuery
     # This is not the greatest test, but at least it tests the interface.
-    bt = get_df_with_test_data(pg_engine, full_data_set=False)
-    engine = bt.engine
+    bt = get_df_with_test_data(engine, full_data_set=False)
     bts1 = bt.groupby((('municipality'), ('city')))
     bts2 = bt.groupby((('municipality'), 'city'))
     bts3 = bt.groupby(('municipality', ('city')))

--- a/bach/tests/functional/bach/test_df_savepoints.py
+++ b/bach/tests/functional/bach/test_df_savepoints.py
@@ -9,9 +9,12 @@ from tests.functional.bach.test_data_and_utils import assert_equals_data, get_df
 from tests.functional.bach.test_savepoints import remove_created_db_objects
 
 
+
+@pytest.mark.skip_athena_todo()
+@pytest.mark.skip_bigquery_todo()
 @pytest.mark.xdist_group(name="db_writers")
-def test_savepoint_materialization(pg_engine):
-    df = get_df_with_test_data(engine=pg_engine)
+def test_savepoint_materialization(engine):
+    df = get_df_with_test_data(engine=engine)
 
     engine = df.engine
     df.set_savepoint("savepoint1")

--- a/bach/tests/functional/bach/test_df_scale.py
+++ b/bach/tests/functional/bach/test_df_scale.py
@@ -1,3 +1,4 @@
+import pytest
 from sklearn.preprocessing import StandardScaler, MinMaxScaler
 
 from tests.functional.bach.test_data_and_utils import (
@@ -115,11 +116,11 @@ def test_standard_scale(engine) -> None:
     )
 
 
-def test_min_max_scale(pg_engine) -> None:
+def test_min_max_scale(engine) -> None:
     numerical_cols = ['skating_order', 'inhabitants', 'founding']
     all_cols = ['city'] + numerical_cols
     pdf = get_pandas_df(TEST_DATA_CITIES_FULL, CITIES_COLUMNS)
-    bt = get_df_with_test_data(engine=pg_engine, full_data_set=True)[all_cols]
+    bt = get_df_with_test_data(engine=engine, full_data_set=True)[all_cols]
     # bt = bt.sort_index()  # TODO: This breaks later on, it shouldn't.
                             #  Required to make this test deterministicly pass/fail
 

--- a/bach/tests/functional/bach/test_df_setitem.py
+++ b/bach/tests/functional/bach/test_df_setitem.py
@@ -55,7 +55,6 @@ def check_set_const(
     for column_name in column_names:
         assert isinstance(bt[column_name], expected_series)
 
-    db_types = {}
     if not is_bigquery(engine):
         # For BigQuery we cannot check the data type of an expression, as it doesn't offer a function for
         # that. For all other databases, we check that the actual type in the database matches the type

--- a/bach/tests/functional/bach/test_df_sort_values.py
+++ b/bach/tests/functional/bach/test_df_sort_values.py
@@ -46,9 +46,11 @@ def test_sort_values_basic(engine):
     )
 
 
-def test_sort_values_expression(pg_engine):
-    # TODO: BigQuery
-    bt = get_df_with_test_data(pg_engine)[['city', 'inhabitants']]
+@pytest.mark.skip_athena_todo()
+@pytest.mark.skip_bigquery_todo()
+def test_sort_values_expression(engine):
+    # TODO: BigQuery, Athena
+    bt = get_df_with_test_data(engine)[['city', 'inhabitants']]
     bt['city'] = bt['city'].str[2:]
     bt = bt.sort_values('city')
     assert_equals_data(

--- a/bach/tests/functional/bach/test_df_unstack.py
+++ b/bach/tests/functional/bach/test_df_unstack.py
@@ -3,8 +3,10 @@ import pytest
 from tests.functional.bach.test_data_and_utils import get_df_with_test_data, assert_equals_data
 
 
-def test_basic_unstack(pg_engine) -> None:
-    bt = get_df_with_test_data(engine=pg_engine, full_data_set=False)
+@pytest.mark.skip_athena_todo()
+@pytest.mark.skip_bigquery_todo()
+def test_basic_unstack(engine) -> None:
+    bt = get_df_with_test_data(engine=engine, full_data_set=False)
 
     with pytest.raises(NotImplementedError, match=r'index must be a multi level'):
         bt.unstack()
@@ -34,8 +36,10 @@ def test_basic_unstack(pg_engine) -> None:
     )
 
 
-def test_unstack_level(pg_engine) -> None:
-    bt = get_df_with_test_data(engine=pg_engine, full_data_set=False)
+@pytest.mark.skip_athena_todo()
+@pytest.mark.skip_bigquery_todo()
+def test_unstack_level(engine) -> None:
+    bt = get_df_with_test_data(engine=engine, full_data_set=False)
     bt = bt.set_index(keys=['city', 'skating_order', 'municipality'])
 
     result = bt.unstack(level=1)

--- a/bach/tests/functional/bach/test_pandas_loading.py
+++ b/bach/tests/functional/bach/test_pandas_loading.py
@@ -1,6 +1,8 @@
 """
 Copyright 2021 Objectiv B.V.
 """
+import pytest
+
 from bach import SeriesBoolean, SeriesInt64, SeriesString, \
     SeriesFloat64, SeriesTimestamp, DataFrame
 from tests.functional.bach.test_data_and_utils import assert_postgres_type
@@ -10,16 +12,19 @@ import datetime
 from tests.unit.bach.util import get_pandas_df
 
 
-def test_all_supported_types(pg_engine):
+@pytest.mark.skip_athena_todo()
+@pytest.mark.skip_bigquery_todo()
+def test_all_supported_types(engine):
     TEST_DATA_SUPPORTED_TYPES = [
         [1.32, 4, datetime.datetime(2015, 12, 13, 9, 54, 45, 543), 'fierljeppen', True]
     ]
     bt = DataFrame.from_pandas(
-        engine=pg_engine,
+        engine=engine,
         df=get_pandas_df(TEST_DATA_SUPPORTED_TYPES, ['float', 'int', 'timestamp', 'string', 'bool']),
         convert_objects=True,
     )
 
+    # TODO: don't use assert_postgres_type here
     assert_postgres_type(bt['float'], 'double precision', SeriesFloat64)
     assert_postgres_type(bt['int'], 'bigint', SeriesInt64)
     assert_postgres_type(bt['timestamp'], 'timestamp without time zone', SeriesTimestamp)
@@ -27,17 +32,21 @@ def test_all_supported_types(pg_engine):
     assert_postgres_type(bt['bool'], 'boolean', SeriesBoolean)
 
 
-def test_string_as_index(pg_engine):
+
+@pytest.mark.skip_athena_todo()
+@pytest.mark.skip_bigquery_todo()
+def test_string_as_index(engine):
     TEST_DATA_SUPPORTED_TYPES = [
         ['fierljeppen', 1.32, 4, datetime.datetime(2015, 12, 13, 9, 54, 45, 543), True]
     ]
 
     bt = DataFrame.from_pandas(
-        engine=pg_engine,
+        engine=engine,
         df=get_pandas_df(TEST_DATA_SUPPORTED_TYPES, ['string', 'float', 'int', 'timestamp', 'bool']),
         convert_objects=True,
     )
 
+    # TODO: don't use assert_postgres_type here
     assert_postgres_type(bt['float'], 'double precision', SeriesFloat64)
     assert_postgres_type(bt['int'], 'bigint', SeriesInt64)
     assert_postgres_type(bt['timestamp'], 'timestamp without time zone', SeriesTimestamp)
@@ -45,16 +54,19 @@ def test_string_as_index(pg_engine):
     assert_postgres_type(bt['bool'], 'boolean', SeriesBoolean)
 
 
-def test_load_df_without_conversion(pg_engine):
+@pytest.mark.skip_athena_todo()
+@pytest.mark.skip_bigquery_todo()
+def test_load_df_without_conversion(engine):
     TEST_DATA_SUPPORTED_TYPES = [
         [1.32, 4, datetime.datetime(2015, 12, 13, 9, 54, 45, 543), True]
     ]
     bt = DataFrame.from_pandas(
-        engine=pg_engine,
+        engine=engine,
         df=get_pandas_df(TEST_DATA_SUPPORTED_TYPES, ['float', 'int', 'timestamp', 'bool']),
         convert_objects=True,
     )
 
+    # TODO: don't use assert_postgres_type here
     assert_postgres_type(bt['float'], 'double precision', SeriesFloat64)
     assert_postgres_type(bt['int'], 'bigint', SeriesInt64)
     assert_postgres_type(bt['timestamp'], 'timestamp without time zone', SeriesTimestamp)

--- a/bach/tests/functional/bach/test_savepoints.py
+++ b/bach/tests/functional/bach/test_savepoints.py
@@ -11,8 +11,10 @@ from sql_models.model import Materialization
 from tests.functional.bach.test_data_and_utils import get_df_with_test_data, assert_equals_data
 
 
-def test_add_savepoint(pg_engine):
-    df = get_df_with_test_data(engine=pg_engine)
+@pytest.mark.skip_athena_todo()
+@pytest.mark.skip_bigquery_todo()
+def test_add_savepoint(engine):
+    df = get_df_with_test_data(engine=engine)
     sps = Savepoints()
     sps.add_savepoint('test', df, Materialization.TABLE)
     df2 = df.groupby('municipality').min()
@@ -28,8 +30,10 @@ def test_add_savepoint(pg_engine):
     assert len(sps.all) == 2
 
 
-def test_add_savepoint_double(pg_engine):
-    df = get_df_with_test_data(engine=pg_engine)
+@pytest.mark.skip_athena_todo()
+@pytest.mark.skip_bigquery_todo()
+def test_add_savepoint_double(engine):
+    df = get_df_with_test_data(engine=engine)
     sps = Savepoints()
     df = df.materialize()
     sps.add_savepoint('first', df, Materialization.TABLE)
@@ -37,8 +41,10 @@ def test_add_savepoint_double(pg_engine):
         sps.add_savepoint('second', df, Materialization.QUERY)
 
 
-def test_write_to_db_queries_only(pg_engine, testrun_uid):
-    df = get_df_with_test_data(engine=pg_engine)
+@pytest.mark.skip_athena_todo()
+@pytest.mark.skip_bigquery_todo()
+def test_write_to_db_queries_only(engine, testrun_uid):
+    df = get_df_with_test_data(engine=engine)
     engine = df.engine
     sps = Savepoints()
     sps.add_savepoint('the_name', df, Materialization.QUERY)
@@ -65,8 +71,9 @@ def test_write_to_db_queries_only(pg_engine, testrun_uid):
     )
 
 
-def test_write_to_db_create_objects(pg_engine, testrun_uid: str):
-    engine = pg_engine
+@pytest.mark.skip_athena_todo()
+@pytest.mark.skip_bigquery_todo()
+def test_write_to_db_create_objects(engine, testrun_uid: str):
     dialect = engine.dialect
     df = get_df_with_test_data(engine)
     engine = df.engine

--- a/bach/tests/functional/bach/test_series.py
+++ b/bach/tests/functional/bach/test_series.py
@@ -41,8 +41,12 @@ def test_series__getitem__(engine):
         non_existing_value_ref.value
 
 
-def test_positional_slicing(pg_engine):
-    bt = get_df_with_test_data(engine=pg_engine, full_data_set=True)['inhabitants'].sort_values()
+@pytest.mark.skip_athena_todo()
+@pytest.mark.skip_bigquery_todo()
+def test_positional_slicing(engine):
+    # TODO: make work with BigQuery and Athena.
+    # See for inspiration: tests.functional.bach.test_df_getitem.test_positional_slicing
+    bt = get_df_with_test_data(engine=engine, full_data_set=True)['inhabitants'].sort_values()
 
     class ReturnSlice:
         def __getitem__(self, key):
@@ -236,8 +240,10 @@ def test_aggregation(engine):
         s.agg(['sum','sum'])
 
 
-def test_type_agnostic_aggregation_functions(pg_engine):
-    bt = get_df_with_test_data(engine=pg_engine, full_data_set=True)
+@pytest.mark.skip_athena_todo()
+@pytest.mark.skip_bigquery_todo()
+def test_type_agnostic_aggregation_functions(engine):
+    bt = get_df_with_test_data(engine=engine, full_data_set=True)
     btg = bt.groupby()
 
     # type agnostic aggregations
@@ -366,8 +372,9 @@ def test_series_inherit_flag(engine):
     assert not bts_derived.expression.has_aggregate_function
 
 
-def test_series_independant_subquery_any_value_all_values(pg_engine):
-    bt = get_df_with_test_data(engine=pg_engine, full_data_set=True)
+@pytest.mark.skip_bigquery_todo()
+def test_series_independant_subquery_any_value_all_values(engine):
+    bt = get_df_with_test_data(engine=engine, full_data_set=True)
     s = bt.inhabitants.max() // 4
 
     bt[bt.inhabitants > s.any_value()].head()
@@ -488,8 +495,9 @@ def test_series_dropna(engine) -> None:
     )
 
 
-def test_series_unstack(pg_engine):
-    engine = pg_engine
+@pytest.mark.skip_athena_todo()
+@pytest.mark.skip_bigquery_todo()
+def test_series_unstack(engine):
     bt = get_df_with_test_data(engine=engine, full_data_set=True)
 
     stacked_bt = bt.groupby(['city','municipality']).inhabitants.sum()

--- a/bach/tests/functional/bach/test_series_describe.py
+++ b/bach/tests/functional/bach/test_series_describe.py
@@ -48,9 +48,10 @@ def test_numerical_describe(engine) -> None:
     pd.testing.assert_series_equal(expected, result.to_pandas(), check_dtype=False)
 
 
-def test_describe_datetime(pg_engine) -> None:
+@pytest.mark.skip_athena_todo()
+@pytest.mark.skip_bigquery_todo()
+def test_describe_datetime(engine) -> None:
     # TODO: Athena and BigQuery. All engines have different string datetime formats
-    engine = pg_engine
     p_series = pd.Series(
         data=[np.datetime64("2000-01-01"), np.datetime64("2010-01-01"), np.datetime64("2010-01-01")],
         name='dt',


### PR DESCRIPTION
Cutting up https://github.com/objectiv/objectiv-analytics/pull/1195 into smaller pieces, and adding some stuff. This is step 6.

Changes:
* Convert tests that use `pg_engine` to use `engine`
  * Add `skip_athena_todo` and `skip_bigquery_todo` as needed
* Remove `pg_engine` fixture 