### PR TITLE
Update old Tracking docs core concepts URLs

### DIFF
--- a/bach/docs/source/example-notebooks/funnel-discovery.rst
+++ b/bach/docs/source/example-notebooks/funnel-discovery.rst
@@ -142,8 +142,8 @@ See step sequences per user
 ---------------------------
 Before we see what helped conversion and what didn't, let's have a look at which consecutive steps each user 
 took (aka the features they used) in general, after starting their session, based on the 
-`location stack <https://objectiv.io/docs/tracking/core-concepts/locations>`_. We have to specify the maximum 
-n steps, and use the :doc:`get_navigation_paths 
+`location stack <https://objectiv.io/docs/tracking/locations>`_. We have to specify the maximum n steps, and 
+use the :doc:`get_navigation_paths 
 <../open-model-hub/models/funnels/FunnelDiscovery/modelhub.FunnelDiscovery.get_navigation_paths>` operation.
 
 .. doctest:: funnel-discovery
@@ -178,7 +178,7 @@ n steps, and use the :doc:`get_navigation_paths
 See top step sequences for all users
 ------------------------------------
 For the bigger picture, calculate the most frequent consecutive steps that all users took after starting 
-their session, based on the `location stack <https://objectiv.io/docs/tracking/core-concepts/locations>`_.
+their session, based on the `location stack <https://objectiv.io/docs/tracking/locations>`_.
 
 .. doctest:: funnel-discovery
 	:skipif: engine is None

--- a/notebooks/funnel-discovery.ipynb
+++ b/notebooks/funnel-discovery.ipynb
@@ -195,7 +195,7 @@
    "id": "fa673673",
    "metadata": {},
    "source": [
-    "Before we see what helped conversion and what didn't, let's have a look at which consecutive steps each user took (aka the features they used) in general, after starting their session, based on the [location stack](https://objectiv.io/docs/tracking/core-concepts/locations). We have to specify the maximum n steps, and use the [get_navigation_paths](https://objectiv.io/docs/modeling/open-model-hub/models/funnels/FunnelDiscovery/get_navigation_paths) operation."
+    "Before we see what helped conversion and what didn't, let's have a look at which consecutive steps each user took (aka the features they used) in general, after starting their session, based on the [location stack](https://objectiv.io/docs/tracking/locations). We have to specify the maximum n steps, and use the [get_navigation_paths](https://objectiv.io/docs/modeling/open-model-hub/models/funnels/FunnelDiscovery/get_navigation_paths) operation."
    ]
   },
   {
@@ -247,7 +247,7 @@
    "id": "73637d50",
    "metadata": {},
    "source": [
-    "For the bigger picture, calculate the most frequent consecutive steps that all users took after starting their session, based on the [location stack](https://objectiv.io/docs/tracking/core-concepts/locations)."
+    "For the bigger picture, calculate the most frequent consecutive steps that all users took after starting their session, based on the [location stack](https://objectiv.io/docs/tracking/locations)."
    ]
   },
   {


### PR DESCRIPTION
Updates a few URLs changed in https://github.com/objectiv/objectiv.io/pull/577.

NOTE: only merge this when https://github.com/objectiv/objectiv.io/pull/577 is live.