### PR TITLE
Bach[Athena]: support from_table for athena

### DIFF
--- a/bach/.secrets/.test_env.sample
+++ b/bach/.secrets/.test_env.sample
@@ -32,7 +32,7 @@ OBJ_DB_ATHENA_REGION_NAME="eu-west-1"
 OBJ_DB_ATHENA_SCHEMA_NAME="bach_test"
 OBJ_DB_ATHENA_CATALOG_NAME="automated_tests"
 OBJ_DB_ATHENA_S3_STAGING_DIR="s3://obj-automated-tests/athena_query_results/"
-OBJ_DB_ATHENA_LOCATION="s3://obj-automated-tests/bach_test/staging/"
+OBJ_DB_ATHENA_LOCATION="s3://obj-automated-tests/bach_test/"
 OBJ_DB_ATHENA_WORK_GROUP="automated_tests_work_group"
 
 

--- a/bach/.secrets/.test_env.sample
+++ b/bach/.secrets/.test_env.sample
@@ -29,8 +29,10 @@ OBJ_DB_ATHENA_AWS_ACCESS_KEY_ID=
 OBJ_DB_ATHENA_AWS_SECRET_ACCESS_KEY=
 
 OBJ_DB_ATHENA_REGION_NAME="eu-west-1"
-OBJ_DB_ATHENA_SCHEMA_NAME="automated_tests.bach_test"
-OBJ_DB_ATHENA_S3_STAGING_DIR="s3://obj-automated-tests/bach_test/staging/"
+OBJ_DB_ATHENA_SCHEMA_NAME="bach_test"
+OBJ_DB_ATHENA_CATALOG_NAME="automated_tests"
+OBJ_DB_ATHENA_S3_STAGING_DIR="s3://obj-automated-tests/athena_query_results/"
+OBJ_DB_ATHENA_LOCATION="s3://obj-automated-tests/bach_test/staging/"
 OBJ_DB_ATHENA_WORK_GROUP="automated_tests_work_group"
 
 

--- a/bach/bach/from_database.py
+++ b/bach/bach/from_database.py
@@ -49,7 +49,6 @@ def get_dtypes_from_table(
         meta_data_table = 'INFORMATION_SCHEMA.COLUMNS'
     elif is_bigquery(engine):
         meta_data_table, table_name = _get_bq_meta_data_table_from_table_name(table_name)
-        filters_expr.append(Expression.construct(f"table_name='{table_name}'"))
     elif is_athena(engine):
         catalog_name = (
             f"{engine.url.query['catalog_name']}." if 'catalog_name' in engine.url.query else ''

--- a/bach/bach/from_database.py
+++ b/bach/bach/from_database.py
@@ -54,6 +54,7 @@ def get_dtypes_from_table(
             f"{engine.url.query['catalog_name']}." if 'catalog_name' in engine.url.query else ''
         )
         meta_data_table = f'{catalog_name}INFORMATION_SCHEMA.COLUMNS'
+        # This filter is needed because athena does not limit to data from the current schema
         filters_expr.append(Expression.construct(f"table_schema='{engine.url.database}'"))
     else:
         raise DatabaseNotSupportedException(engine)

--- a/bach/bach/from_database.py
+++ b/bach/bach/from_database.py
@@ -1,16 +1,17 @@
 """
 Copyright 2022 Objectiv B.V.
 """
-from typing import Dict, Optional, Tuple
+from typing import Dict, Tuple
 
 from sqlalchemy.engine import Engine
 
+from bach.expression import Expression, join_expressions
 from bach.types import get_dtype_from_db_dtype, StructuredDtype
 from bach.utils import escape_parameter_characters
 from sql_models.constants import DBDialect
 from sql_models.model import SqlModel, CustomSqlModelBuilder
 from sql_models.sql_generator import to_sql
-from sql_models.util import is_postgres, DatabaseNotSupportedException, is_bigquery
+from sql_models.util import is_postgres, DatabaseNotSupportedException, is_bigquery, is_athena
 
 
 def get_dtypes_from_model(engine: Engine, node: SqlModel) -> Dict[str, StructuredDtype]:
@@ -43,16 +44,27 @@ def get_dtypes_from_table(
         BigQuery, e.g. 'project_id.dataset.table_name'
     :return: Dictionary with as key the column names of the table, and as values the dtype of the column.
     """
+    filters_expr = []
     if is_postgres(engine):
         meta_data_table = 'INFORMATION_SCHEMA.COLUMNS'
     elif is_bigquery(engine):
         meta_data_table, table_name = _get_bq_meta_data_table_from_table_name(table_name)
+        filters_expr.append(Expression.construct(f"table_name='{table_name}'"))
+    elif is_athena(engine):
+        catalog_name = (
+            f"{engine.url.query['catalog_name']}." if 'catalog_name' in engine.url.query else ''
+        )
+        meta_data_table = f'{catalog_name}INFORMATION_SCHEMA.COLUMNS'
+        filters_expr.append(Expression.construct(f"table_schema='{engine.url.database}'"))
     else:
         raise DatabaseNotSupportedException(engine)
+
+    filters_expr.append(Expression.construct(f"table_name='{table_name}'"))
+    filters_stmt = join_expressions(filters_expr, join_str=' AND ').to_sql(engine.dialect)
     sql = f"""
         select column_name, data_type
         from {meta_data_table}
-        where table_name = '{table_name}'
+        where {filters_stmt}
         order by ordinal_position;
     """
     return _get_dtypes_from_information_schema_query(engine=engine, query=sql)

--- a/bach/tests/conftest.py
+++ b/bach/tests/conftest.py
@@ -70,7 +70,7 @@ _DB_ATHENA_REGION_NAME = _ENV.get('OBJ_DB_ATHENA_REGION_NAME', 'eu-west-1')
 _DB_ATHENA_CATALOG_NAME = _ENV.get('OBJ_DB_ATHENA_CATALOG_NAME', 'automated_tests')
 _DB_ATHENA_SCHEMA_NAME = _ENV.get('OBJ_DB_ATHENA_SCHEMA_NAME', 'bach_test')
 _DB_ATHENA_S3_STAGING_DIR = _ENV.get('OBJ_DB_ATHENA_S3_STAGING_DIR', 's3://obj-automated-tests/athena_query_results/')
-DB_ATHENA_LOCATION = _ENV.get('OBJ_DB_ATHENA_LOCATION', 's3://obj-automated-tests/bach_test/staging/')
+DB_ATHENA_LOCATION = _ENV.get('OBJ_DB_ATHENA_LOCATION', 's3://obj-automated-tests/bach_test/')
 _DB_ATHENA_WORK_GROUP = _ENV.get('OBJ_DB_ATHENA_WORK_GROUP', 'automated_tests_work_group')
 
 

--- a/bach/tests/conftest.py
+++ b/bach/tests/conftest.py
@@ -67,8 +67,10 @@ _DB_ATHENA_TEST_URL = _ENV.get('OBJ_DB_ATHENA_TEST_URL')
 _DB_ATHENA_AWS_ACCESS_KEY_ID = _ENV.get('OBJ_DB_ATHENA_AWS_ACCESS_KEY_ID')
 _DB_ATHENA_AWS_SECRET_ACCESS_KEY = _ENV.get('OBJ_DB_ATHENA_AWS_SECRET_ACCESS_KEY')
 _DB_ATHENA_REGION_NAME = _ENV.get('OBJ_DB_ATHENA_REGION_NAME', 'eu-west-1')
-_DB_ATHENA_SCHEMA_NAME = _ENV.get('OBJ_DB_ATHENA_SCHEMA_NAME', 'automated_tests.bach_test')
-_DB_ATHENA_S3_STAGING_DIR = _ENV.get('OBJ_DB_ATHENA_S3_STAGING_DIR', 's3://obj-automated-tests/bach_test/staging/')
+_DB_ATHENA_CATALOG_NAME = _ENV.get('OBJ_DB_ATHENA_CATALOG_NAME', 'automated_tests')
+_DB_ATHENA_SCHEMA_NAME = _ENV.get('OBJ_DB_ATHENA_SCHEMA_NAME', 'bach_test')
+_DB_ATHENA_S3_STAGING_DIR = _ENV.get('OBJ_DB_ATHENA_S3_STAGING_DIR', 's3://obj-automated-tests/athena_query_results/')
+DB_ATHENA_LOCATION = _ENV.get('OBJ_DB_ATHENA_LOCATION', 's3://obj-automated-tests/bach_test/staging/')
 _DB_ATHENA_WORK_GROUP = _ENV.get('OBJ_DB_ATHENA_WORK_GROUP', 'automated_tests_work_group')
 
 
@@ -253,10 +255,13 @@ def _get_athena_engine() -> Engine:
     schema_name = quote_plus(_DB_ATHENA_SCHEMA_NAME)
     s3_staging_dir = quote_plus(_DB_ATHENA_S3_STAGING_DIR)
     athena_work_group = quote_plus(_DB_ATHENA_WORK_GROUP)
+    catalog_name = quote_plus(_DB_ATHENA_CATALOG_NAME)
 
     url = (
         f'awsathena+rest://'
         f'{aws_access_key_id}:{aws_secret_access_key}'
         f'@athena.{region_name}.amazonaws.com:443/'
-        f'{schema_name}?s3_staging_dir={s3_staging_dir}&work_group={athena_work_group}')
+        f'{schema_name}?s3_staging_dir={s3_staging_dir}&work_group={athena_work_group}'
+        f'&catalog_name={catalog_name}'
+    )
     return create_engine(url)

--- a/bach/tests/functional/bach/test_df_from.py
+++ b/bach/tests/functional/bach/test_df_from.py
@@ -12,14 +12,24 @@ from sqlalchemy.engine import Engine
 from bach import DataFrame
 from sql_models.model import CustomSqlModelBuilder, SqlModel, Materialization
 from sql_models.sql_generator import to_sql
-from sql_models.util import is_postgres, is_bigquery
+from sql_models.util import is_postgres, is_bigquery, is_athena
+from tests.conftest import DB_ATHENA_LOCATION
 from tests.functional.bach.test_data_and_utils import assert_equals_data
-
-pytestmark = pytest.mark.skip_athena_todo()  # TODO: Athena
 
 def _create_test_table(engine: Engine, table_name: str):
     # TODO: insert data too, and check in the tests below that we get that data back in the DataFrame
     #  https://github.com/objectiv/objectiv-analytics/issues/1093
+    if is_athena(engine):
+        with engine.connect() as conn:
+            conn.execute(f'drop table if exists {table_name};')
+            conn.execute(
+                (
+                    f'create external table {table_name}'
+                    '(a bigint, b string, c double, d date, e timestamp, f boolean) \n'
+                    f"location '{DB_ATHENA_LOCATION}';"
+                )
+            )
+            return
     if is_postgres(engine):
         sql = f'drop table if exists {table_name}; ' \
               f'create table {table_name}(a bigint, b text, c double precision, d date, e timestamp, f boolean); '
@@ -33,6 +43,7 @@ def _create_test_table(engine: Engine, table_name: str):
 
 
 @pytest.mark.skip_postgres
+@pytest.mark.skip_athena
 def test_from_table_structural_big_query(engine, unique_table_test_name):
     # Test specifically for structural types on BigQuery. We don't support that on Postgres, so we skip
     # postgres for this test
@@ -82,6 +93,7 @@ def test_from_table_basic(engine, unique_table_test_name):
 
 
 @pytest.mark.skip_bigquery_todo()
+@pytest.mark.skip_athena_todo()
 def test_from_model_basic(engine, unique_table_test_name):
     # This is essentially the same test as test_from_table_basic(), but tests creating the dataframe with
     # from_model instead of from_table
@@ -130,6 +142,7 @@ def test_from_table_column_ordering(engine, unique_table_test_name):
 
 
 @pytest.mark.skip_bigquery_todo()
+@pytest.mark.skip_athena_todo()
 def test_from_model_column_ordering(engine, unique_table_test_name):
     # This is essentially the same test as test_from_table_model_ordering(), but tests creating the dataframe with
     # from_model instead of from_table
@@ -158,6 +171,7 @@ def test_from_model_column_ordering(engine, unique_table_test_name):
 
 
 @pytest.mark.skip_postgres
+@pytest.mark.skip_athena
 def test_big_query_from_other_project(engine):
     # Test specifically for BigQuery, whether DataFrame.from_table() works on a table in a different project.
 

--- a/bach/tests/functional/bach/test_df_from.py
+++ b/bach/tests/functional/bach/test_df_from.py
@@ -26,7 +26,7 @@ def _create_test_table(engine: Engine, table_name: str):
                 (
                     f'create external table {table_name}'
                     '(a bigint, b string, c double, d date, e timestamp, f boolean) \n'
-                    f"location '{DB_ATHENA_LOCATION}';"
+                    f"location '{DB_ATHENA_LOCATION}/{table_name}/';"
                 )
             )
             return


### PR DESCRIPTION
Added `catalog_name` to aws athena URL, otherwise sqlalchemy raises an error when trying SELECT statements. I'm still missing adding a mapping of integer db types for athena, as we currently support only `bigint` and we should also support:
`tinyint`, `smallint`, `int`/`integer`. Sort of the same for `double`, `float`, `decimal` and `char` + `var`. It's better for us to discuss if we should change `supported_db_dtype` (from Series class) as `Dict[DBDialect, Tuple[str, ...]]` or we have a separate dict for athena.