### PR TITLE
Bach tests athena 7 - Remove athena_supported mark

### DIFF
--- a/bach/pytest.ini
+++ b/bach/pytest.ini
@@ -14,4 +14,3 @@ markers =
     skip_bigquery: Mark a test as testing code that does not need to work with BigQuery.
     skip_athena_todo: Temporary mark, mark a test as not yet passing for Athena, which should be fixed.
     skip_bigquery_todo: Temporary mark, mark a test as not yet passing for BigQuery, which should be fixed.
-    athena_supported: Temporary mark, mark as test as working with Athena

--- a/bach/tests/conftest.py
+++ b/bach/tests/conftest.py
@@ -77,7 +77,6 @@ MARK_SKIP_POSTGRES = 'skip_postgres'
 MARK_SKIP_ATHENA = 'skip_athena'
 MARK_SKIP_BIGQUERY = 'skip_bigquery'
 # Temporary marks
-MARK_ATHENA_SUPPORTED = 'athena_supported'
 MARK_SKIP_ATHENA_TODO = 'skip_athena_todo'
 MARK_SKIP_BIGQUERY_TODO = 'skip_bigquery_todo'
 

--- a/bach/tests/functional/bach/test_df.py
+++ b/bach/tests/functional/bach/test_df.py
@@ -8,7 +8,6 @@ from bach import DataFrame, SeriesBoolean
 from tests.functional.bach.test_data_and_utils import assert_equals_data, get_df_with_test_data
 
 
-@pytest.mark.athena_supported
 def test_basic(engine):
     bt = get_df_with_test_data(engine)
     assert_equals_data(
@@ -25,7 +24,6 @@ def test_basic(engine):
     )
 
 
-@pytest.mark.athena_supported
 def test_head(engine):
     bt = get_df_with_test_data(engine, full_data_set=True)
     bt = bt.sort_index()

--- a/bach/tests/functional/bach/test_df_getitem.py
+++ b/bach/tests/functional/bach/test_df_getitem.py
@@ -67,7 +67,6 @@ def test_get_item_multiple(engine):
     )
 
 
-@pytest.mark.athena_supported
 def test_positional_slicing(engine):
     bt = get_df_with_test_data(engine, full_data_set=True)
     bt = bt.sort_index()

--- a/bach/tests/functional/bach/test_df_setitem.py
+++ b/bach/tests/functional/bach/test_df_setitem.py
@@ -68,7 +68,7 @@ def check_set_const(
         assert_db_types(bt, db_types)
 
 
-@pytest.mark.athena_supported()
+
 def test_set_const_int(engine):
     constants = [
         np.int64(4),
@@ -79,7 +79,7 @@ def test_set_const_int(engine):
     check_set_const(engine, constants, SeriesInt64)
 
 
-@pytest.mark.athena_supported()
+
 def test_set_const_float(engine):
     constants = [
         5.1,
@@ -90,7 +90,6 @@ def test_set_const_float(engine):
     # special cases.
 
 
-@pytest.mark.athena_supported()
 def test_set_const_bool(engine):
     constants = [
         True,
@@ -99,7 +98,6 @@ def test_set_const_bool(engine):
     check_set_const(engine, constants, SeriesBoolean)
 
 
-@pytest.mark.athena_supported()
 def test_set_const_str(engine):
     constants = [
         'keatsen'
@@ -140,7 +138,7 @@ def test_set_const_timedelta(engine):
     check_set_const(engine, constants, SeriesTimedelta)
 
 
-@pytest.mark.athena_supported()
+
 def test_set_const_json(engine):
     constants = [
         ['a', 'b', 'c'],

--- a/bach/tests/functional/bach/test_series_boolean.py
+++ b/bach/tests/functional/bach/test_series_boolean.py
@@ -1,10 +1,6 @@
 import numpy
-import pytest
 
 from tests.functional.bach.test_data_and_utils import assert_equals_data, get_df_with_test_data
-
-
-pytestmark = pytest.mark.athena_supported()
 
 
 def test_from_const(engine):

--- a/bach/tests/functional/bach/test_series_date.py
+++ b/bach/tests/functional/bach/test_series_date.py
@@ -15,7 +15,6 @@ from bach.series.utils.datetime_formats import _C_STANDARD_CODES_X_POSTGRES_DATE
     CODES_SUPPORTED_IN_ALL_DIALECTS, STRINGS_SUPPORTED_IN_ALL_DIALECTS
 
 
-@pytest.mark.athena_supported()
 @pytest.mark.parametrize("asstring", [True, False])
 def test_date_comparator(asstring: bool, engine):
     mt = get_df_with_food_data(engine)[['date']]
@@ -49,7 +48,6 @@ def test_date_comparator(asstring: bool, engine):
     )
 
 
-@pytest.mark.athena_supported()
 def test_date_format(engine, recwarn):
     timestamp = datetime.datetime(2021, 5, 3, 11, 28, 36, 388000)
     date = datetime.date(2022, 1, 1)
@@ -147,7 +145,6 @@ def test_date_format_all_supported_pg_codes(engine, recwarn):
     assert len(recwarn) > 0
 
 
-@pytest.mark.athena_supported()
 def test_date_trunc(engine):
     mt = get_df_with_food_data(engine)
     mt['date'] = mt['date'].astype('date')
@@ -231,7 +228,6 @@ def test_date_trunc(engine):
         mt['time'].dt.date_trunc('hour')
 
 
-@pytest.mark.athena_supported()
 def test_date_arithmetic(engine):
     data = [
         ['d', datetime.date(2020, 3, 11), 'date', (None, 'timedelta')],
@@ -242,7 +238,6 @@ def test_date_arithmetic(engine):
     types_plus_min(engine, data, datetime.date(2021, 7, 23), 'date')
 
 
-@pytest.mark.athena_supported()
 def test_to_pandas(engine):
     bt = get_df_with_test_data(engine)
     bt['d'] = datetime.date(2020, 3, 11)

--- a/bach/tests/functional/bach/test_series_float.py
+++ b/bach/tests/functional/bach/test_series_float.py
@@ -4,15 +4,9 @@
 # TODO test aggregation functions
 import math
 from unittest.mock import ANY
-
-import pytest
-
 from bach import SeriesFloat64
 from tests.functional.bach.test_data_and_utils import assert_equals_data, get_df_with_test_data
 from tests.functional.bach.test_series_numeric import helper_test_simple_arithmetic
-
-
-pytestmark = pytest.mark.athena_supported()
 
 
 def test_from_value(engine):

--- a/bach/tests/functional/bach/test_series_int.py
+++ b/bach/tests/functional/bach/test_series_int.py
@@ -1,15 +1,10 @@
 """
 Copyright 2021 Objectiv B.V.
 """
-import pytest
-
 from bach import Series, SeriesInt64
 from tests.functional.bach.test_data_and_utils import assert_equals_data, assert_postgres_type,\
     get_df_with_test_data
 from tests.functional.bach.test_series_numeric import helper_test_simple_arithmetic
-
-
-pytestmark = pytest.mark.athena_supported()
 
 
 def test_add_int_constant(engine):

--- a/bach/tests/functional/bach/test_series_json.py
+++ b/bach/tests/functional/bach/test_series_json.py
@@ -18,7 +18,6 @@ import pytest
 
 pytestmark = [
     pytest.mark.parametrize('dtype', ('json', 'json_postgres'), indirect=True),
-    pytest.mark.athena_supported()
 ]
 
 

--- a/bach/tests/functional/bach/test_series_numeric.py
+++ b/bach/tests/functional/bach/test_series_numeric.py
@@ -48,7 +48,6 @@ def helper_test_simple_arithmetic(engine: Engine, a: Union[int, float], b: Union
     )
 
 
-@pytest.mark.athena_supported()
 def test_round(engine):
     values = [1.9, 3.0, 4.123, 6.425124, 2.00000000001, 2.1, np.nan, 7.]
     pdf = pd.DataFrame(data={'num': values})
@@ -70,7 +69,6 @@ def test_round(engine):
     )
 
 
-@pytest.mark.athena_supported()
 def test_round_integer(engine):
     values = [1, 3, 4, 6, 2, 2, 6, 7]
     pdf = pd.DataFrame(data={'num': values})
@@ -88,7 +86,6 @@ def test_round_integer(engine):
     )
 
 
-@pytest.mark.athena_supported()
 def test_aggregations_simple_tests(engine):
     values = [1, 3, 4, 6, 2, 2, np.nan, 7, 8]
     pdf = pd.DataFrame(data={'num': values})
@@ -105,7 +102,6 @@ def test_aggregations_simple_tests(engine):
         assert pd_agg == bt_agg.value
 
 
-@pytest.mark.athena_supported()
 def test_aggregations_sum_mincount(engine):
     pdf = pd.DataFrame(data={'num': [1, np.nan, 7, 8]})
     bt = DataFrame.from_pandas(engine=engine, df=pdf, convert_objects=True)
@@ -316,7 +312,6 @@ def test_series_qcut(engine) -> None:
             np.testing.assert_almost_equal(exp.right, float(res.right), decimal=2)
 
 
-@pytest.mark.athena_supported()
 def test_series_scale(engine) -> None:
     inhabitants = get_df_with_test_data(engine, full_data_set=True)['inhabitants']
     result = inhabitants.scale()
@@ -347,7 +342,6 @@ def test_series_scale(engine) -> None:
     )
 
 
-@pytest.mark.athena_supported()
 def test_series_minmax_scale(engine) -> None:
     inhabitants = get_df_with_test_data(engine, full_data_set=True)['inhabitants']
     result = inhabitants.minmax_scale()
@@ -377,7 +371,6 @@ def test_series_minmax_scale(engine) -> None:
     )
 
 
-@pytest.mark.athena_supported()
 def test_exp(engine) -> None:
     skating_order = get_df_with_test_data(engine, full_data_set=True)['skating_order']
     result = skating_order.exp()

--- a/bach/tests/functional/bach/test_series_string.py
+++ b/bach/tests/functional/bach/test_series_string.py
@@ -137,7 +137,6 @@ def test_string_replace(engine) -> None:
     assert_equals_data(result_df, expected_columns=expected_columns, expected_data=expected_data)
 
 
-@pytest.mark.athena_supported
 def test_string_lower_upper(engine) -> None:
     df = get_df_with_test_data(engine, full_data_set=True)
     df['municipality_lower'] = df['municipality'].str.lower()

--- a/bach/tests/functional/bach/test_series_time.py
+++ b/bach/tests/functional/bach/test_series_time.py
@@ -2,14 +2,10 @@
 Copyright 2021 Objectiv B.V.
 """
 import datetime
-
-import pytest
-
 from tests.functional.bach.test_data_and_utils import get_df_with_test_data
 from tests.functional.bach.test_series_timestamp import types_plus_min
 
 
-@pytest.mark.athena_supported()
 def test_time_arithmetic(engine):
     data = [
         ['d', datetime.date(2020, 3, 11), 'date', (None, None)],
@@ -20,7 +16,6 @@ def test_time_arithmetic(engine):
     types_plus_min(engine, data, datetime.time(13, 11, 5), 'time')
 
 
-@pytest.mark.athena_supported()
 def test_to_pandas(engine):
     bt = get_df_with_test_data(engine)
     bt['t'] = datetime.time(23, 11, 5, 123456)

--- a/bach/tests/functional/bach/test_series_timedelta.py
+++ b/bach/tests/functional/bach/test_series_timedelta.py
@@ -14,7 +14,6 @@ from tests.functional.bach.test_data_and_utils import assert_equals_data, \
 from tests.functional.bach.test_series_timestamp import types_plus_min
 
 
-@pytest.mark.athena_supported()
 def test_timedelta_arithmetic(engine):
     data = [
         ['d', datetime.date(2020, 3, 11), 'date', ('date', None)],
@@ -26,7 +25,6 @@ def test_timedelta_arithmetic(engine):
     types_plus_min(engine, data, datetime.timedelta(days=123, seconds=5621), 'timedelta')
 
 
-@pytest.mark.athena_supported()
 def test_timedelta_arithmetic2(engine):
     bt = get_df_with_test_data(engine, full_data_set=True)[['inhabitants']]
     td = datetime.timedelta(days=365, seconds=9877)
@@ -55,7 +53,6 @@ def test_timedelta_arithmetic2(engine):
     )
 
 
-@pytest.mark.athena_supported()
 def test_timedelta(engine):
     mt = get_df_with_food_data(engine)[['skating_order', 'moment']]
 
@@ -111,7 +108,6 @@ def test_timedelta(engine):
     )
 
 
-@pytest.mark.athena_supported()
 def test_to_pandas(engine):
     bt = get_df_with_test_data(engine)
     bt['td'] = datetime.timedelta(days=321, seconds=9877)
@@ -143,7 +139,6 @@ def test_timedelta_operations(engine):
     np.testing.assert_equal(expected.to_numpy(), result.sort_index().to_numpy())
 
 
-@pytest.mark.athena_supported()
 def test_timedelta_dt_properties(engine) -> None:
     unit = 'ms' if is_athena(engine) else 'us'
     pdf = pd.DataFrame(
@@ -212,7 +207,6 @@ def test_timedelta_dt_properties(engine) -> None:
     )
 
 
-@pytest.mark.athena_supported()
 def test_timedelta_dt_components(engine) -> None:
     unit = 'ms' if is_athena(engine) else 'us'
     pdf = pd.DataFrame(

--- a/bach/tests/functional/bach/test_series_timestamp.py
+++ b/bach/tests/functional/bach/test_series_timestamp.py
@@ -13,7 +13,6 @@ from sql_models.util import is_athena
 from tests.functional.bach.test_data_and_utils import assert_equals_data, get_df_with_test_data,\
     get_df_with_food_data
 
-pytestmark = pytest.mark.athena_supported()
 
 def floor_datetime(engine, dt: datetime.datetime) -> datetime.datetime:
     pdt = pd.Timestamp.fromtimestamp(dt.timestamp())

--- a/bach/tests/functional/bach/test_series_uuid.py
+++ b/bach/tests/functional/bach/test_series_uuid.py
@@ -13,9 +13,6 @@ from sql_models.util import is_postgres, is_bigquery, is_athena
 from tests.functional.bach.test_data_and_utils import assert_equals_data, run_query, get_df_with_test_data
 
 
-pytestmark = pytest.mark.athena_supported()
-
-
 def test_uuid_value_to_expression(engine):
     bt = get_df_with_test_data(engine)[['city']]
     bt['x'] = uuid.UUID('0022c7dd-074b-4a44-a7cb-b7716b668264')

--- a/bach/tests/unit/bach/test_df_from_pandas.py
+++ b/bach/tests/unit/bach/test_df_from_pandas.py
@@ -32,7 +32,7 @@ def test__assert_column_names_valid_generic(dialect):
     with pytest.raises(ValueError, match='Not all columns names are strings'):
         _assert_column_names_valid(dialect=dialect, df=pdf)
 
-@pytest.mark.athena_supported()
+
 def test__assert_column_names_valid_db_specific(dialect):
     # test whether column names are allowed for specific dialects
     # We'll just test a few combinations here

--- a/bach/tests/unit/bach/test_series_date.py
+++ b/bach/tests/unit/bach/test_series_date.py
@@ -9,8 +9,6 @@ import pytest
 from bach import SeriesDate
 from bach.expression import Expression
 
-pytestmark = pytest.mark.athena_supported()
-
 
 def test_supported_value_to_literal(dialect):
     def assert_call(value, expected_token_value: str):

--- a/bach/tests/unit/bach/test_series_time.py
+++ b/bach/tests/unit/bach/test_series_time.py
@@ -12,7 +12,6 @@ from bach.expression import Expression
 
 @pytest.mark.skip_bigquery('Athena specific test; test_supported_value_to_literal() below covers BigQuery')
 @pytest.mark.skip_postgres('Athena specific test; test_supported_value_to_literal() below covers Postgres')
-@pytest.mark.athena_supported
 def test_supported_value_to_literal_athena(dialect):
     def assert_call(value, expected_token_value: float):
         result = SeriesTime.supported_value_to_literal(dialect=dialect, value=value, dtype='time')
@@ -114,7 +113,6 @@ def test_supported_value_to_literal(dialect):
     assert SeriesTime.supported_value_to_literal(dialect, None, dtype) == Expression.construct('NULL')
 
 
-@pytest.mark.athena_supported
 def test_supported_value_to_literal_str_non_happy_path(dialect):
     dtype = 'timestamp'
     with pytest.raises(ValueError, match=r'Not a valid string literal: .* for time'):

--- a/bach/tests/unit/bach/test_series_timedelta.py
+++ b/bach/tests/unit/bach/test_series_timedelta.py
@@ -13,7 +13,6 @@ from bach.expression import Expression
 
 @pytest.mark.skip_bigquery('Athena specific test; test_supported_value_to_literal() below covers BigQuery')
 @pytest.mark.skip_postgres('Athena specific test; test_supported_value_to_literal() below covers Postgres')
-@pytest.mark.athena_supported
 def test_supported_value_to_literal_athena(dialect):
     def assert_call(value, expected_token_value: float):
         result = SeriesTimedelta.supported_value_to_literal(dialect, value, dtype=SeriesTimedelta.dtype)

--- a/bach/tests/unit/bach/test_utils.py
+++ b/bach/tests/unit/bach/test_utils.py
@@ -22,7 +22,6 @@ class ColNameValid(NamedTuple):
     bigquery: bool
 
 
-@pytest.mark.athena_supported()
 def test_is_valid_column_name(dialect):
     tests = [
         #            column name                              PG     Athena BQ


### PR DESCRIPTION
Cutting up https://github.com/objectiv/objectiv-analytics/pull/1195 into smaller pieces, and adding some stuff. This is step 7.

Change: Remove the unused `@pytest.mark.athena_supported` mark