### PR TITLE
Revert "Revert "ModelHub[Athena]: Remove `skip_athena_todo` marker""

### DIFF
--- a/modelhub/pytest.ini
+++ b/modelhub/pytest.ini
@@ -13,7 +13,6 @@ markers =
     skip_postgres: Mark a test as testing code that does not need to work with Postgres.
     skip_bigquery: Mark a test as testing code that does not need to work with BigQuery.
     skip_athena: Mark a test as testing code that does not need to work with Athena.
-    skip_athena_todo: Temporary mark, mark a test as not yet passing for Athena, which should be fixed.
 
 
 # disable version check in tests

--- a/modelhub/tests_modelhub/conftest.py
+++ b/modelhub/tests_modelhub/conftest.py
@@ -25,8 +25,6 @@ Category 4, 5 and 6 are for functionality that we explicitly not support on some
 Category 4, 5 and 6 are the exception, these need to be marked with the `skip_postgres`,
 `skip_bigquery` or `skip_athena` marks.
 
-Temporarily, for Category 6 `skip_athena_todo` mark is also considered for skipping test run for Athena engine.
-This mark helps highlighting that the test MUST be supported by the engine and in a future we should work on it.
 """
 import os
 from urllib.parse import quote_plus
@@ -64,8 +62,6 @@ MARK_SKIP_POSTGRES = 'skip_postgres'
 MARK_SKIP_ATHENA = 'skip_athena'
 MARK_SKIP_BIGQUERY = 'skip_bigquery'
 
-# temporary mark, remove when all MH functionalities are supported for Athena
-MARK_SKIP_ATHENA_TODO = 'skip_athena_todo'
 
 def pytest_addoption(parser: Parser):
     # Add options for parameterizing multi-database tests for testing either Postgres, Bigquery, or both.
@@ -90,7 +86,7 @@ def pytest_generate_tests(metafunc: Metafunc):
     markers = list(metafunc.definition.iter_markers())
     skip_postgres = any(mark.name == MARK_SKIP_POSTGRES for mark in markers)
     skip_bigquery = any(mark.name == MARK_SKIP_BIGQUERY for mark in markers)
-    skip_athena = any(mark.name in (MARK_SKIP_ATHENA, MARK_SKIP_ATHENA_TODO) for mark in markers)
+    skip_athena = any(mark.name == MARK_SKIP_ATHENA for mark in markers)
     db_params = []
 
     testing_bq = metafunc.config.getoption("all") or metafunc.config.getoption("big_query")


### PR DESCRIPTION
Reverts objectiv/objectiv-analytics#1348 - which reverted https://github.com/objectiv/objectiv-analytics/pull/1297

Now that https://github.com/objectiv/objectiv-analytics/pull/1372 is merged, we really no longer need this.