### PR TITLE
Test changes as preparation for supporting mapping series-names

### DIFF
--- a/bach/tests/functional/bach/test_data_and_utils.py
+++ b/bach/tests/functional/bach/test_data_and_utils.py
@@ -7,10 +7,12 @@ This file does not contain any test, but having the file's name start with `test
 as a test file. This makes pytest rewrite the asserts to give clearer errors.
 """
 import datetime
+import math
 import uuid
 from copy import copy
 from decimal import Decimal
 from typing import List, Union, Type, Any, Dict
+from unittest.mock import ANY
 
 import pandas as pd
 import sqlalchemy
@@ -242,21 +244,47 @@ def assert_equals_data(
             actual = copy(val)
             expected = copy(expected_row[j])
 
-            if isinstance(val, (float, Decimal)) and round_decimals:
+            if isinstance(expected, (float, Decimal)) and round_decimals:
                 actual = round(Decimal(actual), decimal)
                 expected = round(Decimal(expected), decimal)
 
             if isinstance(actual, pd.Timestamp):
-                pdt_expected = pd.Timestamp(expected, tz=None)
                 actual = actual.floor(freq=_date_freq)
-                expected = pdt_expected.floor(freq=_date_freq)
+                if isinstance(expected, (pd.Timestamp, datetime.datetime)):
+                    pdt_expected = pd.Timestamp(expected)
+                    expected = pdt_expected.floor(freq=_date_freq)
 
-            assert_msg = f'row {i} is not equal: {expected_row} != {df_row}'
-            if actual is pd.NaT:
-                assert expected is pd.NaT, assert_msg
-            else:
+            assert_msg = f'row {i} is not equal: {expected_row} != {df_row}; value: {expected} != {actual}'
+            if not _is_na(actual):
                 assert actual == expected, assert_msg
+            elif type(expected) is type(ANY):
+                # Actual is None, NaN, or NaT, and expected is ANY. This is OK
+                # We handle this as a separate case because isna() and isnan() functions don't understand
+                # ANY
+                pass
+            else:
+                # Generically check: if actual is None/NaN/NaT, then expected should be None/NaN/NaT too
+                assert _is_na(expected), assert_msg
+                # If we specifically expect NaN, then we expect the result to be NaN
+                # If we specifically expect NaT, then we expect the result to be NaT
+                # If we expect None, then the result can be any of None, Nan, or NaT
+                if isinstance(expected, float) and math.isnan(expected):
+                    assert isinstance(actual, float), assert_msg
+                    assert math.isnan(actual), assert_msg
+                elif expected is pd.NaT:
+                    assert actual is pd.NaT, assert_msg
     return db_values
+
+
+def _is_na(value: Any) -> bool:
+    """
+    Check if value is NaN, Nat, or None.
+    Similar to pandas.isna(), but won't raise a warning when value is an empty array
+    """
+    is_nan = isinstance(value, float) and math.isnan(value)
+    is_nat = value is pd.NaT
+    is_none = value is None
+    return is_nan or is_nat or is_none
 
 
 def _get_view_sql_data(df: DataFrame):

--- a/bach/tests/functional/bach/test_df_fillna.py
+++ b/bach/tests/functional/bach/test_df_fillna.py
@@ -1,6 +1,7 @@
 """
 Copyright 2022 Objectiv B.V.
 """
+import math
 from unittest.mock import ANY
 
 import pandas as pd
@@ -36,6 +37,7 @@ def test_basic_fillna(engine) -> None:
     result = df.fillna(value=0)
     assert_equals_data(
         result,
+        use_to_pandas=True,
         expected_columns=['_index_0', 'A', 'B', 'C', 'D', 'E'],
         expected_data=[
             [0, 0, 0, 0, 0, 0],
@@ -101,16 +103,16 @@ def test_fillna_w_methods(engine) -> None:
     sort_by = ['A', 'B', 'C']
     ascending = [False, True, False]
 
-    tz_info = timezone.utc if is_bigquery(engine) else None
     assert_equals_data(
         df.sort_values(by=sort_by, ascending=ascending),
+        use_to_pandas=True,
         expected_columns=['_index_0', 'A', 'B', 'C', 'D', 'E', 'F', 'G'],
         expected_data=[
-            [1,    3,    4, None,    1,    1, None, datetime(2022, 1, 2, tzinfo=tz_info)],
-            [5,    1, None, None, None, None,  'd', datetime(2022, 1, 5, tzinfo=tz_info)],
-            [3, None,    2, None,    0, None,  'c',                                 None],
-            [2, None,    3, None,    4, None,  'b',                                 None],
-            [7, None, None,    1, None, None,  'f',                                 None],
+            [1,    3,    4, None,    1,    1, None, datetime(2022, 1, 2)],
+            [5,    1, None, None, None, None,  'd', datetime(2022, 1, 5)],
+            [3, None,    2, None,    0, None,  'c',                 None],
+            [2, None,    3, None,    4, None,  'b',                 None],
+            [7, None, None,    1, None, None,  'f',                 None],
             # last 3 rows are non-deterministic because A, B, C are all nulls
             [ANY, None, None, None] + [ANY] * 4,
             [ANY, None, None, None] + [ANY] * 4,
@@ -121,13 +123,14 @@ def test_fillna_w_methods(engine) -> None:
     result_ffill = df.fillna(method='ffill', sort_by=sort_by, ascending=ascending)
     assert_equals_data(
         result_ffill,
+        use_to_pandas=True,
         expected_columns=['_index_0', 'A', 'B', 'C', 'D', 'E', 'F', 'G'],
         expected_data=[
-            [1,    3,    4, None,    1,    1, None, datetime(2022, 1, 2, tzinfo=tz_info)],
-            [5,    1,    4, None,    1,    1,  'd', datetime(2022, 1, 5, tzinfo=tz_info)],
-            [3,    1,    2, None,    0,    1,  'c', datetime(2022, 1, 5, tzinfo=tz_info)],
-            [2,    1,    3, None,    4,    1,  'b', datetime(2022, 1, 5, tzinfo=tz_info)],
-            [7,    1,    3,    1,    4,    1,  'f', datetime(2022, 1, 5, tzinfo=tz_info)],
+            [1,    3,    4, None,    1,    1, None, datetime(2022, 1, 2)],
+            [5,    1,    4, None,    1,    1,  'd', datetime(2022, 1, 5)],
+            [3,    1,    2, None,    0,    1,  'c', datetime(2022, 1, 5)],
+            [2,    1,    3, None,    4,    1,  'b', datetime(2022, 1, 5)],
+            [7,    1,    3,    1,    4,    1,  'f', datetime(2022, 1, 5)],
             # last 3 rows are non-deterministic because A, B, C were initially all nulls
             [ANY,  1,    3,    1] + [ANY] * 4,
             [ANY,  1,    3,    1] + [ANY] * 4,
@@ -140,10 +143,11 @@ def test_fillna_w_methods(engine) -> None:
     )
     assert_equals_data(
         result_bfill,
+        use_to_pandas=True,
         expected_columns=['_index_0', 'A', 'B', 'C', 'D', 'E', 'F', 'G'],
         expected_data=[
-            [1,    3,    4,    1,    1,    1,  'd', datetime(2022, 1, 2, tzinfo=tz_info)],
-            [5,    1,    2,    1,    0,  ANY,  'd', datetime(2022, 1, 5, tzinfo=tz_info)],
+            [1,    3,    4,    1,    1,    1,  'd', datetime(2022, 1, 2)],
+            [5,    1,    2,    1,    0,  ANY,  'd', datetime(2022, 1, 5)],
             [3, None,    2,    1,    0,  ANY,  'c',                 ANY],
             [2, None,    3,    1,    4,  ANY,  'b',                 ANY],
             [7, None, None,    1,  ANY,  ANY,  'f',                 ANY],
@@ -156,39 +160,39 @@ def test_fillna_w_methods(engine) -> None:
 
 
 def test_fillna_w_methods_w_sorted_df(engine) -> None:
-    tz_info = timezone.utc if is_bigquery(engine) else None
-
     pdf = pd.DataFrame(DATA, columns=list("ABCDEFG"))
     df = DataFrame.from_pandas(engine=engine, df=pdf, convert_objects=True).sort_index()
 
     result_ffill = df.fillna(method='ffill')
     assert_equals_data(
         result_ffill,
+        use_to_pandas=True,
         expected_columns=['_index_0', 'A', 'B', 'C', 'D', 'E', 'F', 'G'],
         expected_data=[
-            [0, None, None, None, None, None, 'a', datetime(2022, 1, 1, tzinfo=tz_info)],
-            [1, 3,    4,    None, 1,    1,    'a', datetime(2022, 1, 2, tzinfo=tz_info)],
-            [2, 3,    3,    None, 4,    1,    'b', datetime(2022, 1, 2, tzinfo=tz_info)],
-            [3, 3,    2,    None, 0,    1,    'c', datetime(2022, 1, 2, tzinfo=tz_info)],
-            [4, 3,    2,    None, 0,    2,    'c', datetime(2022, 1, 2, tzinfo=tz_info)],
-            [5, 1,    2,    None, 0,    2,    'd', datetime(2022, 1, 5, tzinfo=tz_info)],
-            [6, 1,    2,    None, 0,    3,    'e', datetime(2022, 1, 6, tzinfo=tz_info)],
-            [7, 1,    2,    1,    0,    3,    'f', datetime(2022, 1, 6, tzinfo=tz_info)],
+            [0, None, None, None, None, None, 'a', datetime(2022, 1, 1)],
+            [1, 3,    4,    None, 1,    1,    'a', datetime(2022, 1, 2)],
+            [2, 3,    3,    None, 4,    1,    'b', datetime(2022, 1, 2)],
+            [3, 3,    2,    None, 0,    1,    'c', datetime(2022, 1, 2)],
+            [4, 3,    2,    None, 0,    2,    'c', datetime(2022, 1, 2)],
+            [5, 1,    2,    None, 0,    2,    'd', datetime(2022, 1, 5)],
+            [6, 1,    2,    None, 0,    3,    'e', datetime(2022, 1, 6)],
+            [7, 1,    2,    1,    0,    3,    'f', datetime(2022, 1, 6)],
         ],
     )
 
     result_bfill = df.fillna(method='bfill')
     assert_equals_data(
         result_bfill,
+        use_to_pandas=True,
         expected_columns=['_index_0', 'A', 'B', 'C', 'D', 'E', 'F', 'G'],
         expected_data=[
-            [0, 3,    4,    1, 1,    1,    'a', datetime(2022, 1, 1, tzinfo=tz_info)],
-            [1, 3,    4,    1, 1,    1,    'b', datetime(2022, 1, 2, tzinfo=tz_info)],
-            [2, 1,    3,    1, 4,    2,    'b', datetime(2022, 1, 5, tzinfo=tz_info)],
-            [3, 1,    2,    1, 0,    2,    'c', datetime(2022, 1, 5, tzinfo=tz_info)],
-            [4, 1,    None, 1, None, 2,    'd', datetime(2022, 1, 5, tzinfo=tz_info)],
-            [5, 1,    None, 1, None, 3,    'd', datetime(2022, 1, 5, tzinfo=tz_info)],
-            [6, None, None, 1, None, 3,    'e', datetime(2022, 1, 6, tzinfo=tz_info)],
+            [0, 3,    4,    1, 1,    1,    'a', datetime(2022, 1, 1)],
+            [1, 3,    4,    1, 1,    1,    'b', datetime(2022, 1, 2)],
+            [2, 1,    3,    1, 4,    2,    'b', datetime(2022, 1, 5)],
+            [3, 1,    2,    1, 0,    2,    'c', datetime(2022, 1, 5)],
+            [4, 1,    None, 1, None, 2,    'd', datetime(2022, 1, 5)],
+            [5, 1,    None, 1, None, 3,    'd', datetime(2022, 1, 5)],
+            [6, None, None, 1, None, 3,    'e', datetime(2022, 1, 6)],
             [7, None, None, 1, None, None, 'f', None],
         ],
     )

--- a/bach/tests/functional/bach/test_df_from.py
+++ b/bach/tests/functional/bach/test_df_from.py
@@ -208,6 +208,7 @@ def test_big_query_from_other_project(engine):
     ]
     assert_equals_data(
         df,
+        use_to_pandas=True,
         expected_columns=expected_columns,
         expected_data=expected_data
     )

--- a/bach/tests/functional/bach/test_df_get_dummies.py
+++ b/bach/tests/functional/bach/test_df_get_dummies.py
@@ -2,6 +2,7 @@ import pandas as pd
 import pytest
 
 from bach import DataFrame
+from sql_models.util import is_postgres
 from tests.functional.bach.test_data_and_utils import assert_equals_data
 
 pytestmark = pytest.mark.skip_athena_todo()  # TODO: Athena
@@ -22,6 +23,7 @@ def test_basic_get_dummies(engine) -> None:
     result = result[expected_columns]
     assert_equals_data(
         result[expected_columns],
+        use_to_pandas=True,
         expected_columns=['_index_0'] + expected_columns,
         expected_data=[
             [0, 1, 1, 0, 0, 1, 0],
@@ -29,10 +31,15 @@ def test_basic_get_dummies(engine) -> None:
             [2, 3, 1, 0, 0, 0, 1]
         ],
     )
-    pd.testing.assert_frame_equal(
-        expected,
-        result.to_pandas(),
-    )
+
+    if is_postgres(engine):
+        # Additional check: query the result again, and check against the pandas implementation.
+        # We only run this on Postgres for performance reasons. The assert_equals_data() above runs for all
+        # databases, which already assures that the result is the same across databases.
+        pd.testing.assert_frame_equal(
+            expected,
+            result.to_pandas(),
+        )
 
 
 def test_get_dummies_dtype(engine) -> None:
@@ -49,6 +56,7 @@ def test_get_dummies_dtype(engine) -> None:
     result = result[expected_columns]
     assert_equals_data(
         result[expected_columns],
+        use_to_pandas=True,
         expected_columns=['_index_0'] + expected_columns,
         expected_data=[
             [0, 1, '1', '0', '0', '1', '0'],
@@ -76,6 +84,7 @@ def test_get_dummies_prefix(engine) -> None:
     result = result[expected_columns]
     assert_equals_data(
         result,
+        use_to_pandas=True,
         expected_columns=['_index_0'] + expected_columns,
         expected_data=[
             [0, 1, 1, 0, 0, 1, 0],
@@ -84,10 +93,14 @@ def test_get_dummies_prefix(engine) -> None:
         ],
     )
 
-    pd.testing.assert_frame_equal(
-        expected,
-        result.to_pandas(),
-    )
+    if is_postgres(engine):
+        # Additional check: query the result again, and check against the pandas implementation.
+        # We only run this on Postgres for performance reasons. The assert_equals_data() above runs for all
+        # databases, which already assures that the result is the same across databases.
+        pd.testing.assert_frame_equal(
+            expected,
+            result.to_pandas(),
+        )
 
 
 def test_get_dummies_w_na(engine) -> None:
@@ -107,6 +120,7 @@ def test_get_dummies_w_na(engine) -> None:
     result = result[expected_columns]
     assert_equals_data(
         result,
+        use_to_pandas=True,
         expected_columns=['_index_0'] + expected_columns,
         expected_data=[
             [0, 1, 1, 1, 0],
@@ -115,10 +129,14 @@ def test_get_dummies_w_na(engine) -> None:
             [3, 4, 0, 0, 0],
         ],
     )
-    pd.testing.assert_frame_equal(
-        expected,
-        result.to_pandas(),
-    )
+    if is_postgres(engine):
+        # Additional check: query the result again, and check against the pandas implementation.
+        # We only run this on Postgres for performance reasons. The assert_equals_data() above runs for all
+        # databases, which already assures that the result is the same across databases.
+        pd.testing.assert_frame_equal(
+            expected,
+            result.to_pandas(),
+        )
 
 
 def test_get_dummies_include_na(engine) -> None:
@@ -138,6 +156,7 @@ def test_get_dummies_include_na(engine) -> None:
     result = result[expected_columns]
     assert_equals_data(
         result,
+        use_to_pandas=True,
         expected_columns=['_index_0'] + expected_columns,
         expected_data=[
             [0, 1, 1, 0, 1, 0, 0],
@@ -145,10 +164,14 @@ def test_get_dummies_include_na(engine) -> None:
             [2, 3, 1, 0, 0, 0, 1],
         ],
     )
-    pd.testing.assert_frame_equal(
-        expected,
-        result.to_pandas(),
-    )
+    if is_postgres(engine):
+        # Additional check: query the result again, and check against the pandas implementation.
+        # We only run this on Postgres for performance reasons. The assert_equals_data() above runs for all
+        # databases, which already assures that the result is the same across databases.
+        pd.testing.assert_frame_equal(
+            expected,
+            result.to_pandas(),
+        )
 
 
 def test_get_dummies_errors(engine) -> None:

--- a/bach/tests/functional/bach/test_df_indexing.py
+++ b/bach/tests/functional/bach/test_df_indexing.py
@@ -141,6 +141,7 @@ def test_basic_set_item_by_label(indexing_dfs: Tuple[pd.DataFrame, DataFrame]) -
 
     assert_equals_data(
         df_cp2,
+        use_to_pandas=True,
         expected_columns=['A', 'B', 'C', 'D'],
         expected_data=[
             ['a', 0, 5, 'f'],
@@ -169,6 +170,7 @@ def test_set_item_by_label_diff_node(indexing_dfs: Tuple[pd.DataFrame, DataFrame
     df.loc['b', ['B', 'D']] = extra_df['C']
     assert_equals_data(
         df.sort_index(),
+        use_to_pandas=True,
         expected_columns=['A', 'B', 'C', 'D'],
         expected_data=[
             ['a', 0, 5, 'f'],

--- a/bach/tests/functional/bach/test_df_merge.py
+++ b/bach/tests/functional/bach/test_df_merge.py
@@ -199,7 +199,6 @@ def test_merge_suffixes(engine):
     mt = get_df_with_food_data(engine)[['skating_order', 'food']]
     result = bt.merge(mt, left_on='_index_skating_order', right_on='skating_order', suffixes=('_AA', '_BB'))
     assert isinstance(result, DataFrame)
-    print(result.view_sql())
     result = result.sort_index()
     assert_equals_data(
         result,

--- a/bach/tests/functional/bach/test_df_merge.py
+++ b/bach/tests/functional/bach/test_df_merge.py
@@ -199,8 +199,11 @@ def test_merge_suffixes(engine):
     mt = get_df_with_food_data(engine)[['skating_order', 'food']]
     result = bt.merge(mt, left_on='_index_skating_order', right_on='skating_order', suffixes=('_AA', '_BB'))
     assert isinstance(result, DataFrame)
+    print(result.view_sql())
+    result = result.sort_index()
     assert_equals_data(
         result,
+        use_to_pandas=True,
         expected_columns=[
             '_index_skating_order_AA',
             '_index_skating_order_BB',
@@ -549,6 +552,7 @@ def test_merge_on_conditions(engine) -> None:
 
     assert_equals_data(
         result.sort_index(),
+        use_to_pandas=True,
         expected_columns=['_index_0_x', '_index_0_y', 'A_x', 'B_x', 'A_y', 'B_y'],
         expected_data=[
             [2, 2, 'c', 250, 'g', 10],
@@ -575,6 +579,7 @@ def test_merge_on_conditions_w_on_data_columns(engine) -> None:
 
     assert_equals_data(
         result.sort_index(),
+        use_to_pandas=True,
         expected_columns=['_index_0_x', '_index_0_y', 'A', 'B_x', 'B_y'],
         expected_data=[
             [1, 1, 'a', 25, 5],
@@ -622,6 +627,7 @@ def test_merge_on_conditions_w_index(engine) -> None:
 
     assert_equals_data(
         result.sort_index(),
+        use_to_pandas=True,
         expected_columns=['_index_0', 'A_x', 'B_x', 'A_y', 'B_y'],
         expected_data=[
             [2, 'c', 250, 'g', 10],

--- a/bach/tests/functional/bach/test_df_setitem.py
+++ b/bach/tests/functional/bach/test_df_setitem.py
@@ -209,6 +209,7 @@ def test_set_series_column_name_with_spaces(engine):
     bt['spaces in column'] = bt['founding']
     assert_equals_data(
         bt,
+        use_to_pandas=True,
         expected_columns=[
             '_index_skating_order',  # index
             'skating_order', 'city', 'municipality', 'inhabitants', 'founding', 'spaces in column'

--- a/bach/tests/functional/bach/test_df_window.py
+++ b/bach/tests/functional/bach/test_df_window.py
@@ -658,6 +658,7 @@ def test_window_nav_functions_with_nulls(engine):
     }
     assert_equals_data(
         df.sort_values(by=['A', 'B']),
+        use_to_pandas=True,
         expected_columns=[
             'A', 'B',
             *expected_fln_value['a'].keys(),

--- a/bach/tests/functional/bach/test_injection_column_name_escaping.py
+++ b/bach/tests/functional/bach/test_injection_column_name_escaping.py
@@ -25,10 +25,21 @@ def test_column_names(engine):
         [2, 'Snits',  1, 1, 1, 1, 1, 1, 1],
         [3, 'Drylts',  1, 1, 1, 1, 1, 1, 1]
     ]
-    assert_equals_data(bt, expected_columns=expected_columns, expected_data=expected_data)
+    assert_equals_data(
+        bt,
+        use_to_pandas=True,
+        expected_columns=expected_columns,
+        expected_data=expected_data
+    )
+
     # Make sure that after materializing the columns are unchanged.
-    bt = bt.materialize()
-    assert_equals_data(bt, expected_columns=expected_columns, expected_data=expected_data)
+    bt = bt.materialize().sort_index()
+    assert_equals_data(
+        bt,
+        use_to_pandas=True,
+        expected_columns=expected_columns,
+        expected_data=expected_data
+    )
 
 
 @pytest.mark.skip_bigquery_todo('#1209 We do not yet support special characters in column names on BigQuery')
@@ -47,7 +58,12 @@ def test_column_names_merge(engine):
         [2, 2, 'Snits',  1, 1, 1, 1, 1, 1, 1],
         [3, 3, 'Drylts',  1, 1, 1, 1, 1, 1, 1]
     ]
-    assert_equals_data(bt, expected_columns=expected_columns, expected_data=expected_data)
+    assert_equals_data(
+        bt,
+        use_to_pandas=True,
+        expected_columns=expected_columns,
+        expected_data=expected_data
+    )
 
 
 def _get_dataframe_with_weird_column_names(engine: Engine):

--- a/bach/tests/functional/bach/test_revert_merge.py
+++ b/bach/tests/functional/bach/test_revert_merge.py
@@ -73,8 +73,8 @@ def test_revert_merge_suffixes(engine):
     mt = get_df_with_food_data(engine)[['skating_order', 'food']]
     merged = bt.merge(mt, left_on='_index_skating_order', right_on='skating_order', suffixes=('_AA', '_BB'))
     result_bt, result_mt = revert_merge(merged)
-    for expected, result in zip([bt, mt], [result_bt, result_mt]):
-        _compare_source_with_replicate(expected, result)
+    _compare_source_with_replicate(bt, result_bt)
+    _compare_source_with_replicate(mt, result_mt)
 
 
 def test_revert_merge_mixed_columns(engine):

--- a/bach/tests/functional/bach/test_revert_merge.py
+++ b/bach/tests/functional/bach/test_revert_merge.py
@@ -73,8 +73,8 @@ def test_revert_merge_suffixes(engine):
     mt = get_df_with_food_data(engine)[['skating_order', 'food']]
     merged = bt.merge(mt, left_on='_index_skating_order', right_on='skating_order', suffixes=('_AA', '_BB'))
     result_bt, result_mt = revert_merge(merged)
-    _compare_source_with_replicate(bt, result_bt)
-    _compare_source_with_replicate(mt, result_mt)
+    for expected, result in zip([bt, mt], [result_bt, result_mt]):
+        _compare_source_with_replicate(expected, result)
 
 
 def test_revert_merge_mixed_columns(engine):

--- a/bach/tests/functional/bach/test_series_string.py
+++ b/bach/tests/functional/bach/test_series_string.py
@@ -119,6 +119,7 @@ def test_get_dummies(engine) -> None:
     assert set(expected_columns) == set(result.data_columns)
     assert_equals_data(
         result[expected_columns],
+        use_to_pandas=True,
         expected_columns=['_index_skating_order'] + expected_columns,
         expected_data=[
             [1, 0, 1, 0],
@@ -186,6 +187,7 @@ def test_string_len(engine) -> None:
         ]
     )
 
+
 def test_to_json_array(engine):
     df = get_df_with_test_data(engine, full_data_set=True)
     s_muni = df['municipality']
@@ -204,6 +206,7 @@ def test_to_json_array(engine):
              'Waadhoeke']
         ]]
     )
+
 
 def test_to_json_array_sorting_null(engine):
     data = [


### PR DESCRIPTION
Preparation for issue #1209  

Changes:
* Main change: `use_to_pandas=True` in tests that use column names with special names or capital characters.
* Optimialisation to `test_df_get_dummies.py`: Only do one query for BQ/Athena, and do the extra query only for Postgres.
* Some changes to `assert_equals_data` to not break on actual values of `NaN`.