### PR TITLE
[DO NOT MERGE YET] Update links to Demo in docs & notebooks (again)

### DIFF
--- a/bach/docs/source/bach/examples.rst
+++ b/bach/docs/source/bach/examples.rst
@@ -15,7 +15,7 @@ In the examples we'll assume that the database has a table called 'example', wit
 columns. The SQL to create that table can be found below in :ref:`appendix_example_data`.
 
 To get a taste of what you can do with Objectiv Bach, There is a `demo
-</docs/home/quickstart-guide>`_ available that enables you to run the full Objectiv pipeline
+</docs/home/try-the-demo>`_ available that enables you to run the full Objectiv pipeline
 on your local machine. It includes our website as a demo app, a Jupyter Notebook environment with working
 models and a Metabase environment to output data to.
 

--- a/bach/docs/source/example-notebooks/explore-data.rst
+++ b/bach/docs/source/example-notebooks/explore-data.rst
@@ -12,7 +12,7 @@ This example notebook shows how you can easily explore your data collected with 
 as a `full Jupyter notebook 
 <https://github.com/objectiv/objectiv-analytics/blob/main/notebooks/explore-your-data.ipynb>`_
 to run on your own data (see how to :doc:`get started in your notebook <../get-started-in-your-notebook>`), 
-or you can instead `run the Demo </docs/home/quickstart-guide/>`_ to quickly try it out. The dataset used 
+or you can instead `run the Demo </docs/home/try-the-demo/>`_ to quickly try it out. The dataset used 
 here is the same as in the Demo.
 
 Get started
@@ -258,7 +258,7 @@ Get the SQL for any analysis
 
 The SQL for any analysis can be exported with one command, so you can use models in production directly to 
 simplify data debugging & delivery to BI tools like Metabase, dbt, etc. See how you can `quickly create BI 
-dashboards with this <https://objectiv.io/docs/home/quickstart-guide#creating-bi-dashboards>`_.
+dashboards with this <https://objectiv.io/docs/home/try-the-demo#creating-bi-dashboards>`_.
 
 .. doctest:: explore-data-features
 	:skipif: engine is None

--- a/bach/docs/source/example-notebooks/feature-engineering.rst
+++ b/bach/docs/source/example-notebooks/feature-engineering.rst
@@ -16,7 +16,7 @@ data set prepared in Bach can be used for machine learning with sklearn
 
 This example is also available in a `notebook
 <https://github.com/objectiv/objectiv-analytics/blob/main/notebooks/feature-engineering.ipynb>`_
-to run on your own data or use our `quickstart <https://objectiv.io/docs/home/quickstart-guide/>`_ to try it 
+to run on your own data or use our `quickstart <https://objectiv.io/docs/home/try-the-demo/>`_ to try it 
 out with demo data in 5 minutes.
 
 First we have to install the open model hub and instantiate the Objectiv DataFrame object; see

--- a/bach/docs/source/example-notebooks/funnel-discovery.rst
+++ b/bach/docs/source/example-notebooks/funnel-discovery.rst
@@ -12,7 +12,7 @@ This example notebook shows how to use the 'Funnel Discovery' model on your data
 It's also available as a `full Jupyter notebook 
 <https://github.com/objectiv/objectiv-analytics/blob/main/notebooks/funnel-discovery.ipynb>`_
 to run on your own data (see how to :doc:`get started in your notebook <../get-started-in-your-notebook>`), 
-or you can instead `run the Demo </docs/home/quickstart-guide/>`_ to quickly try it out. The dataset used 
+or you can instead `run the Demo </docs/home/try-the-demo/>`_ to quickly try it out. The dataset used 
 here is the same as in the Demo.
 
 In classical funnel analysis you predefine the steps, and then you analyze the differences for user 
@@ -473,7 +473,7 @@ Get the SQL for any analysis
 
 The SQL for any analysis can be exported with one command, so you can use models in production directly to 
 simplify data debugging & delivery to BI tools like Metabase, dbt, etc. See how you can `quickly create BI 
-dashboards with this <https://objectiv.io/docs/home/quickstart-guide#creating-bi-dashboards>`_.
+dashboards with this <https://objectiv.io/docs/home/try-the-demo#creating-bi-dashboards>`_.
 
 Where to go next
 ----------------

--- a/bach/docs/source/example-notebooks/logistic-regression.rst
+++ b/bach/docs/source/example-notebooks/logistic-regression.rst
@@ -12,7 +12,7 @@ The open model hub supports logistic regression on Bach data objects. A logistic
 
 This example is also available in a `notebook
 <https://github.com/objectiv/objectiv-analytics/blob/main/notebooks/model-hub-logistic-regression.ipynb>`_
-to run on your own data or use our `quickstart <https://objectiv.io/docs/home/quickstart-guide/>`_ to try it 
+to run on your own data or use our `quickstart <https://objectiv.io/docs/home/try-the-demo/>`_ to try it 
 out with demo data in 5 minutes.
 
 First we have to install the open model hub and instantiate the Objectiv DataFrame object; see
@@ -135,7 +135,7 @@ Get the sql statement for the _full_ data set including the predicted values.
 
 The SQL for any analysis can be exported with this one command, so you can use models in production directly 
 to simplify data debugging & delivery to BI tools like Metabase, dbt, etc. See how you can `quickly create BI 
-dashboards with this <https://objectiv.io/docs/home/quickstart-guide#creating-bi-dashboards>`_.
+dashboards with this <https://objectiv.io/docs/home/try-the-demo#creating-bi-dashboards>`_.
 
 This demonstrates the core functionality of the Logistic Regression model in the open model hub. Stay tuned 
 for more metrics for assessing the fit of the model, as well as simplifying splitting the data into training 

--- a/bach/docs/source/example-notebooks/machine-learning.rst
+++ b/bach/docs/source/example-notebooks/machine-learning.rst
@@ -17,7 +17,7 @@ This example is also available in a `notebook
 <https://github.com/objectiv/objectiv-analytics/blob/main/notebooks/sklearn-example.ipynb>`_
 to run on your own data or use our
 `quickstart
-<https://objectiv.io/docs/home/quickstart-guide/>`_ to try it out with demo data in 5 minutes.
+<https://objectiv.io/docs/home/try-the-demo/>`_ to try it out with demo data in 5 minutes.
 
 First we have to install the open model hub and instantiate the Objectiv DataFrame object; see
 :doc:`getting started in your notebook <../get-started-in-your-notebook>`.

--- a/bach/docs/source/example-notebooks/marketing-analytics.rst
+++ b/bach/docs/source/example-notebooks/marketing-analytics.rst
@@ -12,7 +12,7 @@ This example notebook shows how you can easily analyze traffic coming from Marke
 via UTM tags. It's also available as a `full Jupyter notebook 
 <https://github.com/objectiv/objectiv-analytics/blob/main/notebooks/marketing-analytics.ipynb>`_
 to run on your own data (see how to :doc:`get started in your notebook <../get-started-in-your-notebook>`), 
-or you can instead `run the Demo </docs/home/quickstart-guide/>`_ to quickly try it out. The dataset used 
+or you can instead `run the Demo </docs/home/try-the-demo/>`_ to quickly try it out. The dataset used 
 here is the same as in the Demo.
 
 Get started
@@ -923,4 +923,4 @@ Get the SQL for any analysis
 
 The SQL for any analysis can be exported with one command, so you can use models in production directly to 
 simplify data debugging & delivery to BI tools like Metabase, dbt, etc. See how you can `quickly create BI 
-dashboards with this <https://objectiv.io/docs/home/quickstart-guide#creating-bi-dashboards>`_.
+dashboards with this <https://objectiv.io/docs/home/try-the-demo#creating-bi-dashboards>`_.

--- a/bach/docs/source/example-notebooks/modelhub-basics.rst
+++ b/bach/docs/source/example-notebooks/modelhub-basics.rst
@@ -11,7 +11,7 @@ Open model hub basics
 In this example, we briefly demonstrate how you can use pre-built models from the open model hub in
 conjunction with, :ref:`Bach <bach>`, our modeling library. It's also available in a `notebook
 <https://github.com/objectiv/objectiv-analytics/blob/main/notebooks/model-hub-demo-notebook.ipynb>`_
-to run on your own data or use our `quickstart <https://objectiv.io/docs/home/quickstart-guide/>`_ to try it 
+to run on your own data or use our `quickstart <https://objectiv.io/docs/home/try-the-demo/>`_ to try it 
 out with demo data in 5 minutes.
 
 This example uses real, unaltered data that was collected from https://objectiv.io with Objectiv’s Tracker. All models

--- a/bach/docs/source/example-notebooks/open-taxonomy.rst
+++ b/bach/docs/source/example-notebooks/open-taxonomy.rst
@@ -13,7 +13,7 @@ dataset that is validated against the `open analytics taxonomy <https://objectiv
 
 It's also available in a 
 `notebook <https://github.com/objectiv/objectiv-analytics/blob/main/notebooks/open-taxonomy-how-to.ipynb>`_
-to run on your own data, or you can instead `run the Demo </docs/home/quickstart-guide/>`_ to quickly try it 
+to run on your own data, or you can instead `run the Demo </docs/home/try-the-demo/>`_ to quickly try it 
 out.
 
 The Objectiv :doc:`Bach API <../bach/api-reference/index>` is strongly pandas-like, to provide a familiar 
@@ -477,7 +477,7 @@ Get the SQL for any analysis
 
 The SQL for any analysis can be exported with one command, so you can use models in production directly to 
 simplify data debugging & delivery to BI tools like Metabase, dbt, etc. See how you can `quickly create BI 
-dashboards with this <https://objectiv.io/docs/home/quickstart-guide#creating-bi-dashboards>`_.
+dashboards with this <https://objectiv.io/docs/home/try-the-demo#creating-bi-dashboards>`_.
 
 .. doctest:: open-taxonomy
 	:skipif: engine is None

--- a/bach/docs/source/example-notebooks/product-analytics.rst
+++ b/bach/docs/source/example-notebooks/product-analytics.rst
@@ -12,7 +12,7 @@ This example notebook shows how you can easily analyze the basics of product ana
 as a `full Jupyter notebook 
 <https://github.com/objectiv/objectiv-analytics/blob/main/notebooks/basic-product-analytics.ipynb>`_
 to run on your own data (see how to :doc:`get started in your notebook <../get-started-in-your-notebook>`), 
-or you can instead `run the Demo </docs/home/quickstart-guide/>`_ to quickly try it out. The dataset used 
+or you can instead `run the Demo </docs/home/try-the-demo/>`_ to quickly try it out. The dataset used 
 here is the same as in the Demo.
 
 Get started
@@ -575,7 +575,7 @@ Get the SQL for any analysis
 ----------------------------
 The SQL for any analysis can be exported with one command, so you can use models in production directly to 
 simplify data debugging & delivery to BI tools like Metabase, dbt, etc. See how you can `quickly create BI 
-dashboards with this <https://objectiv.io/docs/home/quickstart-guide#creating-bi-dashboards>`_.
+dashboards with this <https://objectiv.io/docs/home/try-the-demo#creating-bi-dashboards>`_.
 
 .. the testsetup below is a workaround to show the actual SQL output
 

--- a/bach/docs/source/example-notebooks/user-intent.rst
+++ b/bach/docs/source/example-notebooks/user-intent.rst
@@ -10,7 +10,7 @@ Basic user intent analysis
 
 This example shows how the open model hub can be used for basic user intent analysis. It's also available in 
 a `notebook <https://github.com/objectiv/objectiv-analytics/blob/main/notebooks/basic-user-intent.ipynb>`_
-to run on your own data or use our `quickstart <https://objectiv.io/docs/home/quickstart-guide/>`_ to try it 
+to run on your own data or use our `quickstart <https://objectiv.io/docs/home/try-the-demo/>`_ to try it 
 out with demo data in 5 minutes.
 
 First we have to install the open model hub and instantiate the Objectiv DataFrame object; see
@@ -166,7 +166,7 @@ Get the SQL for any analysis
 
 The SQL for any analysis can be exported with one command, so you can use models in production directly to 
 simplify data debugging & delivery to BI tools like Metabase, dbt, etc. See how you can `quickly create BI 
-dashboards with this <https://objectiv.io/docs/home/quickstart-guide#creating-bi-dashboards>`_.
+dashboards with this <https://objectiv.io/docs/home/try-the-demo#creating-bi-dashboards>`_.
 
 .. code-block:: python
 

--- a/notebooks/basic-product-analytics.ipynb
+++ b/notebooks/basic-product-analytics.ipynb
@@ -5,7 +5,7 @@
    "id": "afb5dddf",
    "metadata": {},
    "source": [
-    "This is one of the Objectiv [example notebooks](https://objectiv.io/docs/modeling/example-notebooks/). These notebooks can run [on your own data](https://objectiv.io/docs/modeling/get-started-in-your-notebook/), or you can instead run the [Demo](https://objectiv.io/docs/home/quickstart-guide/) to quickly try them out."
+    "This is one of the Objectiv [example notebooks](https://objectiv.io/docs/modeling/example-notebooks/). These notebooks can run [on your own data](https://objectiv.io/docs/modeling/get-started-in-your-notebook/), or you can instead run the [Demo](https://objectiv.io/docs/home/try-the-demo/) to quickly try them out."
    ]
   },
   {
@@ -688,7 +688,7 @@
    "metadata": {},
    "source": [
     "## Get the SQL for any analysis\n",
-    "The SQL for any analysis can be exported with one command, so you can use models in production directly to simplify data debugging & delivery to BI tools like Metabase, dbt, etc. See how you can [quickly create BI dashboards with this](https://objectiv.io/docs/home/quickstart-guide#creating-bi-dashboards)."
+    "The SQL for any analysis can be exported with one command, so you can use models in production directly to simplify data debugging & delivery to BI tools like Metabase, dbt, etc. See how you can [quickly create BI dashboards with this](https://objectiv.io/docs/home/try-the-demo#creating-bi-dashboards)."
    ]
   },
   {

--- a/notebooks/basic-user-intent.ipynb
+++ b/notebooks/basic-user-intent.ipynb
@@ -6,9 +6,9 @@
    "metadata": {},
    "source": [
     "This is one of the Objectiv example notebooks. For more examples visit the \n",
-    "[example notebooks](https://objectiv.io/docs/modeling/example-notebooks/) section of our docs. The notebooks can run with the demo data set that comes with the our [quickstart](https://objectiv.io/docs/home/quickstart-guide/), but can be used to run on your own collected data as well.\n",
+    "[example notebooks](https://objectiv.io/docs/modeling/example-notebooks/) section of our docs. The notebooks can run with the demo data set that comes with the our [quickstart](https://objectiv.io/docs/home/try-the-demo/), but can be used to run on your own collected data as well.\n",
     "\n",
-    "All example notebooks are also available in our [quickstart](https://objectiv.io/docs/home/quickstart-guide/). With the quickstart you can spin up a fully functional Objectiv demo pipeline in five minutes. This also allows you to run these notebooks and experiment with them on a demo data set."
+    "All example notebooks are also available in our [quickstart](https://objectiv.io/docs/home/try-the-demo/). With the quickstart you can spin up a fully functional Objectiv demo pipeline in five minutes. This also allows you to run these notebooks and experiment with them on a demo data set."
    ]
   },
   {
@@ -316,7 +316,7 @@
    },
    "source": [
     "## Get the SQL for this user intent analysis\n",
-    "The SQL for any analysis can be exported with one command, so you can use models in production directly to simplify data debugging & delivery to BI tools like Metabase, dbt, etc. See how you can [quickly create BI dashboards with this](https://objectiv.io/docs/home/quickstart-guide#creating-bi-dashboards)."
+    "The SQL for any analysis can be exported with one command, so you can use models in production directly to simplify data debugging & delivery to BI tools like Metabase, dbt, etc. See how you can [quickly create BI dashboards with this](https://objectiv.io/docs/home/try-the-demo#creating-bi-dashboards)."
    ]
   },
   {

--- a/notebooks/explore-your-data.ipynb
+++ b/notebooks/explore-your-data.ipynb
@@ -5,7 +5,7 @@
    "id": "afb5dddf",
    "metadata": {},
    "source": [
-    "This is one of the Objectiv [example notebooks](https://objectiv.io/docs/modeling/example-notebooks/). These notebooks can run [on your own data](https://objectiv.io/docs/modeling/get-started-in-your-notebook/), or you can instead run the [Demo](https://objectiv.io/docs/home/quickstart-guide/) to quickly try them out."
+    "This is one of the Objectiv [example notebooks](https://objectiv.io/docs/modeling/example-notebooks/). These notebooks can run [on your own data](https://objectiv.io/docs/modeling/get-started-in-your-notebook/), or you can instead run the [Demo](https://objectiv.io/docs/home/try-the-demo/) to quickly try them out."
    ]
   },
   {
@@ -272,7 +272,7 @@
    "metadata": {},
    "source": [
     "## Get the SQL for any analysis\n",
-    "The SQL for any analysis can be exported with one command, so you can use models in production directly to simplify data debugging & delivery to BI tools like Metabase, dbt, etc. See how you can [quickly create BI dashboards with this](https://objectiv.io/docs/home/quickstart-guide#creating-bi-dashboards)."
+    "The SQL for any analysis can be exported with one command, so you can use models in production directly to simplify data debugging & delivery to BI tools like Metabase, dbt, etc. See how you can [quickly create BI dashboards with this](https://objectiv.io/docs/home/try-the-demo#creating-bi-dashboards)."
    ]
   },
   {

--- a/notebooks/feature-engineering.ipynb
+++ b/notebooks/feature-engineering.ipynb
@@ -6,9 +6,9 @@
    "metadata": {},
    "source": [
     "This is one of the Objectiv example notebooks. For more examples visit the \n",
-    "[example notebooks](https://objectiv.io/docs/modeling/example-notebooks/) section of our docs. The notebooks can run with the demo data set that comes with the our [quickstart](https://objectiv.io/docs/home/quickstart-guide/), but can be used to run on your own collected data as well.\n",
+    "[example notebooks](https://objectiv.io/docs/modeling/example-notebooks/) section of our docs. The notebooks can run with the demo data set that comes with the our [quickstart](https://objectiv.io/docs/home/try-the-demo/), but can be used to run on your own collected data as well.\n",
     "\n",
-    "All example notebooks are also available in our [quickstart](https://objectiv.io/docs/home/quickstart-guide/). With the quickstart you can spin up a fully functional Objectiv demo pipeline in five minutes. This also allows you to run these notebooks and experiment with them on a demo data set."
+    "All example notebooks are also available in our [quickstart](https://objectiv.io/docs/home/try-the-demo/). With the quickstart you can spin up a fully functional Objectiv demo pipeline in five minutes. This also allows you to run these notebooks and experiment with them on a demo data set."
    ]
   },
   {

--- a/notebooks/funnel-discovery.ipynb
+++ b/notebooks/funnel-discovery.ipynb
@@ -5,7 +5,7 @@
    "id": "741991f3",
    "metadata": {},
    "source": [
-    "This is one of the Objectiv [example notebooks](https://objectiv.io/docs/modeling/example-notebooks/). These notebooks can run [on your own data](https://objectiv.io/docs/modeling/get-started-in-your-notebook/), or you can instead run the [Demo](https://objectiv.io/docs/home/quickstart-guide/) to quickly try them out."
+    "This is one of the Objectiv [example notebooks](https://objectiv.io/docs/modeling/example-notebooks/). These notebooks can run [on your own data](https://objectiv.io/docs/modeling/get-started-in-your-notebook/), or you can instead run the [Demo](https://objectiv.io/docs/home/try-the-demo/) to quickly try them out."
    ]
   },
   {
@@ -646,7 +646,7 @@
    "metadata": {},
    "source": [
     "## Get the SQL for any analysis\n",
-    "The SQL for any analysis can be exported with one command, so you can use models in production directly to simplify data debugging & delivery to BI tools like Metabase, dbt, etc. See how you can [quickly create BI dashboards with this](https://objectiv.io/docs/home/quickstart-guide#creating-bi-dashboards)."
+    "The SQL for any analysis can be exported with one command, so you can use models in production directly to simplify data debugging & delivery to BI tools like Metabase, dbt, etc. See how you can [quickly create BI dashboards with this](https://objectiv.io/docs/home/try-the-demo#creating-bi-dashboards)."
    ]
   },
   {

--- a/notebooks/marketing-analytics.ipynb
+++ b/notebooks/marketing-analytics.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This is one of the Objectiv [example notebooks](https://objectiv.io/docs/modeling/example-notebooks/). These notebooks can run [on your own data](https://objectiv.io/docs/modeling/get-started-in-your-notebook/), or you can instead run the [Demo](https://objectiv.io/docs/home/quickstart-guide/) to quickly try them out."
+    "This is one of the Objectiv [example notebooks](https://objectiv.io/docs/modeling/example-notebooks/). These notebooks can run [on your own data](https://objectiv.io/docs/modeling/get-started-in-your-notebook/), or you can instead run the [Demo](https://objectiv.io/docs/home/try-the-demo/) to quickly try them out."
    ]
   },
   {
@@ -953,7 +953,7 @@
    "metadata": {},
    "source": [
     "## Get the SQL for any analysis\n",
-    "The SQL for any analysis can be exported with one command, so you can use models in production directly to simplify data debugging & delivery to BI tools like Metabase, dbt, etc. See how you can [quickly create BI dashboards with this](https://objectiv.io/docs/home/quickstart-guide#creating-bi-dashboards)."
+    "The SQL for any analysis can be exported with one command, so you can use models in production directly to simplify data debugging & delivery to BI tools like Metabase, dbt, etc. See how you can [quickly create BI dashboards with this](https://objectiv.io/docs/home/try-the-demo#creating-bi-dashboards)."
    ]
   }
  ],

--- a/notebooks/model-hub-demo-notebook.ipynb
+++ b/notebooks/model-hub-demo-notebook.ipynb
@@ -6,9 +6,9 @@
    "metadata": {},
    "source": [
     "This is one of the Objectiv example notebooks. For more examples visit the \n",
-    "[example notebooks](https://objectiv.io/docs/modeling/example-notebooks/) section of our docs. The notebooks can run with the demo data set that comes with the our [quickstart](https://objectiv.io/docs/home/quickstart-guide/), but can be used to run on your own collected data as well.\n",
+    "[example notebooks](https://objectiv.io/docs/modeling/example-notebooks/) section of our docs. The notebooks can run with the demo data set that comes with the our [quickstart](https://objectiv.io/docs/home/try-the-demo/), but can be used to run on your own collected data as well.\n",
     "\n",
-    "All example notebooks are also available in our [quickstart](https://objectiv.io/docs/home/quickstart-guide/). With the quickstart you can spin up a fully functional Objectiv demo pipeline in five minutes. This also allows you to run these notebooks and experiment with them on a demo data set."
+    "All example notebooks are also available in our [quickstart](https://objectiv.io/docs/home/try-the-demo/). With the quickstart you can spin up a fully functional Objectiv demo pipeline in five minutes. This also allows you to run these notebooks and experiment with them on a demo data set."
    ]
   },
   {
@@ -319,7 +319,7 @@
    "id": "cdb8c7be-3767-4cac-ae18-652c2eac76c0",
    "metadata": {},
    "source": [
-    "The SQL for any analysis can be exported with this one command, so you can use models in production directly to simplify data debugging & delivery to BI tools like Metabase, dbt, etc. See how you can [quickly create BI dashboards with this](https://objectiv.io/docs/home/quickstart-guide#creating-bi-dashboards)."
+    "The SQL for any analysis can be exported with this one command, so you can use models in production directly to simplify data debugging & delivery to BI tools like Metabase, dbt, etc. See how you can [quickly create BI dashboards with this](https://objectiv.io/docs/home/try-the-demo#creating-bi-dashboards)."
    ]
   },
   {

--- a/notebooks/model-hub-logistic-regression.ipynb
+++ b/notebooks/model-hub-logistic-regression.ipynb
@@ -6,9 +6,9 @@
    "metadata": {},
    "source": [
     "This is one of the Objectiv example notebooks. For more examples visit the \n",
-    "[example notebooks](https://objectiv.io/docs/modeling/example-notebooks/) section of our docs. The notebooks can run with the demo data set that comes with the our [quickstart](https://objectiv.io/docs/home/quickstart-guide/), but can be used to run on your own collected data as well.\n",
+    "[example notebooks](https://objectiv.io/docs/modeling/example-notebooks/) section of our docs. The notebooks can run with the demo data set that comes with the our [quickstart](https://objectiv.io/docs/home/try-the-demo/), but can be used to run on your own collected data as well.\n",
     "\n",
-    "All example notebooks are also available in our [quickstart](https://objectiv.io/docs/home/quickstart-guide/). With the quickstart you can spin up a fully functional Objectiv demo pipeline in five minutes. This also allows you to run these notebooks and experiment with them on a demo data set."
+    "All example notebooks are also available in our [quickstart](https://objectiv.io/docs/home/try-the-demo/). With the quickstart you can spin up a fully functional Objectiv demo pipeline in five minutes. This also allows you to run these notebooks and experiment with them on a demo data set."
    ]
   },
   {
@@ -362,7 +362,7 @@
    "id": "892c5ba1-d1c1-4878-88c6-290fd8ccb4a8",
    "metadata": {},
    "source": [
-    "The SQL for any analysis can be exported with this one command, so you can use models in production directly to simplify data debugging & delivery to BI tools like Metabase, dbt, etc. See how you can [quickly create BI dashboards with this](https://objectiv.io/docs/home/quickstart-guide#creating-bi-dashboards)."
+    "The SQL for any analysis can be exported with this one command, so you can use models in production directly to simplify data debugging & delivery to BI tools like Metabase, dbt, etc. See how you can [quickly create BI dashboards with this](https://objectiv.io/docs/home/try-the-demo#creating-bi-dashboards)."
    ]
   },
   {

--- a/notebooks/open-taxonomy-how-to.ipynb
+++ b/notebooks/open-taxonomy-how-to.ipynb
@@ -5,7 +5,7 @@
    "id": "0dac359c",
    "metadata": {},
    "source": [
-    "This is one of the Objectiv [example notebooks](https://objectiv.io/docs/modeling/example-notebooks/). These notebooks can run [on your own data](https://objectiv.io/docs/modeling/get-started-in-your-notebook/), or you can instead run the [Demo](https://objectiv.io/docs/home/quickstart-guide/) to quickly try them out."
+    "This is one of the Objectiv [example notebooks](https://objectiv.io/docs/modeling/example-notebooks/). These notebooks can run [on your own data](https://objectiv.io/docs/modeling/get-started-in-your-notebook/), or you can instead run the [Demo](https://objectiv.io/docs/home/try-the-demo/) to quickly try them out."
    ]
   },
   {
@@ -519,7 +519,7 @@
    "metadata": {},
    "source": [
     "## Get the SQL for any analysis\n",
-    "The SQL for any analysis can be exported with one command, so you can use models in production directly to simplify data debugging & delivery to BI tools like Metabase, dbt, etc. See how you can [quickly create BI dashboards with this](https://objectiv.io/docs/home/quickstart-guide#creating-bi-dashboards)."
+    "The SQL for any analysis can be exported with one command, so you can use models in production directly to simplify data debugging & delivery to BI tools like Metabase, dbt, etc. See how you can [quickly create BI dashboards with this](https://objectiv.io/docs/home/try-the-demo#creating-bi-dashboards)."
    ]
   },
   {

--- a/notebooks/sklearn-example.ipynb
+++ b/notebooks/sklearn-example.ipynb
@@ -6,9 +6,9 @@
    "metadata": {},
    "source": [
     "This is one of the Objectiv example notebooks. For more examples visit the \n",
-    "[example notebooks](https://objectiv.io/docs/modeling/example-notebooks/) section of our docs. The notebooks can run with the demo data set that comes with the our [quickstart](https://objectiv.io/docs/home/quickstart-guide/), but can be used to run on your own collected data as well.\n",
+    "[example notebooks](https://objectiv.io/docs/modeling/example-notebooks/) section of our docs. The notebooks can run with the demo data set that comes with the our [quickstart](https://objectiv.io/docs/home/try-the-demo/), but can be used to run on your own collected data as well.\n",
     "\n",
-    "All example notebooks are also available in our [quickstart](https://objectiv.io/docs/home/quickstart-guide/). With the quickstart you can spin up a fully functional Objectiv demo pipeline in five minutes. This also allows you to run these notebooks and experiment with them on a demo data set."
+    "All example notebooks are also available in our [quickstart](https://objectiv.io/docs/home/try-the-demo/). With the quickstart you can spin up a fully functional Objectiv demo pipeline in five minutes. This also allows you to run these notebooks and experiment with them on a demo data set."
    ]
   },
   {


### PR DESCRIPTION
Same changes as in https://github.com/objectiv/objectiv-analytics/pull/1230/files

created with:
```bash
git checkout main
git pull
git checkout -b docs-touchpoints-updates-again
git revert 3624276af90f0e1fd138f83875d317f71f487fc4
git revert e8192924a9b89a8e2c9e26f3984138f670a9b6cc
```

Updates the link to our Demo docs from https://objectiv.io/docs/home/quickstart-guide/ to https://objectiv.io/docs/home/try-the-demo/, in both docs & notebooks, as changed in https://github.com/objectiv/objectiv.io/pull/548.

NOTE: should only be merged once the new docs are live. 

TODO:
- [x] Merge once https://github.com/objectiv/objectiv.io/pull/548 is live.
- [ ] Build new Docker demo containers, test & release them.