### PR TITLE
Correct some wrongly classified tests as db_independent and db specific

### DIFF
--- a/bach/bach/from_database.py
+++ b/bach/bach/from_database.py
@@ -46,7 +46,7 @@ def get_dtypes_from_table(
     if is_postgres(engine):
         meta_data_table = 'INFORMATION_SCHEMA.COLUMNS'
     elif is_bigquery(engine):
-        meta_data_table, table_name = _get_meta_data_table_from_table_name(table_name)
+        meta_data_table, table_name = _get_bq_meta_data_table_from_table_name(table_name)
     else:
         raise DatabaseNotSupportedException(engine)
     sql = f"""
@@ -58,7 +58,7 @@ def get_dtypes_from_table(
     return _get_dtypes_from_information_schema_query(engine=engine, query=sql)
 
 
-def _get_meta_data_table_from_table_name(table_name) -> Tuple[str, str]:
+def _get_bq_meta_data_table_from_table_name(table_name) -> Tuple[str, str]:
     """
     From a BigQuery table name, get the meta-data table name that contains the column information for that
     table, and the short table name.

--- a/bach/tests/conftest.py
+++ b/bach/tests/conftest.py
@@ -131,10 +131,10 @@ def pytest_addoption(parser: Parser):
 
     # This function will automatically be called by pytest at the start of a test run, see:
     # https://docs.pytest.org/en/6.2.x/reference.html#initialization-hooks
-    parser.addoption('--postgres', action='store_true', help='run the functional tests for Postgres')
-    parser.addoption('--big-query', action='store_true', help='run the functional tests for BigQuery')
-    parser.addoption('--athena', action='store_true', help='run the functional tests for Athena')
-    parser.addoption('--all', action='store_true', help='run the functional tests for all databases.')
+    parser.addoption('--postgres', action='store_true', help='run the tests for Postgres')
+    parser.addoption('--big-query', action='store_true', help='run the tests for BigQuery')
+    parser.addoption('--athena', action='store_true', help='run the tests for Athena')
+    parser.addoption('--all', action='store_true', help='run the tests for all databases.')
 
 
 def pytest_sessionstart(session: Session):

--- a/bach/tests/unit/bach/test_from_database.py
+++ b/bach/tests/unit/bach/test_from_database.py
@@ -1,14 +1,17 @@
 """
 Copyright 2022 Objectiv B.V.
 """
-from bach.from_database import _get_meta_data_table_from_table_name
+import pytest
+
+from bach.from_database import _get_bq_meta_data_table_from_table_name
 
 
-def test__get_meta_data_table_from_table_name():
-    assert _get_meta_data_table_from_table_name('test_table') == ('INFORMATION_SCHEMA.COLUMNS', 'test_table')
-    assert _get_meta_data_table_from_table_name('dataset.test_table') == \
+@pytest.mark.db_independent('Function under test always assumes BQ; does not need dialect or engine param')
+def test__get_bq_meta_data_table_from_table_name():
+    assert _get_bq_meta_data_table_from_table_name('test_table') == ('INFORMATION_SCHEMA.COLUMNS', 'test_table')
+    assert _get_bq_meta_data_table_from_table_name('dataset.test_table') == \
            ('dataset.INFORMATION_SCHEMA.COLUMNS', 'test_table')
-    assert _get_meta_data_table_from_table_name('project_id.dataset.test_table') == \
+    assert _get_bq_meta_data_table_from_table_name('project_id.dataset.test_table') == \
            ('project_id.dataset.INFORMATION_SCHEMA.COLUMNS', 'test_table')
-    assert _get_meta_data_table_from_table_name('objectiv-production.a-dataset.a_table') == \
+    assert _get_bq_meta_data_table_from_table_name('objectiv-production.a-dataset.a_table') == \
            ('objectiv-production.a-dataset.INFORMATION_SCHEMA.COLUMNS', 'a_table')

--- a/bach/tests/unit/bach/test_merge.py
+++ b/bach/tests/unit/bach/test_merge.py
@@ -2,7 +2,6 @@
 Copyright 2021 Objectiv B.V.
 """
 import pytest
-from sqlalchemy.dialects.postgresql.base import PGDialect
 
 from bach.expression import Expression
 from bach.merge import (

--- a/bach/tests/unit/bach/test_series_multi_level.py
+++ b/bach/tests/unit/bach/test_series_multi_level.py
@@ -5,9 +5,8 @@ from bach.expression import Expression, MultiLevelExpression
 from sql_models.util import is_postgres, is_bigquery
 from tests.unit.bach.util import get_fake_df_test_data
 
-pytestmark = pytest.mark.skip_athena_todo()  # TODO: Athena
 
-
+@pytest.mark.db_independent('tested function does not care about engine or dialect')
 def test_series_numeric_interval_levels_dtypes() -> None:
     supported_dtypes = SeriesNumericInterval.get_supported_level_dtypes()
     assert 'lower' in supported_dtypes
@@ -20,6 +19,7 @@ def test_series_numeric_interval_levels_dtypes() -> None:
     assert supported_dtypes['bounds'] == ('string', )
 
 
+@pytest.mark.skip_athena_todo()  # TODO: Athena
 def test_series_numeric_interval_get_instance(dialect) -> None:
     bt = get_fake_df_test_data(dialect)
     params = {
@@ -52,6 +52,7 @@ def test_series_numeric_interval_get_instance(dialect) -> None:
     assert numeric_interval.bounds.name == '_interval_bounds'
 
 
+@pytest.mark.skip_athena_todo()  # TODO: Athena
 def test_series_numeric_interval_from_value(dialect) -> None:
     bt = get_fake_df_test_data(dialect)
 
@@ -82,6 +83,7 @@ def test_series_numeric_interval_from_value(dialect) -> None:
     assert '(]' in result.bounds.expression.to_sql(dialect)
 
 
+@pytest.mark.skip_athena_todo()  # TODO: Athena
 def test_series_numeric_interval_copy_override(dialect) -> None:
     bt = get_fake_df_test_data(dialect)[['inhabitants']].agg(['min', 'max'])
     bt = bt.materialize()
@@ -108,6 +110,7 @@ def test_series_numeric_interval_copy_override(dialect) -> None:
     assert '[)' in result.bounds.expression.to_sql(dialect)
 
 
+@pytest.mark.skip_athena_todo()  # TODO: Athena
 def test_series_numeric_interval_parse_level_value(dialect) -> None:
     bt = get_fake_df_test_data(dialect)
     numeric_interval = SeriesNumericInterval.from_value(
@@ -131,6 +134,7 @@ def test_series_numeric_interval_parse_level_value(dialect) -> None:
     assert 'inhabitants' in result.expression.to_sql(dialect)
 
 
+@pytest.mark.skip_athena_todo()  # TODO: Athena
 def test_series_numeric_expression(dialect) -> None:
     inhabitants = get_fake_df_test_data(dialect)['inhabitants']
     numeric_interval = SeriesNumericInterval.from_value(
@@ -154,6 +158,7 @@ def test_series_numeric_expression(dialect) -> None:
         raise Exception()
 
 
+@pytest.mark.skip_athena_todo()  # TODO: Athena
 def test_series_numeric_interval_get_column_expression(dialect) -> None:
     bt = get_fake_df_test_data(dialect)
     numeric_interval = SeriesNumericInterval.from_value(
@@ -182,6 +187,7 @@ def test_series_numeric_interval_get_column_expression(dialect) -> None:
         raise Exception()
 
 
+@pytest.mark.skip_athena_todo()  # TODO: Athena
 def test_series_numeric_interval_as_index_unstack(dialect) -> None:
     bt = get_fake_df_test_data(dialect)
     bt['num_interval'] = SeriesNumericInterval.from_value(
@@ -199,6 +205,7 @@ def test_series_numeric_interval_as_index_unstack(dialect) -> None:
         bt['inhabitants'].unstack()
 
 
+@pytest.mark.skip_athena_todo()  # TODO: Athena
 def test_series_numeric_interval_arithmetic_operations(dialect) -> None:
     bt = get_fake_df_test_data(dialect)
     bt['num_interval'] = SeriesNumericInterval.from_value(
@@ -218,6 +225,7 @@ def test_series_numeric_interval_arithmetic_operations(dialect) -> None:
         bt['num_interval'] + bt['num_interval']
 
 
+@pytest.mark.skip_athena_todo()  # TODO: Athena
 def test_series_numeric_interval_as_independent_subquery(dialect) -> None:
     bt = get_fake_df_test_data(dialect)
     bt['num_interval'] = SeriesNumericInterval.from_value(
@@ -245,6 +253,7 @@ def test_series_numeric_interval_as_independent_subquery(dialect) -> None:
         bt['inhabitants'].isin(bt['num_interval'])
 
 
+@pytest.mark.skip_athena_todo()  # TODO: Athena
 def test_series_numeric_interval_equals(dialect) -> None:
     bt = get_fake_df_test_data(dialect)
     bt['num_interval'] = SeriesNumericInterval.from_value(
@@ -271,6 +280,7 @@ def test_series_numeric_interval_equals(dialect) -> None:
     assert not bt['num_interval'].equals(bt['inhabitants'])
 
 
+@pytest.mark.skip_athena_todo()  # TODO: Athena
 def test_series_numeric_interval_isnull(dialect) -> None:
     bt = get_fake_df_test_data(dialect)
     bt['num_interval'] = SeriesNumericInterval.from_value(
@@ -289,6 +299,7 @@ def test_series_numeric_interval_isnull(dialect) -> None:
     assert result.equals(expected)
 
 
+@pytest.mark.skip_athena_todo()  # TODO: Athena
 def test_series_numeric_interval_notnull(dialect) -> None:
     bt = get_fake_df_test_data(dialect)
     bt['num_interval'] = SeriesNumericInterval.from_value(
@@ -307,6 +318,7 @@ def test_series_numeric_interval_notnull(dialect) -> None:
     assert result.equals(expected)
 
 
+@pytest.mark.skip_athena_todo()  # TODO: Athena
 def test_series_numeric_interval_fillna(dialect) -> None:
     bt = get_fake_df_test_data(dialect)[['inhabitants']]
     bt['num_interval'] = SeriesNumericInterval.from_value(

--- a/bach/tests/unit/bach/test_series_multi_level.py
+++ b/bach/tests/unit/bach/test_series_multi_level.py
@@ -6,7 +6,7 @@ from sql_models.util import is_postgres, is_bigquery
 from tests.unit.bach.util import get_fake_df_test_data
 
 
-@pytest.mark.db_independent('tested function does not care about engine or dialect')
+@pytest.mark.db_independent
 def test_series_numeric_interval_levels_dtypes() -> None:
     supported_dtypes = SeriesNumericInterval.get_supported_level_dtypes()
     assert 'lower' in supported_dtypes

--- a/bach/tests/unit/bach/test_types.py
+++ b/bach/tests/unit/bach/test_types.py
@@ -59,6 +59,7 @@ def _test_validate_is_dtype_false(dtype: Any, matches=None):
         validate_is_dtype(dtype)
 
 
+@pytest.mark.db_independent
 def test_validate_dtype_value():
     validate_dtype_value(static_dtype='bool', instance_dtype='bool', value=True)
     validate_dtype_value(static_dtype='bool', instance_dtype='bool', value=False)

--- a/bach/tests/unit/bach/test_utils.py
+++ b/bach/tests/unit/bach/test_utils.py
@@ -51,6 +51,7 @@ def test_is_valid_column_name(dialect):
         assert is_valid_column_name(dialect, column_name) is expected
 
 
+@pytest.mark.db_independent
 def test_validate_sorting_expressions() -> None:
     model = BachSqlModel(
         model_spec=CustomSqlModelBuilder(sql='SELECT * FROM test', name='test'),

--- a/bach/tests/unit/sql_models/test_model.py
+++ b/bach/tests/unit/sql_models/test_model.py
@@ -5,7 +5,6 @@ import re
 from typing import List
 
 import pytest
-from sqlalchemy.dialects.postgresql.base import PGDialect
 
 from sql_models.graph_operations import get_node, get_graph_nodes_info
 from sql_models.model import SqlModel, RefPath, CustomSqlModelBuilder, Materialization
@@ -13,9 +12,7 @@ from sql_models.sql_generator import to_sql
 from tests.unit.sql_models.util import RefModel, ValueModel, JoinModel
 
 
-pytestmark = [pytest.mark.db_independent]  # mark all tests here as database independent.
-
-
+@pytest.mark.db_independent
 def test_builder_cycles_raise_exception():
     rm1 = RefModel()
     rm2 = RefModel(ref=rm1)
@@ -28,7 +25,7 @@ def test_builder_cycles_raise_exception():
     with pytest.raises(Exception):
         rm2.instantiate_recursively()
 
-
+@pytest.mark.db_independent
 def test_equality_base_cases():
     vm1 = ValueModel.build(key='X', val=1)
     vm2 = ValueModel.build(key='X', val=2)
@@ -47,6 +44,7 @@ def test_equality_base_cases():
     assert graph1 != rm
 
 
+@pytest.mark.db_independent
 def test_equality_different_classes():
     vm1 = ValueModel.build(key='X', val=1)
     vm2 = ValueModel.build(key='X', val=2)
@@ -69,6 +67,7 @@ def test_equality_different_classes():
     assert vm2 == csm2
 
 
+@pytest.mark.db_independent
 def test_equality_different_property_formatters():
     csm_builder = CustomSqlModelBuilder(sql='select {val} as value')
     csm_alt_builder = CustomSqlModelBuilder(sql='select {val} as value')
@@ -93,8 +92,7 @@ def test_equality_different_property_formatters():
     assert csm1.set(tuple(), val=3).hash != csm3.set(tuple(), val=3).hash
 
 
-def test_set():
-    dialect = PGDialect()
+def test_set(dialect):
     # Build a simple graph
     vm1 = ValueModel.build(key='X', val=1)
     vm2 = ValueModel.build(key='X', val=2)
@@ -140,6 +138,7 @@ def test_set():
     assert sql_diff_ignore_hash_changes == [('X', 'Y')]
 
 
+@pytest.mark.db_independent
 def test_set_complex_graph():
     # Build a complex graph, and use set() to update a node
     #
@@ -213,12 +212,14 @@ def test_set_complex_graph():
     _assert_graph_difference(graph, new_graph3, same_paths, changed_paths)
 
 
+@pytest.mark.db_independent
 def test_set_error():
     vm1 = ValueModel.build(key='a', val=1)
     with pytest.raises(ValueError, match='non-existing placeholder'):
         vm1.set(tuple(), xyz=123)
 
 
+@pytest.mark.db_independent
 def test_link():
     # Graph:
     # vm1 <--+-- rm <-----\
@@ -261,6 +262,7 @@ def test_link():
     assert get_node(new_graph3, ('ref_right',)) is graph
 
 
+@pytest.mark.db_independent
 def test_set_materialization():
     # Graph:
     # vm1 <--+-- rm <-----\
@@ -303,6 +305,7 @@ def test_set_materialization():
     assert get_node(new_graph2, ('ref_left', 'ref_right')) is not vm1
 
 
+@pytest.mark.db_independent
 def test_set_materialization_name():
     # Graph:
     # vm1 <--+-- rm <-----\

--- a/bach/tests/unit/sql_models/test_sql_generator.py
+++ b/bach/tests/unit/sql_models/test_sql_generator.py
@@ -2,7 +2,6 @@
 Copyright 2021 Objectiv B.V.
 """
 import pytest
-from sqlalchemy.dialects.postgresql.base import PGDialect
 
 from sql_models.model import SqlModelBuilder, CustomSqlModelBuilder
 from sql_models.sql_generator import to_sql
@@ -127,9 +126,8 @@ class MultiplierWithId(SqlModelBuilder):
         '''
 
 
-def test_model_thrice_simple():
-    # TODO: bigquery
-    dialect = PGDialect()
+@pytest.mark.skip_bigquery_todo()
+def test_model_thrice_simple(dialect):
     model = Double.build(
         source=Double(
             source=Double(


### PR DESCRIPTION
### Background and PR
After all PRs mentioned in this comment https://github.com/objectiv/objectiv-analytics/pull/1195#issuecomment-1238586678 were merged. I had a look at what we still needed to do to get BigQuery and Athena to fully-supported, by looking at the tests that we still need to fix. I noticed that the numbers didn't quite match up, because some tests weren't classified correctly. This PR fixes that


### Some Numbers on tests
* `154` tests are not yet working for Athena: `pytest tests/ -m 'skip_athena_todo' --athena --collect-only`
* `32` tests are not yet working for BigQuery: `pytest tests/ -m 'skip_bigquery_todo' --big-query --collect-only`
* `597` tests in total.
* When running with `--all`, we run `1432` tests
  * `55` are database  independent
  * `525` run against Postgres or use the Postgres Dialect
  * `493` run against BigQuery or use the BigQuery Dialect
  * `359` run against Athena or use the Athena Dialect
