### PR TITLE
Add `display_sql_as_md` operation to example notebooks

### DIFF
--- a/bach/docs/README.md
+++ b/bach/docs/README.md
@@ -50,5 +50,11 @@ To run doctests for a single file:
 python -m doctest -v [PATH_TO_FILE] -o NORMALIZE_WHITESPACE -o IGNORE_EXCEPTION_DETAIL -o ELLIPSIS -o DONT_ACCEPT_TRUE_FOR_1
 ```
 
+or:
+
+```
+sphinx-build -M doctest source build [PATH_TO_FILE]
+```
+
 Note that this will probably require copying some of the global doctest config currently defined in `conf.py` 
 to the respective file.

--- a/bach/docs/source/example-notebooks/explore-data.rst
+++ b/bach/docs/source/example-notebooks/explore-data.rst
@@ -37,16 +37,6 @@ We first have to instantiate the model hub and an Objectiv DataFrame object.
 .. doctest:: explore-data
 	:skipif: engine is None
 
-	.. >>> import pandas as pd
-	.. >>> pd.set_option('display.max_columns', None) # show all columns where possible, so dataframes don't get unneccesarily cut off
-	.. >>> pd.set_option('display.expand_frame_repr', False)  # do not output dataframes on multiple lines, but over full width
-	.. >>> from bach.dataframe import DataFrame
-	.. >>> import os
-	.. >>> import sqlalchemy
-	.. >>> DB_URL = os.environ.get('OBJ_DB_PG_TEST_URL', 'postgresql://objectiv:@localhost:5432/objectiv')
-	.. >>> engine = sqlalchemy.create_engine(DB_URL)
-	.. >>> start_date = '2022-06-01'
-	.. >>> end_date = '2022-06-30'
 	>>> # instantiate the model hub, set the default time aggregation to daily
 	>>> # and get the application & path global contexts
 	>>> from modelhub import ModelHub

--- a/bach/docs/source/example-notebooks/explore-data.rst
+++ b/bach/docs/source/example-notebooks/explore-data.rst
@@ -37,9 +37,20 @@ We first have to instantiate the model hub and an Objectiv DataFrame object.
 .. doctest:: explore-data
 	:skipif: engine is None
 
+	.. >>> import pandas as pd
+	.. >>> pd.set_option('display.max_columns', None) # show all columns where possible, so dataframes don't get unneccesarily cut off
+	.. >>> pd.set_option('display.expand_frame_repr', False)  # do not output dataframes on multiple lines, but over full width
+	.. >>> from bach.dataframe import DataFrame
+	.. >>> import os
+	.. >>> import sqlalchemy
+	.. >>> DB_URL = os.environ.get('OBJ_DB_PG_TEST_URL', 'postgresql://objectiv:@localhost:5432/objectiv')
+	.. >>> engine = sqlalchemy.create_engine(DB_URL)
+	.. >>> start_date = '2022-06-01'
+	.. >>> end_date = '2022-06-30'
 	>>> # instantiate the model hub, set the default time aggregation to daily
 	>>> # and get the application & path global contexts
 	>>> from modelhub import ModelHub
+	>>> from bach import display_sql_as_markdown
 	>>> modelhub = ModelHub(time_aggregation='%Y-%m-%d', global_contexts=['application', 'path'])
 	>>> # get an Objectiv DataFrame within a defined timeframe
 	>>> df = modelhub.get_objectiv_dataframe(db_url=DB_URL, start_date=start_date, end_date=end_date)
@@ -261,6 +272,11 @@ simplify data debugging & delivery to BI tools like Metabase, dbt, etc. See how 
 dashboards with this <https://objectiv.io/docs/home/try-the-demo#creating-bi-dashboards>`_.
 
 .. doctest:: explore-data-features
+	:hide:
+	
+	>>> def display_sql_as_markdown(arg): [print('sql\n' + arg.view_sql() + '\n')]
+
+.. doctest:: explore-data-features
 	:skipif: engine is None
 
 	>>> # show the underlying SQL for this dataframe - works for any dataframe/model in Objectiv
@@ -349,7 +365,6 @@ dashboards with this <https://objectiv.io/docs/home/try-the-demo#creating-bi-das
 	          ) || (CASE WHEN jsonb_array_length("location_stack") > 1 THEN ' located at ' || (SELECT string_agg(replace(regexp_replace(value ->> '_type', '([a-z])([A-Z])', '\1 \2', 'g'), ' Context', '') || ': ' || (value ->> 'id'), ' => ') FROM jsonb_array_elements("location_stack") WITH ORDINALITY WHERE ORDINALITY < jsonb_array_length("location_stack") ) ELSE '' END),
 	          "event_type"
 	<BLANKLINE>
-
 
 Where to go next
 ----------------

--- a/bach/docs/source/example-notebooks/open-taxonomy.rst
+++ b/bach/docs/source/example-notebooks/open-taxonomy.rst
@@ -61,6 +61,7 @@ in the global contexts and how to access this data for analyses.
 	>>> # instantiate the model hub, set the default time aggregation to daily
 	>>> # and get the global contexts that will be used in this example
 	>>> modelhub = ModelHub(time_aggregation='%Y-%m-%d', global_contexts=['application', 'marketing'])
+	>>> from bach import display_sql_as_markdown
 	>>> # get an Objectiv DataFrame within a defined timeframe
 	>>> df = modelhub.get_objectiv_dataframe(db_url=DB_URL, start_date=start_date, end_date=end_date)
 
@@ -478,6 +479,11 @@ Get the SQL for any analysis
 The SQL for any analysis can be exported with one command, so you can use models in production directly to 
 simplify data debugging & delivery to BI tools like Metabase, dbt, etc. See how you can `quickly create BI 
 dashboards with this <https://objectiv.io/docs/home/try-the-demo#creating-bi-dashboards>`_.
+
+.. doctest:: open-taxonomy
+	:hide:
+	
+	>>> def display_sql_as_markdown(arg): [print('sql\n' + arg.view_sql() + '\n')]
 
 .. doctest:: open-taxonomy
 	:skipif: engine is None


### PR DESCRIPTION
- Adds `display_sql_as_md` operation to two example notebooks that didn't have it yet.
- Updates README with how to run a single example notebook.

Results in: https://github.com/objectiv/objectiv.io/pull/557