### PR TITLE
[ModelHub] Expose display_sql_as_markdown in module

### DIFF
--- a/bach/docs/source/example-notebooks/explore-data.rst
+++ b/bach/docs/source/example-notebooks/explore-data.rst
@@ -39,8 +39,7 @@ We first have to instantiate the model hub and an Objectiv DataFrame object.
 
 	>>> # instantiate the model hub, set the default time aggregation to daily
 	>>> # and get the application & path global contexts
-	>>> from modelhub import ModelHub
-	>>> from bach import display_sql_as_markdown
+	>>> from modelhub import ModelHub, display_sql_as_markdown
 	>>> modelhub = ModelHub(time_aggregation='%Y-%m-%d', global_contexts=['application', 'path'])
 	>>> # get an Objectiv DataFrame within a defined timeframe
 	>>> df = modelhub.get_objectiv_dataframe(db_url=DB_URL, start_date=start_date, end_date=end_date)

--- a/bach/docs/source/example-notebooks/marketing-analytics.rst
+++ b/bach/docs/source/example-notebooks/marketing-analytics.rst
@@ -40,8 +40,8 @@ We first have to instantiate the model hub and an Objectiv DataFrame object.
 
 	>>> # instantiate the model hub, and set the default time aggregation to daily
 	>>> # and set the global contexts that will be used in this example
-	>>> from modelhub import ModelHub
-	>>> from bach import DataFrame, display_sql_as_markdown
+	>>> from modelhub import ModelHub, display_sql_as_markdown
+	>>> from bach import DataFrame
 	>>> from datetime import datetime, timedelta
 	>>> import pandas as pd
 	>>> modelhub = ModelHub(time_aggregation='%Y-%m-%d', global_contexts=['http', 'marketing', 'application'])

--- a/bach/docs/source/example-notebooks/open-taxonomy.rst
+++ b/bach/docs/source/example-notebooks/open-taxonomy.rst
@@ -57,11 +57,10 @@ in the global contexts and how to access this data for analyses.
 .. doctest:: open-taxonomy
 	:skipif: engine is None
 
-	>>> from modelhub import ModelHub
+	>>> from modelhub import ModelHub, display_sql_as_markdown
 	>>> # instantiate the model hub, set the default time aggregation to daily
 	>>> # and get the global contexts that will be used in this example
 	>>> modelhub = ModelHub(time_aggregation='%Y-%m-%d', global_contexts=['application', 'marketing'])
-	>>> from bach import display_sql_as_markdown
 	>>> # get an Objectiv DataFrame within a defined timeframe
 	>>> df = modelhub.get_objectiv_dataframe(db_url=DB_URL, start_date=start_date, end_date=end_date)
 
@@ -375,8 +374,7 @@ the sampled is written to the database, therefore the `table_name` must be provi
 	:skipif: engine is None
 
 	from modelhub import ModelHub
-	from bach import display_sql_as_markdown
-	def display_sql_as_markdown(arg): 
+	def display_sql_as_markdown(arg):
 		print('sql\\n' + arg.view_sql() + '\\n') # print out SQL instead of an object
 	start_date = '2022-06-01'
 	end_date = '2022-06-30'
@@ -442,7 +440,6 @@ The sample can also be used for grouping and aggregating. The example below coun
 	:skipif: engine is None
 
 	from modelhub import ModelHub
-	from bach import display_sql_as_markdown
 	start_date = '2022-06-01'
 	end_date = '2022-06-30'
 	modelhub = ModelHub(time_aggregation='%Y-%m-%d', global_contexts=['application', 'marketing'])

--- a/bach/docs/source/example-notebooks/product-analytics.rst
+++ b/bach/docs/source/example-notebooks/product-analytics.rst
@@ -38,8 +38,7 @@ We first have to instantiate the model hub and an Objectiv DataFrame object.
 .. doctest:: product-analytics
 	:skipif: engine is None
 
-	>>> from modelhub import ModelHub
-	>>> from bach import display_sql_as_markdown
+	>>> from modelhub import ModelHub, display_sql_as_markdown
 	>>> from datetime import datetime
 	>>> # instantiate the model hub and set the default time aggregation to daily
 	>>> # and set the global contexts that will be used in this example
@@ -583,7 +582,6 @@ dashboards with this <https://objectiv.io/docs/home/try-the-demo#creating-bi-das
 	:skipif: engine is None
 
 	from modelhub import ModelHub
-	from bach import display_sql_as_markdown
 	from datetime import datetime
 	# instantiate the model hub and set the default time aggregation to daily
 	modelhub = ModelHub(time_aggregation='%Y-%m-%d')

--- a/bach/docs/source/example-notebooks/user-intent.rst
+++ b/bach/docs/source/example-notebooks/user-intent.rst
@@ -22,7 +22,7 @@ Besides the open model hub, we have to import the following packages for this ex
 
 .. code-block:: python
 
-    from bach import display_sql_as_markdown
+    from modelhub import display_sql_as_markdown
     import bach
     import pandas as pd
     from datetime import timedelta

--- a/modelhub/modelhub/__init__.py
+++ b/modelhub/modelhub/__init__.py
@@ -11,6 +11,9 @@ from modelhub.models.funnel_discovery import FunnelDiscovery
 from modelhub.pipelines import *
 from modelhub.series import *
 
+# convenience import to allow users to use this without importing anything from bach
+from bach import display_sql_as_markdown
+
 
 # Here we do a basic version check, to make sure we are on the most recent versions of objectiv-bach and
 # objectiv-modelhub. This is done by querying the backend that holds a cached version of the latest versions

--- a/notebooks/basic-product-analytics.ipynb
+++ b/notebooks/basic-product-analytics.ipynb
@@ -52,8 +52,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from modelhub import ModelHub\n",
-    "from bach import display_sql_as_markdown\n",
+    "from modelhub import ModelHub, display_sql_as_markdown\n",
     "from datetime import datetime\n",
     "\n",
     "# instantiate the model hub and set the default time aggregation to daily\n",

--- a/notebooks/basic-user-intent.ipynb
+++ b/notebooks/basic-user-intent.ipynb
@@ -53,10 +53,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from modelhub import ModelHub\n",
-    "from bach import display_sql_as_markdown\n",
+    "from modelhub import ModelHub, display_sql_as_markdown\n",
     "import bach\n",
-    "import pandas as pd \n",
+    "import pandas as pd\n",
     "from datetime import timedelta"
    ]
   },

--- a/notebooks/marketing-analytics.ipynb
+++ b/notebooks/marketing-analytics.ipynb
@@ -41,8 +41,7 @@
    "outputs": [],
    "source": [
     "from modelhub import ModelHub\n",
-    "from bach import DataFrame, display_sql_as_markdown\n",
-    "from datetime import datetime, timedelta\n",
+    "from bach import DataFrame\n",
     "import pandas as pd\n",
     "\n",
     "# instantiate the model hub and set the default time aggregation to daily\n",

--- a/notebooks/model-hub-demo-notebook.ipynb
+++ b/notebooks/model-hub-demo-notebook.ipynb
@@ -52,8 +52,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from modelhub import ModelHub\n",
-    "from bach import display_sql_as_markdown"
+    "from modelhub import ModelHub, display_sql_as_markdown"
    ]
   },
   {

--- a/notebooks/model-hub-logistic-regression.ipynb
+++ b/notebooks/model-hub-logistic-regression.ipynb
@@ -45,8 +45,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from modelhub import ModelHub\n",
-    "from bach import display_sql_as_markdown"
+    "from modelhub import ModelHub, display_sql_as_markdown"
    ]
   },
   {


### PR DESCRIPTION
In order to be able to do
```
from modelhub import ModelHub, display_sql_as_markdown
```
vs old
```
from modelhub import ModelHub
from bach import display_sql_as_markdown
```