### PR TITLE
[MH/BQ] Allow secrets to be used directly from environment

### DIFF
--- a/bach/setup.cfg
+++ b/bach/setup.cfg
@@ -35,7 +35,7 @@ include_package_data = True
 
 [options.extras_require]
 bigquery = 
-    sqlalchemy-bigquery
+    sqlalchemy-bigquery>=1.4.0
     google-cloud-bigquery-storage
 athena =
     pyathena>=2.10.0

--- a/modelhub/modelhub/modelhub.py
+++ b/modelhub/modelhub/modelhub.py
@@ -1,6 +1,8 @@
 """
 Copyright 2021 Objectiv B.V.
 """
+import base64
+import os
 import re
 from typing import List, Union, Dict, Tuple, Optional, cast, Any
 from typing import TYPE_CHECKING
@@ -92,7 +94,6 @@ class ModelHub:
         If db_url is for BigQuery, bq_credentials_path or bq_credentials must be provided.
         When both are given, bq_credentials wins.
         """
-        import os
         kwargs: Dict[str, Any] = {}
 
         if db_url and re.match(r'^bigquery://.+', db_url):
@@ -100,7 +101,6 @@ class ModelHub:
                 raise ValueError('BigQuery credentials or path is required for engine creation.')
 
             if bq_credentials:
-                import base64
                 credentials_base64 = base64.b64encode(bq_credentials.encode('utf-8'))
                 kwargs['credentials_base64'] = credentials_base64
             else:

--- a/modelhub/modelhub/modelhub.py
+++ b/modelhub/modelhub/modelhub.py
@@ -103,9 +103,13 @@ class ModelHub:
             if bq_credentials_env not in os.environ:
                 raise ValueError('BigQuery credentials environment variable name not in env.')
 
+            credentials = os.environ.get(bq_credentials_env)
+            if not credentials:
+                raise ValueError('BigQuery credentials environment variable is empty.')
+
             from tempfile import NamedTemporaryFile
             with NamedTemporaryFile(mode='w') as creds:
-                creds.write(os.environ.get(bq_credentials_env))
+                creds.write(credentials)
                 creds.flush()
                 return create_engine(db_url, credentials_path=creds.name)
 

--- a/modelhub/modelhub/modelhub.py
+++ b/modelhub/modelhub/modelhub.py
@@ -94,7 +94,7 @@ class ModelHub:
         """
         import os
         if db_url and re.match(r'^bigquery://.+', db_url):
-            if not bq_credentials_path or bq_credentials_env:
+            if not (bq_credentials_path or bq_credentials_env):
                 raise ValueError('BigQuery credentials path or env is required for engine creation.')
 
             if not bq_credentials_env:

--- a/modelhub/modelhub/modelhub.py
+++ b/modelhub/modelhub/modelhub.py
@@ -107,7 +107,7 @@ class ModelHub:
             with NamedTemporaryFile(mode='w') as creds:
                 creds.write(os.environ.get(bq_credentials_env))
                 creds.flush()
-                return create_engine(db_url, credentials_path=bq_credentials_path)
+                return create_engine(db_url, credentials_path=creds.name)
 
         db_url = db_url or os.environ.get('DSN', 'postgresql://objectiv:@localhost:5432/objectiv')
         return create_engine(db_url)

--- a/modelhub/tests_modelhub/functional/modelhub/test_model_hub.py
+++ b/modelhub/tests_modelhub/functional/modelhub/test_model_hub.py
@@ -589,7 +589,7 @@ def test_get_objectiv_dataframe_db_connection(db_params: DBParams):
 
         ## Test fallback to DSN
         os.environ['DSN'] = db_params.url
-        mh.get_objectiv_dataframe(db_url=None)
+        mh.get_objectiv_dataframe(db_url=None, table_name=db_params.table_name)
 
     elif 'bigquery' in db_params.url:
         gac_orig = os.environ.get('GOOGLE_APPLICATION_CREDENTIALS', None)


### PR DESCRIPTION
Next to `bq_credentials_path` which reads BQ credentials from a file, we now also support `bq_credentials_env` which reads from the specified env variable, so less boilerplate code is required when using secrets in Hex/Deepnote, etc.
```    
df = modelhub.get_objectiv_dataframe(start_date=start_date, end_date=end_date,
            db_url='bigquery://objectiv-production/snowplow',
            bq_credentials_env='SECRET_ENV_VAR'
)
```