### PR TITLE
ModelHub: Refactor of `ObjectivStack.get_contexts_with_type`

### DIFF
--- a/modelhub/modelhub/pipelines/extracted_contexts.py
+++ b/modelhub/modelhub/pipelines/extracted_contexts.py
@@ -15,6 +15,7 @@ import modelhub
 from bach.types import StructuredDtype
 from sqlalchemy.engine import Engine
 
+from modelhub.series.operations.context_flattening import ContextFlattening
 from modelhub.util import (
     ObjectivSupportedColumns, get_supported_dtypes_per_objectiv_column, check_objectiv_dataframe
 )
@@ -252,16 +253,15 @@ class NativeObjectivExtractedContextsPipeline(BaseExtractedContextsPipeline):
                 f'{self._engine.name} requires flattening for global context extraction, but'
                 f'{ObjectivSupportedColumns.GLOBAL_CONTEXTS.value} is not present in dataframe.'
             )
-        df_cp = df.copy()
 
-        gc_series = (
-            df_cp[ObjectivSupportedColumns.GLOBAL_CONTEXTS.value].astype('objectiv_global_contexts')
-        )
-        # Extract the requested global contexts
-        for gc in self._global_contexts:
-            if gc in df_cp.data:
-                raise ValueError(f'column {gc} already existing in df, can not extract global context')
-            df_cp[gc] = gc_series.obj.get_contexts(gc).astype('objectiv_global_context')
+        df_cp = df.copy()
+        if self._global_contexts:
+            flattened_contexts_df = ContextFlattening(
+                contexts_series=df_cp[ObjectivSupportedColumns.GLOBAL_CONTEXTS.value],
+                global_contexts=self._global_contexts,
+                with_location_stack=False,
+            )()
+            df_cp = df_cp.copy_override(series={**df_cp.data, **flattened_contexts_df.data})
 
         return df_cp.drop(columns=[ObjectivSupportedColumns.GLOBAL_CONTEXTS.value])
 

--- a/modelhub/modelhub/series/operations/context_flattening.py
+++ b/modelhub/modelhub/series/operations/context_flattening.py
@@ -112,15 +112,20 @@ class ContextFlattening:
         """
         data_json_path = 'json_extract(element, \'$["data"]\')'
         if is_location_stack:
-            data_json_path = f'json_extract({data_json_path}, \'$["location_stack"]\''
+            data_json_path = f'json_extract({data_json_path}, \'$["location_stack"]\')'
 
         expression_str = f'''
-        transform(
+        cast(transform(
             filter(
                 cast({{}} as array(json)),
                 element -> strpos(cast(json_extract(element, '$["schema"]') as varchar), {{}}) > 0
             ),
-            element -> {data_json_path})'''
+            element -> {data_json_path}
+        ) as json)'''
+
+        if not is_location_stack:
+            expression_str = f'cast({expression_str} as json)'
+
         expression = Expression.construct(
             expression_str,
             self._contexts_series,

--- a/modelhub/modelhub/series/operations/context_flattening.py
+++ b/modelhub/modelhub/series/operations/context_flattening.py
@@ -1,0 +1,127 @@
+from typing import List
+
+import bach
+from bach.expression import Expression
+from sql_models.util import (
+    quote_identifier, is_postgres, is_athena, DatabaseNotSupportedException, is_bigquery
+)
+
+
+class ContextFlattening:
+    """
+    Class that extracts specified global contexts and location stack array from a series json based on
+    the supported format per engine.
+    """
+    def __init__(
+        self,
+        contexts_series: bach.SeriesJson,
+        global_contexts: List[str] = None,
+        with_location_stack: bool = True,
+    ) -> None:
+        self._contexts_series = contexts_series
+        self._global_contexts = global_contexts or []
+        self._with_location_stack = with_location_stack
+
+        if not self._global_contexts and not with_location_stack:
+            raise Exception('must define which contexts to extract.')
+
+    def __call__(self) -> bach.DataFrame:
+        """
+        Returns a dataframe containing a new series per requested global context
+        and location stack (if required).
+        """
+        from modelhub.series.series_objectiv import SeriesGlobalContext, SeriesLocationStack
+        result = self._contexts_series.to_frame()
+        for gc in self._global_contexts:
+            context_name = f'{gc.capitalize()}Context'
+            result[gc] = self._extract_context_data(context_name).copy_override_type(SeriesGlobalContext)
+
+        if self._with_location_stack:
+            from modelhub.util import ObjectivSupportedColumns
+            ls_name = str(ObjectivSupportedColumns.LOCATION_STACK.value)
+            result[ls_name] = self._extract_location_stack().copy_override_type(SeriesLocationStack)
+
+        return result.drop(columns=[self._contexts_series.name])
+
+    def _extract_context_data(self, context_name: str) -> bach.SeriesJson:
+        engine = self._contexts_series.engine
+        if is_postgres(engine):
+            return self._postgres_extract_context_data(context_name)
+
+        if is_bigquery(engine):
+            return self._bigquery_extract_context_data(context_name)
+
+        if is_athena(engine):
+            return self._athena_extract_context_data(context_name)
+
+        raise DatabaseNotSupportedException(engine)
+
+    def _extract_location_stack(self) -> bach.SeriesJson:
+        """
+        Extracts location stack value from context series. Currently only Athena is supported,
+        as Postgres uses native objectiv taxonomy format, therefore `location_stack` value is extracted
+        from a different json. For BigQuery, location_stack is already flattened for Snowplow implementation.
+        """
+        from modelhub.util import ObjectivSupportedColumns
+        engine = self._contexts_series.engine
+        ls_name = str(ObjectivSupportedColumns.LOCATION_STACK.value)
+        if is_athena(engine):
+            ls_series = self._athena_extract_context_data(ls_name, is_location_stack=True)
+            # previous expression will return a nested array, just get the first element
+            return ls_series.json[0]
+
+        raise DatabaseNotSupportedException(engine)
+
+    def _postgres_extract_context_data(self, context_name) -> bach.SeriesJson:
+        """
+        Extracts all elements where `_type` value equals to the requested context name.
+        """
+        dialect = self._contexts_series.engine.dialect
+        expression_str = f'''
+        jsonb_path_query_array({{}},
+        \'$[*] ? (@._type == $type)\',
+        \'{{"type":{quote_identifier(dialect, context_name)}}}\')'''
+        expression = Expression.construct(expression_str, self._contexts_series)
+        return self._contexts_series.copy_override(expression=expression)
+
+    def _bigquery_extract_context_data(self, context_name: str) -> bach.SeriesJson:
+        # This is quite ugly, but we need to convert to JSON (pre GA), and back to string because
+        # there is no nicer way to otherwise generate the JSON array that we need (as a string for now)
+        # This should be revisited when we implement BQ JSON through that datatype.
+        expression = Expression.construct(
+            '''
+            to_json_string(array(
+                select ctx
+                from unnest(json_query_array(parse_json({}), '$')) as ctx with offset as pos
+                where json_value(ctx, '$."_type"') = {}
+            ))''',
+            self._contexts_series,
+            Expression.string_value(context_name)
+        )
+
+        return self._contexts_series.copy_override(expression=expression)
+
+    def _athena_extract_context_data(
+        self, context_name: str, is_location_stack: bool = False,
+    ) -> bach.SeriesJson:
+        """
+        Extracts all elements where each element's `schema` value contains the context name as a substr.
+        """
+        data_json_path = 'json_extract(element, \'$["data"]\')'
+        if is_location_stack:
+            data_json_path = f'json_extract({data_json_path}, \'$["location_stack"]\''
+
+        expression_str = f'''
+        transform(
+            filter(
+                cast({{}} as array(json)),
+                element -> strpos(cast(json_extract(element, '$["schema"]') as varchar), {{}}) > 0
+            ),
+            element -> {data_json_path})'''
+        expression = Expression.construct(
+            expression_str,
+            self._contexts_series,
+            Expression.string_value(context_name)
+        )
+
+        return self._contexts_series.copy_override(expression=expression)

--- a/modelhub/modelhub/series/operations/context_flattening.py
+++ b/modelhub/modelhub/series/operations/context_flattening.py
@@ -33,7 +33,7 @@ class ContextFlattening:
         from modelhub.series.series_objectiv import SeriesGlobalContext, SeriesLocationStack
         result = self._contexts_series.to_frame()
         for gc in self._global_contexts:
-            context_name = f'{gc.capitalize()}Context'
+            context_name = "".join([c.capitalize() for c in gc.split('_')]) + 'Context'
             result[gc] = self._extract_context_data(context_name).copy_override_type(SeriesGlobalContext)
 
         if self._with_location_stack:
@@ -81,7 +81,10 @@ class ContextFlattening:
         jsonb_path_query_array({{}},
         \'$[*] ? (@._type == $type)\',
         \'{{"type":{quote_identifier(dialect, context_name)}}}\')'''
-        expression = Expression.construct(expression_str, self._contexts_series)
+        expression = Expression.construct(
+            expression_str,
+            self._contexts_series,
+        )
         return self._contexts_series.copy_override(expression=expression)
 
     def _bigquery_extract_context_data(self, context_name: str) -> bach.SeriesJson:

--- a/modelhub/modelhub/series/series_objectiv.py
+++ b/modelhub/modelhub/series/series_objectiv.py
@@ -14,6 +14,7 @@ from bach.series.series_json import JsonAccessor
 from bach.types import register_dtype
 from sql_models.util import is_postgres, DatabaseNotSupportedException, is_bigquery
 
+from modelhub.series.operations.context_flattening import ContextFlattening
 
 TSeriesJson = TypeVar('TSeriesJson', bound='SeriesJson')
 
@@ -78,51 +79,11 @@ class ObjectivStack(JsonAccessor, Generic[TSeriesJson]):
 
         :param name: The name of the context-array to retrieve, in snake_case
         """
-        upper_camel_name = "".join([c.capitalize() for c in name.split('_')]) + 'Context'
-
-        return self.get_contexts_with_type(upper_camel_name).astype('objectiv_global_context')
-
-    def get_contexts_with_type(self, type: str):
-        """
-        Returns an array of contexts from an Objectiv stack where `_type` matches `type`.
-
-        :param type: the _type to search for in the contexts of the stack.
-        :returns: a seriesjson, containing a possibly empty array of the specified types
-        """
-        dialect = self._series_object.engine.dialect
-        if is_postgres(dialect):
-            return self._postgres_get_contexts_with_type(type)
-        if is_bigquery(dialect):
-            return self._bigquery_get_contexts_with_type(type)
-        raise DatabaseNotSupportedException(dialect)
-
-    def _postgres_get_contexts_with_type(self, type: str):
-        dialect = self._series_object.engine.dialect
-        expression_str = f'''
-        jsonb_path_query_array({{}},
-        \'$[*] ? (@._type == $type)\',
-        \'{{"type":{quote_identifier(dialect, type)}}}\')'''
-        expression = Expression.construct(
-            expression_str,
-            self._series_object
+        cf = ContextFlattening(
+            contexts_series=self._series_object, global_contexts=[name], with_location_stack=False,
         )
-        return self._series_object.copy_override_dtype('json').copy_override(expression=expression)
-
-    def _bigquery_get_contexts_with_type(self, type: str):
-        # This is quite ugly, but we need to convert to JSON (pre GA), and back to string because
-        # there is no nicer way to otherwise generate the JSON array that we need (as a string for now)
-        # This should be revisited when we implement BQ JSON through that datatype.
-        expression = Expression.construct(
-            '''
-            to_json_string(array(
-                select ctx
-                from unnest(json_query_array(parse_json({}), '$')) as ctx with offset as pos
-                where json_value(ctx, '$."_type"') = {}
-            ))''',
-            self._series_object,
-            Expression.string_value(type)
-        )
-        return self._series_object.copy_override_dtype('json').copy_override(expression=expression)
+        c_series = cf()[name].copy_override(name=self._series_object.name)
+        return c_series.copy_override_type(SeriesGlobalContext)
 
 
 @register_dtype(value_types=[], override_registered_types=True)


### PR DESCRIPTION
Moved code from `ObjectivStack.get_contexts_with_type` to new class `ContextFlattening`. Since we require it for flattening global contexts and location stack for Athena, which caused code duplication with current implementation. 