### PR TITLE
Bach map names pre tests

### DIFF
--- a/bach/tests/functional/bach/test_df_append.py
+++ b/bach/tests/functional/bach/test_df_append.py
@@ -1,10 +1,12 @@
 import numpy as np
 import pandas as pd
+import pytest
 
 from bach import DataFrame
 from tests.functional.bach.test_data_and_utils import assert_equals_data
 
 
+@pytest.mark.skip_athena_todo('https://github.com/objectiv/objectiv-analytics/issues/1209')
 def test_append_w_aligned_columns(engine) -> None:
     caller_pdf = pd.DataFrame({'A': [1, 2, 3, 4, 5], 'B': ['a', 'b', 'c', 'd', 'e']})
     other_pdf = pd.DataFrame({'A': [6, 7, 8, 9], 'B': ['f', 'g', 'h', 'i']})
@@ -17,6 +19,8 @@ def test_append_w_aligned_columns(engine) -> None:
     np.testing.assert_equal(expected.to_numpy(), result.to_numpy())
 
 
+@pytest.mark.skip_bigquery_todo('https://github.com/objectiv/objectiv-analytics/issues/1209')
+@pytest.mark.skip_athena_todo('https://github.com/objectiv/objectiv-analytics/issues/1209')
 def test_append_w_non_aligned_columns(engine) -> None:
     # Column names 'A#' and 'a#' should be considered as two different columns, i.e. they don't align
     # By adding the '#' to the column names we also test the correct handling of special characters

--- a/bach/tests/functional/bach/test_df_from_pandas.py
+++ b/bach/tests/functional/bach/test_df_from_pandas.py
@@ -290,6 +290,7 @@ def test_from_pandas_types_cte(engine, unique_table_test_name):
 
     assert_equals_data(
         df,
+        use_to_pandas=True,
         expected_columns=['_index_int_column',
                           'float_column',
                           'bool_column',

--- a/bach/tests/functional/bach/test_df_get_dummies.py
+++ b/bach/tests/functional/bach/test_df_get_dummies.py
@@ -22,7 +22,7 @@ def test_basic_get_dummies(engine) -> None:
     assert set(expected_columns) == set(result.data_columns)
     result = result[expected_columns]
     assert_equals_data(
-        result[expected_columns],
+        result,
         use_to_pandas=True,
         expected_columns=['_index_0'] + expected_columns,
         expected_data=[

--- a/bach/tests/functional/bach/test_df_indexing.py
+++ b/bach/tests/functional/bach/test_df_indexing.py
@@ -4,7 +4,6 @@ import pandas as pd
 import pytest
 
 from bach import Series, DataFrame
-from sql_models.util import is_bigquery
 from tests.functional.bach.test_data_and_utils import assert_equals_data, get_df_with_test_data
 
 
@@ -33,7 +32,7 @@ def test_basic_indexing(indexing_dfs: Tuple[pd.DataFrame, DataFrame]) -> None:
     assert isinstance(single_label_result, Series)
     pd.testing.assert_series_equal(
         pdf.loc['b'].astype(str),
-        single_label_result.to_pandas(),
+        single_label_result.sort_index().to_pandas(),
         check_names=False,
     )
 
@@ -79,11 +78,6 @@ def test_basic_indexing_column_based(indexing_dfs: Tuple[pd.DataFrame, DataFrame
 @pytest.mark.skip_athena_todo('https://github.com/objectiv/objectiv-analytics/issues/1209')
 def test_index_slicing(indexing_dfs: Tuple[pd.DataFrame, DataFrame]) -> None:
     pdf, df = indexing_dfs
-
-    if is_bigquery(df.engine):
-        # TODO: BigQuery
-        # indexing with slicing is still not supported for BigQuery
-        return
 
     df = df.sort_index()
     result_slicing = df.loc['b':'d']
@@ -185,10 +179,6 @@ def test_set_item_by_label_diff_node(indexing_dfs: Tuple[pd.DataFrame, DataFrame
 @pytest.mark.skip_athena_todo('https://github.com/objectiv/objectiv-analytics/issues/1209')
 def test_set_item_by_slicing(indexing_dfs: Tuple[pd.DataFrame, DataFrame], engine) -> None:
     pdf, df = indexing_dfs
-    if is_bigquery(df.engine):
-        # TODO: BigQuery
-        # indexing with slicing is still not supported for BigQuery
-        return
     df = df.sort_index()
 
     df.loc['b':'d'] = 1
@@ -199,6 +189,7 @@ def test_set_item_by_slicing(indexing_dfs: Tuple[pd.DataFrame, DataFrame], engin
 
     assert_equals_data(
         df.sort_index(),
+        use_to_pandas=True,
         expected_columns=['A', 'B', 'C', 'D'],
         expected_data=[
             ['a', 0, 5, 'f'],
@@ -223,6 +214,7 @@ def test_set_item_by_slicing(indexing_dfs: Tuple[pd.DataFrame, DataFrame], engin
     df.loc['b':'d', ['B', 'D']] = extra_df['B']
     assert_equals_data(
         df.sort_index(),
+        use_to_pandas=True,
         expected_columns=['A', 'B', 'C', 'D'],
         expected_data=[
             ['a', 0, 5, 'f'],

--- a/bach/tests/functional/bach/test_df_sample.py
+++ b/bach/tests/functional/bach/test_df_sample.py
@@ -126,6 +126,35 @@ def test_sample_operations_filter(engine, unique_table_test_name):
     )
 
 
+def test_sample_column_name_special_char(engine, unique_table_test_name):
+    bt = get_df_with_test_data(engine, True)
+    bt_sample = bt.get_sample(table_name=unique_table_test_name,
+                              filter=bt.skating_order % 2 == 0,
+                              overwrite=True)
+
+    bt_sample['City'] = bt_sample.city + '_better'
+    bt_sample['a#'] = bt_sample.city.str[:2] + bt_sample.municipality.str[:2]
+    bt_sample['A#'] = bt_sample.inhabitants + 10
+    bt_sample['b_b'] = bt_sample.inhabitants + bt_sample.founding
+
+    all_data_bt = bt_sample.get_unsampled()
+    all_data_bt['B_B'] = all_data_bt.inhabitants + 5
+
+    expected_columns = [
+        '_index_skating_order',  # index
+        'skating_order', 'city', 'municipality', 'inhabitants', 'founding',
+        'City', 'a#', 'A#', 'b_b', 'B_B'
+    ]
+
+    assert list(bt_sample.all_series.keys()) == expected_columns[:-1]
+    assert_equals_data(
+        all_data_bt,
+        use_to_pandas=True,
+        expected_columns=expected_columns,
+        expected_data=_EXPECTED_DATA_OPERATIONS
+    )
+
+
 def test_combine_unsampled_with_before_data(engine, unique_table_test_name):
     # Test that the get_unsampled() df has a base_node and state that is compatible with the base_node and
     # state of the original df

--- a/bach/tests/functional/bach/test_df_sample.py
+++ b/bach/tests/functional/bach/test_df_sample.py
@@ -126,6 +126,7 @@ def test_sample_operations_filter(engine, unique_table_test_name):
     )
 
 
+@pytest.mark.skip_bigquery_todo('https://github.com/objectiv/objectiv-analytics/issues/1209')
 def test_sample_column_name_special_char(engine, unique_table_test_name):
     bt = get_df_with_test_data(engine, True)
     bt_sample = bt.get_sample(table_name=unique_table_test_name,

--- a/bach/tests/functional/bach/test_injection_column_name_escaping.py
+++ b/bach/tests/functional/bach/test_injection_column_name_escaping.py
@@ -17,13 +17,16 @@ def test_column_names(engine):
     # Postgres does allow 'weird' characters, if properly escaped. Test the escaping
     bt = _get_dataframe_with_weird_column_names(engine)
     expected_columns = ['_index_skating_order',
-                        'city', 'With_Capitals', 'with_capitals',
-                        'With A Space Too', '""with"_quotes""', 'with%percentage',
-                        'with{format}{{strings}}{{}', 'Aa_!#!$*(aA®Řﬦ‎	⛔']
+                        'city',
+                        'With_And_Without_Capitals', 'with_and_without_capitals',
+                        'With A Space Too',
+                        '"""with"_quotes""', '```with`_quotes``', "'''with'_quotes''",
+                        'with%percentage', 'with{format}{{strings}}{{}',
+                        'Aa_!#!$*(aA®Řﬦ‎	⛔']
     expected_data = [
-        [1, 'Ljouwert', 1, 1, 1, 1, 1, 1, 1],
-        [2, 'Snits',  1, 1, 1, 1, 1, 1, 1],
-        [3, 'Drylts',  1, 1, 1, 1, 1, 1, 1]
+        [1, 'Ljouwert', 1, 2, 3, 4, 5, 6, 7, 8, 9],
+        [2, 'Snits', 1, 2, 3, 4, 5, 6, 7, 8, 9],
+        [3, 'Drylts', 1, 2, 3, 4, 5, 6, 7, 8, 9]
     ]
     assert_equals_data(
         bt,
@@ -50,13 +53,16 @@ def test_column_names_merge(engine):
     bt2 = get_df_with_test_data(engine)[['city']]
     bt = bt.merge(bt2, on='city')
     expected_columns = ['_index_skating_order_x', '_index_skating_order_y',
-                        'city', 'With_Capitals', 'with_capitals',
-                        'With A Space Too', '""with"_quotes""', 'with%percentage',
-                        'with{format}{{strings}}{{}', 'Aa_!#!$*(aA®Řﬦ‎	⛔']
+                        'city',
+                        'With_And_Without_Capitals', 'with_and_without_capitals',
+                        'With A Space Too',
+                        '"""with"_quotes""', '```with`_quotes``', "'''with'_quotes''",
+                        'with%percentage', 'with{format}{{strings}}{{}',
+                        'Aa_!#!$*(aA®Řﬦ‎	⛔']
     expected_data = [
-        [1, 1, 'Ljouwert', 1, 1, 1, 1, 1, 1, 1],
-        [2, 2, 'Snits',  1, 1, 1, 1, 1, 1, 1],
-        [3, 3, 'Drylts',  1, 1, 1, 1, 1, 1, 1]
+        [1, 1, 'Ljouwert', 1, 2, 3, 4, 5, 6, 7, 8, 9],
+        [2, 2, 'Snits', 1, 2, 3, 4, 5, 6, 7, 8, 9],
+        [3, 3, 'Drylts', 1, 2, 3, 4, 5, 6, 7, 8, 9]
     ]
     assert_equals_data(
         bt,
@@ -68,13 +74,21 @@ def test_column_names_merge(engine):
 
 def _get_dataframe_with_weird_column_names(engine: Engine):
     bt = get_df_with_test_data(engine)[['city']]
-    bt['With_Capitals'] = 1
-    bt['with_capitals'] = 1
-    bt['With A Space Too'] = 1
-    bt['""with"_quotes""'] = 1
-    bt['with%percentage'] = 1
-    bt['with{format}{{strings}}{{}'] = 1
-    bt['Aa_!#!$*(aA®Řﬦ‎	⛔'] = 1
+    # Some database engine have case-insensitive column names. Make sure this doesn't cause problems by
+    # having two columns with the same name, but different capitalization
+    bt['With_And_Without_Capitals'] = 1
+    bt['with_and_without_capitals'] = 2
+    # Test proper quoting of column names with spaces.
+    bt['With A Space Too'] = 3
+    # Test proper encoding of quote characters.
+    bt['"""with"_quotes""'] = 4
+    bt['```with`_quotes``'] = 5
+    bt["'''with'_quotes''"] = 6
+    # Test proper encoding of possible formatting and escaping characters.
+    bt['with%percentage'] = 7
+    bt['with{format}{{strings}}{{}'] = 8
+    # Test encoding of non-ascii characters
+    bt['Aa_!#!$*(aA®Řﬦ‎	⛔'] = 9
     return bt
 
 # TODO: tests for groupby and windowing

--- a/bach/tests/functional/bach/test_injection_escaping.py
+++ b/bach/tests/functional/bach/test_injection_escaping.py
@@ -60,7 +60,7 @@ def test_format_injection_merge(engine):
 
 
 def test_percentage_injection(engine):
-    # We use(d) format() in multiple places, this test is to prevent regressions in correct escaping
+    # In some places '%' is used for placehorders. This test is to prevent regressions in correct escaping
     bt = get_df_with_test_data(engine)[['city']]
     bt['city'] = bt['city'] + ' %(test)s %%  ?'
     print(bt.engine)

--- a/bach/tests/functional/bach/test_revert_merge.py
+++ b/bach/tests/functional/bach/test_revert_merge.py
@@ -71,10 +71,10 @@ def test_revert_merge_basic_on_indexes(engine):
 def test_revert_merge_suffixes(engine):
     bt = get_df_with_test_data(engine, full_data_set=False)[['skating_order', 'city']]
     mt = get_df_with_food_data(engine)[['skating_order', 'food']]
-    merged = bt.merge(mt, left_on='_index_skating_order', right_on='skating_order', suffixes=('_AA', '_BB'))
+    merged = bt.merge(mt, left_on='_index_skating_order', right_on='skating_order', suffixes=('_AA', '_aa'))
     result_bt, result_mt = revert_merge(merged)
-    for expected, result in zip([bt, mt], [result_bt, result_mt]):
-        _compare_source_with_replicate(expected, result)
+    _compare_source_with_replicate(bt, result_bt)
+    _compare_source_with_replicate(mt, result_mt)
 
 
 def test_revert_merge_mixed_columns(engine):

--- a/bach/tests/functional/bach/test_series_append.py
+++ b/bach/tests/functional/bach/test_series_append.py
@@ -25,6 +25,30 @@ def test_series_append_same_dtype(engine) -> None:
     )
 
 
+def test_series_append_column_name_special_chars(engine) -> None:
+    df = get_df_with_test_data(engine, full_data_set=False)[['city', 'skating_order']]
+    df.skating_order = df.skating_order.astype(str)
+    df = df.rename(columns={'city': 'A!@_'})
+
+    result = df['A!@_'].append(df.skating_order)
+    print(result.view_sql())
+    assert isinstance(result, Series)
+
+    assert_equals_data(
+        result.sort_values(),
+        use_to_pandas=True,
+        expected_columns=['_index_skating_order', 'A!@_'],
+        expected_data=[
+            [1, '1'],
+            [2, '2'],
+            [3, '3'],
+            [3, 'Drylts'],
+            [1, 'Ljouwert'],
+            [2, 'Snits'],
+        ],
+    )
+
+
 @pytest.mark.skip_athena_todo()  # TODO: remove '.0' from stringified float
 def test_series_append_different_dtype(engine) -> None:
     bt = get_df_with_test_data(engine, full_data_set=False)[['city', 'inhabitants', 'founding']]

--- a/bach/tests/functional/bach/test_series_append.py
+++ b/bach/tests/functional/bach/test_series_append.py
@@ -24,6 +24,7 @@ def test_series_append_same_dtype(engine) -> None:
         ],
     )
 
+
 @pytest.mark.skip_bigquery_todo('https://github.com/objectiv/objectiv-analytics/issues/1209')
 @pytest.mark.skip_athena_todo('https://github.com/objectiv/objectiv-analytics/issues/1209')
 def test_series_append_column_name_special_chars(engine) -> None:

--- a/bach/tests/functional/bach/test_series_append.py
+++ b/bach/tests/functional/bach/test_series_append.py
@@ -32,7 +32,6 @@ def test_series_append_column_name_special_chars(engine) -> None:
     df = df.rename(columns={'city': 'A!@_'})
 
     result = df['A!@_'].append(df.skating_order)
-    print(result.view_sql())
     assert isinstance(result, Series)
 
     assert_equals_data(

--- a/bach/tests/functional/bach/test_series_append.py
+++ b/bach/tests/functional/bach/test_series_append.py
@@ -24,7 +24,8 @@ def test_series_append_same_dtype(engine) -> None:
         ],
     )
 
-
+@pytest.mark.skip_bigquery_todo('https://github.com/objectiv/objectiv-analytics/issues/1209')
+@pytest.mark.skip_athena_todo('https://github.com/objectiv/objectiv-analytics/issues/1209')
 def test_series_append_column_name_special_chars(engine) -> None:
     df = get_df_with_test_data(engine, full_data_set=False)[['city', 'skating_order']]
     df.skating_order = df.skating_order.astype(str)

--- a/bach/tests/functional/bach/test_series_json.py
+++ b/bach/tests/functional/bach/test_series_json.py
@@ -360,6 +360,8 @@ def test_json_flatten_array(engine, dtype):
     )
 
 
+@pytest.mark.skip_bigquery_todo('https://github.com/objectiv/objectiv-analytics/issues/1209')
+@pytest.mark.skip_athena_todo('https://github.com/objectiv/objectiv-analytics/issues/1209')
 def test_json_flatten_array_column_name_special_chars(engine, dtype):
     df = get_df_with_json_data(engine=engine, dtype=dtype)
     df = df.sort_index()[:2]  # two rows should be enough, and keeps the expected data shorter

--- a/bach/tests/functional/bach/test_series_json.py
+++ b/bach/tests/functional/bach/test_series_json.py
@@ -360,7 +360,7 @@ def test_json_flatten_array(engine, dtype):
     )
 
 
-def test_json_flatten_array_column_names(engine, dtype):
+def test_json_flatten_array_column_name_special_chars(engine, dtype):
     df = get_df_with_json_data(engine=engine, dtype=dtype)
     df = df.sort_index()[:2]  # two rows should be enough, and keeps the expected data shorter
 
@@ -387,6 +387,7 @@ def test_json_flatten_array_column_names(engine, dtype):
         ],
         use_to_pandas=True,
     )
+
 
 def test_complex_types_astype_json(engine, dtype):
 

--- a/bach/tests/unit/bach/test_series.py
+++ b/bach/tests/unit/bach/test_series.py
@@ -43,6 +43,7 @@ def test_equals(dialect):
     assert not left['c'].equals(right['c'])
 
     engine = left.engine
+    base_node = left.base_node
     engine_other = FakeEngine(dialect=engine.dialect, url='sql://some_other_string')
 
     int_type = get_series_type_from_dtype('int64')
@@ -51,22 +52,22 @@ def test_equals(dialect):
     expr_test = Expression.construct('test')
     expr_other = Expression.construct('test::text')
 
-    sleft = int_type(engine=engine, base_node=None, index={}, name='test',
+    sleft = int_type(engine=engine, base_node=base_node, index={}, name='test',
                      expression=expr_test, group_by=None, order_by=[],
                      instance_dtype='int64')
-    sright = int_type(engine=engine, base_node=None, index={}, name='test',
+    sright = int_type(engine=engine, base_node=base_node, index={}, name='test',
                       expression=expr_test, group_by=None, order_by=[],
                       instance_dtype='int64')
     assert sleft.equals(sright)
 
     # different expression
-    sright = int_type(engine=engine, base_node=None, index={}, name='test',
+    sright = int_type(engine=engine, base_node=base_node, index={}, name='test',
                       expression=expr_other, group_by=None, order_by=[],
                       instance_dtype='int64')
     assert not sleft.equals(sright)
 
     # different name
-    sright = int_type(engine=engine, base_node=None, index={}, name='test_2',
+    sright = int_type(engine=engine, base_node=base_node, index={}, name='test_2',
                       expression=expr_test, group_by=None, order_by=[],
                       instance_dtype='int64')
     assert not sleft.equals(sright)
@@ -78,26 +79,26 @@ def test_equals(dialect):
     assert not sleft.equals(sright)
 
     # different engine
-    sright = int_type(engine=engine_other, base_node=None, index={}, name='test',
+    sright = int_type(engine=engine_other, base_node=base_node, index={}, name='test',
                       expression=expr_test, group_by=None, order_by=[],
                       instance_dtype='int64')
     assert not sleft.equals(sright)
 
     # different type
-    sright = float_type(engine=engine, base_node=None, index={}, name='test',
+    sright = float_type(engine=engine, base_node=base_node, index={}, name='test',
                         expression=expr_test, group_by=None, order_by=[],
                         instance_dtype='float64')
     assert not sleft.equals(sright)
 
     # different group_by
-    sright = int_type(engine=engine, base_node=None, index={}, name='test', expression=expr_test,
+    sright = int_type(engine=engine, base_node=base_node, index={}, name='test', expression=expr_test,
                       group_by=GroupBy(group_by_columns=[]), order_by=[],
                       instance_dtype='int64')
     assert not sleft.equals(sright)
 
     # different sorting
     sright = int_type(
-        engine=engine, base_node=None, index={}, name='test', expression=expr_test,
+        engine=engine, base_node=base_node, index={}, name='test', expression=expr_test,
         group_by=None, order_by=[SortColumn(expression=expr_test, asc=True)],
         instance_dtype='int64',
     )
@@ -106,10 +107,10 @@ def test_equals(dialect):
     assert sleft.equals(sright)
 
     index_series = sleft
-    sleft = int_type(engine=engine, base_node=None, index={'a': index_series}, name='test',
+    sleft = int_type(engine=engine, base_node=base_node, index={'a': index_series}, name='test',
                      expression=expr_test, group_by=None, order_by=[],
                      instance_dtype='int64')
-    sright = int_type(engine=engine, base_node=None, index={'a': index_series}, name='test',
+    sright = int_type(engine=engine, base_node=base_node, index={'a': index_series}, name='test',
                       expression=expr_test, group_by=None, order_by=[],
                       instance_dtype='int64')
     assert sleft.equals(sright)


### PR DESCRIPTION
Preparation for issue #1209 

* Add tests that use column names with special characters and/or lower and upper case characters
* Add `use_pandas=True` to some tests that will need that, as they use special character in column names
* other preparatory changes to tests

Note that not all tests work for BigQuery currently. Specific issue is that BigQuery column names are case-insensitive. So for example `a` and `A` are actually considered to be the same column name by BQ, but Bach is not aware of that.  #1209 will fix that.