### PR TITLE
Bach[Athena]: fix dtype_to_expression str -> json

### DIFF
--- a/bach/bach/series/series_string.py
+++ b/bach/bach/series/series_string.py
@@ -10,7 +10,7 @@ from bach.partitioning import get_order_by_expression
 from bach.series import Series
 from bach.expression import Expression, AggregateFunctionExpression, get_variable_tokens, ConstValueExpression
 from bach.series.series import WrappedPartition
-from bach.types import StructuredDtype
+from bach.types import StructuredDtype, get_series_type_from_dtype
 from sql_models.constants import DBDialect
 from sql_models.util import DatabaseNotSupportedException, is_bigquery, is_postgres, is_athena
 
@@ -251,7 +251,9 @@ class SeriesString(Series):
         if source_dtype == 'string':
             return expression
 
-        if is_athena(dialect) and source_dtype == 'json':
+        series_type = get_series_type_from_dtype(source_dtype)
+        from bach.series import SeriesJson
+        if is_athena(dialect) and issubclass(series_type, SeriesJson):
             # casting directly to varchar will "deserialize" the json text, meaning that the string value
             # will be extracted as scalar. For example: "a string" will result into: a string
             # which yields different results compare to Postgres and BigQuery


### PR DESCRIPTION
Was not working for modelhub's objectiv series. This fixes some issues with the notebooks.