### PR TITLE
Bach enable some more tests

### DIFF
--- a/bach/tests/functional/bach/test_bt_custom_types.py
+++ b/bach/tests/functional/bach/test_bt_custom_types.py
@@ -17,6 +17,7 @@ class ReversedStringType(Series):
     dtype_aliases = ('reversed_text', 'backwards_string')
     supported_db_dtype = {
         DBDialect.POSTGRES: 'text',
+        DBDialect.ATHENA: 'varchar',
         DBDialect.BIGQUERY: 'string',
     }
     supported_value_types = (str,)
@@ -35,7 +36,6 @@ class ReversedStringType(Series):
             return Expression.construct(f'reverse(cast({{}} as {cls.get_db_dtype(dialect)}))', expression)
 
 
-@pytest.mark.skip_athena_todo()  # TODO: Athena
 def test_custom_type(monkeypatch, engine):
     # make sure monkeypatch the type-registry, as it should be restored after this test finishes.
     monkeypatch.setattr('bach.types._registry', TypeRegistry())

--- a/bach/tests/functional/bach/test_df_astype.py
+++ b/bach/tests/functional/bach/test_df_astype.py
@@ -148,7 +148,6 @@ def test_astype_to_timestamp(engine):
     )
 
 
-@pytest.mark.skip_athena_todo()  # TODO: Athena
 def test_astype_to_time(engine):
     bt = get_df_with_test_data(engine)
     bt = bt[[]]
@@ -157,6 +156,7 @@ def test_astype_to_time(engine):
     bt = bt.astype('time')
     assert_equals_data(
         bt,
+        use_to_pandas=True,
         expected_columns=['_index_skating_order', 'a', 'b'],
         expected_data=[
             [1, time(3, 4, 0), time(23, 25, 59)],

--- a/bach/tests/functional/bach/test_df_from_pandas.py
+++ b/bach/tests/functional/bach/test_df_from_pandas.py
@@ -48,9 +48,7 @@ TYPES_COLUMNS = ['int_column', 'float_column', 'bool_column', 'datetime_column',
                  'dict_column', 'timedelta_column', 'mixed_column']
 
 
-pytestmark = pytest.mark.skip_athena_todo()  # TODO: Athena
-
-
+@pytest.mark.skip_athena_todo()  # TODO: Athena
 def test_from_pandas_table(engine, unique_table_test_name):
     pdf = get_pandas_df(TEST_DATA_CITIES, CITIES_COLUMNS)
     bt = DataFrame.from_pandas(
@@ -64,6 +62,7 @@ def test_from_pandas_table(engine, unique_table_test_name):
     assert_equals_data(bt, expected_columns=EXPECTED_COLUMNS, expected_data=EXPECTED_DATA)
 
 
+@pytest.mark.skip_athena_todo()  # TODO: Athena
 def test_from_pandas_table_injection(engine, unique_table_test_name):
     pdf = get_pandas_df(TEST_DATA_INJECTION, COLUMNS_INJECTION)
     bt = DataFrame.from_pandas(
@@ -116,6 +115,7 @@ def test_from_pandas_ephemeral_injection(engine):
     )
 
 
+@pytest.mark.skip_athena_todo()  # TODO: Athena
 def test_from_pandas_non_happy_path(engine, unique_table_test_name):
     pdf = get_pandas_df(TEST_DATA_CITIES, CITIES_COLUMNS)
     with pytest.raises(TypeError):
@@ -148,6 +148,7 @@ def test_from_pandas_non_happy_path(engine, unique_table_test_name):
         )
 
 
+@pytest.mark.skip_athena_todo()  # TODO: Athena
 @pytest.mark.skip_bigquery_todo()
 @pytest.mark.parametrize("materialization", ['cte', 'table'])
 def test_from_pandas_index(materialization: str, engine, unique_table_test_name):
@@ -193,6 +194,7 @@ def test_from_pandas_index(materialization: str, engine, unique_table_test_name)
         expected_data=[[idx] + x[1:] for idx, x in enumerate(EXPECTED_DATA)])
 
 
+@pytest.mark.skip_athena_todo()  # TODO: Athena
 @pytest.mark.skip_bigquery_todo()
 @pytest.mark.parametrize("materialization", ['cte', 'table'])
 def test_from_pandas_types(materialization: str, engine, unique_table_test_name):
@@ -213,6 +215,7 @@ def test_from_pandas_types(materialization: str, engine, unique_table_test_name)
 
     assert_equals_data(
         df,
+        use_to_pandas=True,
         expected_columns=[
             '_index_int_column',
             'float_column',
@@ -240,6 +243,7 @@ def test_from_pandas_types(materialization: str, engine, unique_table_test_name)
 
     assert_equals_data(
         df,
+        use_to_pandas=True,
         expected_columns=[
             '_index_int_column',
             'int32_column'

--- a/bach/tests/functional/bach/test_df_setitem.py
+++ b/bach/tests/functional/bach/test_df_setitem.py
@@ -68,7 +68,6 @@ def check_set_const(
         assert_db_types(bt, db_types)
 
 
-
 def test_set_const_int(engine):
     constants = [
         np.int64(4),
@@ -77,7 +76,6 @@ def test_set_const_int(engine):
         2147483648
     ]
     check_set_const(engine, constants, SeriesInt64)
-
 
 
 def test_set_const_float(engine):
@@ -129,14 +127,12 @@ def test_set_const_time(engine):
     check_set_const(engine, constants, SeriesTime)
 
 
-@pytest.mark.skip_athena_todo()  # TODO: Athena
 def test_set_const_timedelta(engine):
     constants = [
         np.datetime64('2005-02-25T03:30') - np.datetime64('2005-01-25T03:30'),
         datetime.datetime.now() - datetime.datetime(2015, 4, 6),
     ]
     check_set_const(engine, constants, SeriesTimedelta)
-
 
 
 def test_set_const_json(engine):

--- a/bach/tests/unit/sql_models/test_util.py
+++ b/bach/tests/unit/sql_models/test_util.py
@@ -46,10 +46,10 @@ def test_quote_identifier(dialect):
         raise Exception()
 
 
-@pytest.mark.skip_athena_todo()  # TODO: Athena research about syntax constants
 def test_quote_string(dialect):
-    if is_postgres(dialect):
-        # https://www.postgresql.org/docs/14/sql-syntax-lexical.html#SQL-SYNTAX-CONSTANTS
+    if is_postgres(dialect) or is_athena(dialect):
+        # Postgres: https://www.postgresql.org/docs/14/sql-syntax-lexical.html#SQL-SYNTAX-CONSTANTS
+        # Athena: https://docs.aws.amazon.com/athena/latest/ug/select.html#select-escaping
         assert quote_string(dialect, "test") == "'test'"
         assert quote_string(dialect, "te'st") == "'te''st'"
         assert quote_string(dialect, "'te''st'") == "'''te''''st'''"


### PR DESCRIPTION
Edit: enabled one more test in this PR
Still ~100~ 99 tests to go for athena. ~Will further prioritize on Monday~ Planned more stuff this week
```
pytest tests/ --athena -m 'skip_athena_todo'
==================================== test session starts =====================================
platform linux -- Python 3.8.10, pytest-6.2.5, py-1.10.0, pluggy-1.0.0
rootdir: /home/thijs/workspace/git-repos/objectiv-analytics/bach, configfile: pytest.ini
plugins: forked-1.4.0, xdist-2.5.0, timeout-2.1.0
collected 606 items / 507 deselected / 99 selected                                           

tests/functional/bach/test_cut.py ssssssssssss                                         [ 12%]
tests/functional/bach/test_df.py s                                                     [ 13%]
tests/functional/bach/test_df_database_create.py s                                     [ 14%]
tests/functional/bach/test_df_describe.py sssssssss                                    [ 23%]
tests/functional/bach/test_df_from.py ss                                               [ 25%]
tests/functional/bach/test_df_from_pandas.py sssssss                                   [ 32%]
tests/functional/bach/test_df_groupby.py sss                                           [ 35%]
tests/functional/bach/test_df_materialize.py ssss                                      [ 39%]
tests/functional/bach/test_df_plot.py ssss                                             [ 43%]
tests/functional/bach/test_df_sample.py ssssssssss                                     [ 53%]
tests/functional/bach/test_df_savepoints.py s                                          [ 54%]
tests/functional/bach/test_df_sort_values.py s                                         [ 55%]
tests/functional/bach/test_df_variables.py s                                           [ 56%]
tests/functional/bach/test_pandas_loading.py sss                                       [ 59%]
tests/functional/bach/test_savepoints.py ssss                                          [ 63%]
tests/functional/bach/test_series.py sss                                               [ 66%]
tests/functional/bach/test_series_append.py s                                          [ 67%]
tests/functional/bach/test_series_describe.py sss                                      [ 70%]
tests/functional/bach/test_series_materialize.py ss                                    [ 72%]
tests/functional/bach/test_series_multi_level.py sssss                                 [ 77%]
tests/functional/bach/test_series_numeric.py ssss                                      [ 81%]
tests/functional/bach/test_series_timedelta.py s                                       [ 82%]
tests/functional/bach/test_series_value_counts.py s                                    [ 83%]
tests/functional/sql_models/test_sql_generator_materialization.py ss                   [ 85%]
tests/unit/bach/test_series_multi_level.py sssssssssssss                               [ 98%]
tests/unit/sql_models/test_sql_generator_materialization.py s                          [100%]

============================ 99 skipped, 507 deselected in 1.73s =============================
```