### PR TITLE
Bach test athena bq improvements

### DIFF
--- a/bach/tests/functional/bach/test_df_from.py
+++ b/bach/tests/functional/bach/test_df_from.py
@@ -174,8 +174,8 @@ def _assert_df_supports_basic_operations(df: DataFrame):
     )
 
 
-@pytest.mark.skip_bigquery_todo()
-@pytest.mark.skip_athena_todo()
+@pytest.mark.skip_bigquery_todo('https://github.com/objectiv/objectiv-analytics/issues/1375')
+@pytest.mark.skip_athena_todo('https://github.com/objectiv/objectiv-analytics/issues/1375')
 def test_from_model_basic(engine, unique_table_test_name):
     # This is essentially the same test as test_from_table_basic(), but tests creating the dataframe with
     # from_model instead of from_table
@@ -236,8 +236,8 @@ def test_from_table_column_ordering(engine, unique_table_test_name):
     assert df == df_all_dtypes
 
 
-@pytest.mark.skip_bigquery_todo()
-@pytest.mark.skip_athena_todo()
+@pytest.mark.skip_bigquery_todo('https://github.com/objectiv/objectiv-analytics/issues/1375')
+@pytest.mark.skip_athena_todo('https://github.com/objectiv/objectiv-analytics/issues/1375')
 def test_from_model_column_ordering(engine, unique_table_test_name):
     # This is essentially the same test as test_from_table_model_ordering(), but tests creating the dataframe with
     # from_model instead of from_table

--- a/bach/tests/functional/bach/test_df_from_pandas.py
+++ b/bach/tests/functional/bach/test_df_from_pandas.py
@@ -49,7 +49,7 @@ TYPES_COLUMNS = ['int_column', 'float_column', 'bool_column', 'datetime_column',
                  'dict_column', 'timedelta_column', 'mixed_column']
 
 
-@pytest.mark.skip_athena_todo()  # TODO: Athena
+@pytest.mark.skip_athena_todo('https://github.com/objectiv/objectiv-analytics/issues/1376')
 def test_from_pandas_table(engine, unique_table_test_name):
     pdf = get_pandas_df(TEST_DATA_CITIES, CITIES_COLUMNS)
     bt = DataFrame.from_pandas(
@@ -63,7 +63,7 @@ def test_from_pandas_table(engine, unique_table_test_name):
     assert_equals_data(bt, expected_columns=EXPECTED_COLUMNS, expected_data=EXPECTED_DATA)
 
 
-@pytest.mark.skip_athena_todo()  # TODO: Athena
+@pytest.mark.skip_athena_todo('https://github.com/objectiv/objectiv-analytics/issues/1376')
 def test_from_pandas_table_injection(engine, unique_table_test_name):
     pdf = get_pandas_df(TEST_DATA_INJECTION, COLUMNS_INJECTION)
     bt = DataFrame.from_pandas(
@@ -116,7 +116,7 @@ def test_from_pandas_ephemeral_injection(engine):
     )
 
 
-@pytest.mark.skip_athena_todo()  # TODO: Athena
+@pytest.mark.skip_athena_todo('https://github.com/objectiv/objectiv-analytics/issues/1376')
 def test_from_pandas_non_happy_path(engine, unique_table_test_name):
     pdf = get_pandas_df(TEST_DATA_CITIES, CITIES_COLUMNS)
     with pytest.raises(TypeError):
@@ -149,8 +149,8 @@ def test_from_pandas_non_happy_path(engine, unique_table_test_name):
         )
 
 
-@pytest.mark.skip_athena_todo()  # TODO: Athena
-@pytest.mark.skip_bigquery_todo()
+@pytest.mark.skip_athena_todo('https://github.com/objectiv/objectiv-analytics/issues/1376')
+@pytest.mark.skip_bigquery_todo('https://github.com/objectiv/objectiv-analytics/issues/1377')
 @pytest.mark.parametrize("materialization", ['cte', 'table'])
 def test_from_pandas_index(materialization: str, engine, unique_table_test_name):
     # test multilevel index
@@ -195,8 +195,8 @@ def test_from_pandas_index(materialization: str, engine, unique_table_test_name)
         expected_data=[[idx] + x[1:] for idx, x in enumerate(EXPECTED_DATA)])
 
 
-@pytest.mark.skip_athena_todo()  # TODO: Athena
-@pytest.mark.skip_bigquery_todo()
+@pytest.mark.skip_athena_todo('https://github.com/objectiv/objectiv-analytics/issues/1376')
+@pytest.mark.skip_bigquery_todo('https://github.com/objectiv/objectiv-analytics/issues/1377')
 @pytest.mark.parametrize("materialization", ['cte', 'table'])
 def test_from_pandas_types(materialization: str, engine, unique_table_test_name):
     pdf = pd.DataFrame.from_records(TYPES_DATA, columns=TYPES_COLUMNS)

--- a/bach/tests/functional/bach/test_df_variables.py
+++ b/bach/tests/functional/bach/test_df_variables.py
@@ -197,7 +197,7 @@ def test_merge_variable_different_types(engine):
     )
 
 
-@pytest.mark.skip_athena_todo()  # TODO: Athena
+@pytest.mark.skip_athena_todo('https://github.com/objectiv/objectiv-analytics/issues/1375')
 def test_get_all_variable_usage(engine):
     df1 = get_df_with_test_data(engine, full_data_set=False)[['skating_order', 'inhabitants']]
     assert df1.get_all_variable_usage() == []
@@ -235,6 +235,7 @@ def test_get_all_variable_usage(engine):
     ]
 
     if is_bigquery(df1.engine):
+        # TODO remove this check after in 'https://github.com/objectiv/objectiv-analytics/issues/1375'
         # DataFrame.from_model is not supported for big query
         return
 

--- a/bach/tests/functional/bach/test_series.py
+++ b/bach/tests/functional/bach/test_series.py
@@ -250,8 +250,8 @@ def test_aggregation(engine):
         s.agg(['sum','sum'])
 
 
-@pytest.mark.skip_athena_todo()
-@pytest.mark.skip_bigquery_todo()
+@pytest.mark.skip_athena_todo('https://github.com/objectiv/objectiv-analytics/issues/1042')
+@pytest.mark.skip_bigquery_todo('https://github.com/objectiv/objectiv-analytics/issues/1042')
 def test_type_agnostic_aggregation_functions(engine):
     bt = get_df_with_test_data(engine=engine, full_data_set=True)
     btg = bt.groupby()
@@ -382,7 +382,7 @@ def test_series_inherit_flag(engine):
     assert not bts_derived.expression.has_aggregate_function
 
 
-@pytest.mark.skip_bigquery_todo()
+@pytest.mark.skip_bigquery_todo('https://github.com/objectiv/objectiv-analytics/issues/1043')
 def test_series_independant_subquery_any_value_all_values(engine):
     bt = get_df_with_test_data(engine=engine, full_data_set=True)
     s = bt.inhabitants.max() // 4
@@ -505,12 +505,10 @@ def test_series_dropna(engine) -> None:
     )
 
 
-@pytest.mark.skip_athena_todo()
-@pytest.mark.skip_bigquery_todo()
 def test_series_unstack(engine):
     bt = get_df_with_test_data(engine=engine, full_data_set=True)
 
-    stacked_bt = bt.groupby(['city','municipality']).inhabitants.sum()
+    stacked_bt = bt.groupby(['city', 'municipality']).inhabitants.sum()
     unstacked_bt = stacked_bt.unstack()
 
     expected_columns = [
@@ -521,6 +519,7 @@ def test_series_unstack(engine):
 
     assert_equals_data(
         unstacked_bt_sorted,
+        use_to_pandas=True,
         expected_columns=['city'] + expected_columns,
         expected_data=[
             ['Boalsert', None, None, None, None, 10120, None],
@@ -547,6 +546,7 @@ def test_series_unstack(engine):
 
     assert_equals_data(
         unstacked_bt_sorted,
+        use_to_pandas=True,
         expected_columns=['municipality'] + expected_columns,
         expected_data=[
             ['De Friese Meren', 'buh', 'buh', 'buh', 'buh', 'buh', 'Sleat', 'buh', 'buh', 'buh', 'buh', 'buh'],
@@ -571,6 +571,7 @@ def test_series_unstack(engine):
 
     assert_equals_data(
         unstacked_bt_sorted,
+        use_to_pandas=True,
         expected_columns=['skating_order'] + expected_columns,
         expected_data=[
             [1, None, 93485., None],

--- a/bach/tests/functional/bach/test_series_append.py
+++ b/bach/tests/functional/bach/test_series_append.py
@@ -48,7 +48,7 @@ def test_series_append_column_name_special_chars(engine) -> None:
     )
 
 
-#@pytest.mark.skip_athena_todo()  # TODO: remove '.0' from stringified float
+@pytest.mark.skip_athena_todo('https://github.com/objectiv/objectiv-analytics/issues/1379')
 def test_series_append_different_dtype(engine) -> None:
     bt = get_df_with_test_data(engine, full_data_set=False)[['city', 'inhabitants', 'founding']]
     bt['founding'] = bt['founding'].astype('float64')

--- a/bach/tests/functional/bach/test_series_append.py
+++ b/bach/tests/functional/bach/test_series_append.py
@@ -48,7 +48,7 @@ def test_series_append_column_name_special_chars(engine) -> None:
     )
 
 
-@pytest.mark.skip_athena_todo()  # TODO: remove '.0' from stringified float
+#@pytest.mark.skip_athena_todo()  # TODO: remove '.0' from stringified float
 def test_series_append_different_dtype(engine) -> None:
     bt = get_df_with_test_data(engine, full_data_set=False)[['city', 'inhabitants', 'founding']]
     bt['founding'] = bt['founding'].astype('float64')

--- a/bach/tests/unit/sql_models/test_sql_generator.py
+++ b/bach/tests/unit/sql_models/test_sql_generator.py
@@ -126,7 +126,6 @@ class MultiplierWithId(SqlModelBuilder):
         '''
 
 
-@pytest.mark.skip_bigquery_todo()
 def test_model_thrice_simple(dialect):
     model = Double.build(
         source=Double(
@@ -149,6 +148,12 @@ def test_model_thrice_simple(dialect):
         select (val * 2) as val
         from "Double___82474fb08efe26024ac77a358a288af8"
     '''
+    if is_bigquery(dialect):
+        # replace " with `, except for "" which becomes a single "
+        expected = expected\
+            .replace('""', 'TMP_QUOTE')\
+            .replace('"', '`') \
+            .replace('TMP_QUOTE', '"')
     assert_roughly_equal_sql(result, expected)
 
 


### PR DESCRIPTION
Two changes:
* Make some tests work with Athena/BigQuery:
  * `test_positional_slicing()`
  * `test_series_unstack()`
* Created issues for non-working tests, and linked those in the `skip_*_todo` marks