### PR TITLE
Bach/MH: Temp fix for CI/Mypy on 3.10

### DIFF
--- a/.github/workflows/bach-tests.yml
+++ b/.github/workflows/bach-tests.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10.6']
         # See https://docs.github.com/en/actions/learn-github-actions/contexts#github-context on why we use endsWith
         isMain:
           - ${{ endsWith(github.ref,'/main') }}
@@ -23,7 +23,7 @@ jobs:
           - isMain: false
             python-version: '3.9'
           - isMain: false
-            python-version: '3.10'
+            python-version: '3.10.6'
           
     services:
       # based on https://docs.github.com/en/actions/guides/creating-postgresql-service-containers

--- a/.github/workflows/modelhub_tests.yml
+++ b/.github/workflows/modelhub_tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10.6']
         # See https://docs.github.com/en/actions/learn-github-actions/contexts#github-context on why we use endsWith
         isMain:
           - ${{ endsWith(github.ref,'/main') }}
@@ -24,7 +24,7 @@ jobs:
           - isMain: false
             python-version: '3.9'
           - isMain: false
-            python-version: '3.10'
+            python-version: '3.10.6'
     services:
       # based on https://docs.github.com/en/actions/guides/creating-postgresql-service-containers
       postgres:


### PR DESCRIPTION

Python 3.10.7 and current release of mypy are not very compatible. Please see: https://github.com/python/mypy/issues/13627
This PR pins python to 3.10.6 for now, until:
https://github.com/python/mypy/issues/13627#issuecomment-1240907370
`Yup, a mypy release with the fix will be out soon (might be included in mypy 0.980, if not it will be in mypy 0.990).`

Error:
https://github.com/objectiv/objectiv-analytics/actions/runs/3112386506/jobs/5045756856
```
/opt/hostedtoolcache/Python/3.10.7/x64/lib/python3.10/site-packages/numpy/__init__.pyi:636: error: Positional-only parameters are only supported in Python 3.8 and greater
```