### PR TITLE
ModelHub: Replace empty spaces with None for user_id and event_id

### DIFF
--- a/modelhub/modelhub/pipelines/extracted_contexts.py
+++ b/modelhub/modelhub/pipelines/extracted_contexts.py
@@ -335,7 +335,6 @@ class SnowplowExtractedContextsPipeline(BaseExtractedContextsPipeline, ABC):
         )
         df_cp = df_cp.drop(columns=['network_userid', 'domain_sessionid'])
 
-
         # Mark duplicated event_ids
         # Unfortunately, some events might share an event ID due to
         # browser pre-cachers or scraping bots sending the same event multiple time. Although,

--- a/modelhub/modelhub/pipelines/extracted_contexts.py
+++ b/modelhub/modelhub/pipelines/extracted_contexts.py
@@ -328,6 +328,11 @@ class SnowplowExtractedContextsPipeline(BaseExtractedContextsPipeline, ABC):
         )
         df_cp = df_cp.drop(columns=['network_userid', 'domain_sessionid'])
 
+        # avoid having empty string in series that will be parsed as UUID
+        uuid_series = [ObjectivSupportedColumns.EVENT_ID, ObjectivSupportedColumns.USER_ID]
+        for series in uuid_series:
+            df_cp.loc[df_cp[series.value] == '', series.value] = None
+
         # Mark duplicated event_ids
         # Unfortunately, some events might share an event ID due to
         # browser pre-cachers or scraping bots sending the same event multiple time. Although,


### PR DESCRIPTION
We should avoid having empty spaces in those columns, else it will raise an error when trying to do `to_pandas()`. 

Added an issue for Bach to handle better this situation: https://github.com/objectiv/objectiv-analytics/issues/1309