### PR TITLE
Bach get dtypes from model

### DIFF
--- a/bach/bach/dataframe.py
+++ b/bach/bach/dataframe.py
@@ -606,8 +606,9 @@ class DataFrame:
         """
         Instantiate a new DataFrame based on the result of the query defined in `model`.
 
-        If all_dtypes is not specified, then a transaction scoped temporary table will be created with
-        0 result rows from the model. The meta data of this table will be used to deduce the dtypes.
+        If all_dtypes is not specified, then the model is compiled to sql and executed as a query on the
+        database. The result-set's meta data is used to determine the columns and dtypes. This might not work
+        with custom data types. If the all_dtypes data is available, it's advised to provide it.
 
         :param engine: a sqlalchemy engine for the database.
         :param model: an SqlModel that specifies the queries to instantiate as DataFrame.
@@ -622,8 +623,7 @@ class DataFrame:
         :returns: A DataFrame based on an SqlModel
 
         .. note::
-            If all_dtypes is not set, then this will query the database and create and remove a temporary
-            table.
+            If all_dtypes is not set, then this will query the database
         """
         name_to_column_mapping = name_to_column_mapping if name_to_column_mapping else {}
         if all_dtypes is not None:

--- a/bach/bach/from_database.py
+++ b/bach/bach/from_database.py
@@ -1,9 +1,9 @@
 """
 Copyright 2022 Objectiv B.V.
 """
-from typing import Dict, Tuple, Mapping, Optional
+from typing import Dict, Tuple, Mapping, Optional, List, Union
 
-from sqlalchemy.engine import Engine
+from sqlalchemy.engine import Engine, Dialect
 
 from bach.expression import Expression, join_expressions
 from bach.types import get_dtype_from_db_dtype, StructuredDtype
@@ -13,6 +13,32 @@ from sql_models.model import SqlModel, CustomSqlModelBuilder
 from sql_models.sql_generator import to_sql
 from sql_models.util import is_postgres, DatabaseNotSupportedException, is_bigquery, is_athena
 
+_DB_TYPE_CODE_TO_DB_TYPE: Mapping[DBDialect, Mapping[Union[int, str], str]] = {
+    # mapping from database driver type-code to actual database types. See inline comments of
+    # get_dtypes_from_model() for more information.
+    DBDialect.POSTGRES: {
+        # Based on `select oid, typname from pg_type order by oid;`
+        16: 'boolean',
+        20: 'bigint',
+        25: 'text',
+        114: 'json',
+        701: 'double precision',
+        1082: 'date',
+        1083: 'time',
+        1114: 'timestamp without time zone',
+        1186: 'interval',
+        2950: 'uuid',
+        3906: 'numrange',
+    },
+    DBDialect.ATHENA: {},
+    DBDialect.BIGQUERY: {
+        # Based on experimental
+        'BOOLEAN': 'BOOL',
+        'FLOAT': 'FLOAT64',
+        'INTEGER': 'INT64',
+    }
+}
+
 
 def get_dtypes_from_model(
         engine: Engine,
@@ -20,32 +46,36 @@ def get_dtypes_from_model(
         name_to_column_mapping: Optional[Mapping[str, str]] = None
 ) -> Dict[str, StructuredDtype]:
     """
-    Create a temporary database table from model and use it to deduce the model's dtypes.
+    Execute the model with limit 0 and use result to deduce the model's dtypes.
 
-    Does not support all database engines.
+    This function relies on a static mapping of the type-code returned by the database driver to the database
+    type. As a result custom types might not work.
 
     :return: Dictionary with as key the column names, and as values the dtype of the column.
     """
     name_to_column_mapping = name_to_column_mapping if name_to_column_mapping else {}
-    if not is_postgres(engine):
-        message_override = f'We cannot automatically derive dtypes from a SqlModel for database ' \
-                           f'dialect "{engine.name}".'
-        raise DatabaseNotSupportedException(engine, message_override=message_override)
+    type_code_mapping = _DB_TYPE_CODE_TO_DB_TYPE[DBDialect.from_engine(engine)]
+
     new_node = CustomSqlModelBuilder(sql='select * from {{previous}} limit 0')(previous=node)
     select_statement = to_sql(dialect=engine.dialect, model=new_node)
-    sql = f"""
-        create temporary table tmp_table_name on commit drop as
-        ({select_statement});
-        select column_name, data_type
-        from information_schema.columns
-        where table_name = 'tmp_table_name'
-        order by ordinal_position;
-    """
-    return _get_dtypes_from_information_schema_query(
-        engine=engine,
-        query=sql,
+    with engine.connect() as conn:
+        sql = escape_parameter_characters(conn, select_statement)
+        res = conn.execute(sql)
+        # See https://peps.python.org/pep-0249/#description for information what is in description.
+        # Unfortunately, the type_code is not the same as the database type on all databases. Therefore, we
+        # need to map it to the actual database type
+        description = res.cursor.description
+
+    rows = [
+        (row[0], type_code_mapping.get(row[1], row[1]))
+        for row in description
+    ]
+    result = _get_dtype_from_db_type(
+        dialect=engine.dialect,
+        rows=rows,
         name_to_column_mapping=name_to_column_mapping
     )
+    return result
 
 
 def get_dtypes_from_table(
@@ -126,13 +156,31 @@ def _get_dtypes_from_information_schema_query(
     If name_to_column_mapping is incomplete, the column names that the query renders will be assumed to be
     series-names.
     """
-    column_to_name_mapping = {column: name for name, column in name_to_column_mapping.items()}
     with engine.connect() as conn:
         sql = escape_parameter_characters(conn, query)
         res = conn.execute(sql)
-        rows = res.fetchall()
+        rows = [(row[0], row[1]) for row in res.fetchall()]
 
-    db_dialect = DBDialect.from_engine(engine)
+    return _get_dtype_from_db_type(
+        dialect=engine.dialect,
+        rows=rows,
+        name_to_column_mapping=name_to_column_mapping
+    )
+
+
+def _get_dtype_from_db_type(
+        dialect: Dialect,
+        rows: List[Tuple[str, str]],
+        name_to_column_mapping: Mapping[str, str]
+) -> Dict[str, StructuredDtype]:
+    """
+    Return dictionary mapping series names to dtypes.
+    :param dialect: dialect
+    :param rows: List of tuples. Each tuple: [0] column name, [1] db_dtype
+    :param name_to_column_mapping: Used to map series names to column names
+    """
+    db_dialect = DBDialect.from_dialect(dialect)
+    column_to_name_mapping = {column: name for name, column in name_to_column_mapping.items()}
     result = {}
     for row in rows:
         column_name, db_dtype = row

--- a/bach/tests/functional/bach/test_df_from.py
+++ b/bach/tests/functional/bach/test_df_from.py
@@ -87,8 +87,8 @@ def _create_test_table(engine: Engine, table_name: str, add_data: bool):
 @pytest.mark.skip_postgres
 @pytest.mark.skip_athena
 def test_from_table_structural_big_query(engine, unique_table_test_name):
-    # Test specifically for structural types on BigQuery. We don't support that on Postgres, so we skip
-    # postgres for this test
+    # Test specifically for structural types on BigQuery. We don't support that on Postgres or Athena, so we
+    # skip those for this test
     table_name = unique_table_test_name
     sql = f'drop table if exists {table_name}; ' \
           f'create table {table_name}(' \
@@ -174,8 +174,6 @@ def _assert_df_supports_basic_operations(df: DataFrame):
     )
 
 
-@pytest.mark.skip_bigquery_todo('https://github.com/objectiv/objectiv-analytics/issues/1375')
-@pytest.mark.skip_athena_todo('https://github.com/objectiv/objectiv-analytics/issues/1375')
 def test_from_model_basic(engine, unique_table_test_name):
     # This is essentially the same test as test_from_table_basic(), but tests creating the dataframe with
     # from_model instead of from_table
@@ -184,10 +182,16 @@ def test_from_model_basic(engine, unique_table_test_name):
     sql_model: SqlModel = CustomSqlModelBuilder(sql=f'select * from {table_name}')()
 
     df = DataFrame.from_model(engine=engine, model=sql_model, index=['a'])
+    expected_dtypes = {'b': 'string', 'c': 'float64', 'd': 'date', 'e': 'timestamp', 'F': 'bool'}
+    expected_base_node_columns = ('a', 'b', 'c', 'd', 'e', 'F')
+    if is_athena(engine):  # Athena automatically lower-cases capital letters in column-names of tables.
+        expected_dtypes = {'b': 'string', 'c': 'float64', 'd': 'date', 'e': 'timestamp', 'f': 'bool'}
+        expected_base_node_columns = ('a', 'b', 'c', 'd', 'e', 'f')
+
     assert df.index_dtypes == {'a': 'int64'}
-    assert df.dtypes == {'b': 'string', 'c': 'float64', 'd': 'date', 'e': 'timestamp', 'F': 'bool'}
+    assert df.dtypes == expected_dtypes
     assert df.is_materialized
-    assert df.base_node.series_names == ('a', 'b', 'c', 'd', 'e', 'F')
+    assert df.base_node.series_names == expected_base_node_columns
     # there should only be a single model that selects from the table, not a whole tree
     assert df.base_node.references == {}
     # Now do some basic operations to establish that the DataFrame instance we got is fully functional.
@@ -196,9 +200,12 @@ def test_from_model_basic(engine, unique_table_test_name):
     _assert_df_supports_basic_operations(df)
 
     # now create same DataFrame, but specify all_dtypes.
+    all_dtypes = {'a': 'int64', 'b': 'string', 'c': 'float64', 'd': 'date', 'e': 'timestamp', 'F': 'bool'}
+    if is_athena(engine):
+        all_dtypes = {k.lower(): v for k, v in all_dtypes.items()}
     df_all_dtypes = DataFrame.from_model(
         engine=engine, model=sql_model, index=['a'],
-        all_dtypes={'a': 'int64', 'b': 'string', 'c': 'float64', 'd': 'date', 'e': 'timestamp', 'F': 'bool'}
+        all_dtypes=all_dtypes
     )
     assert df == df_all_dtypes
 
@@ -236,8 +243,6 @@ def test_from_table_column_ordering(engine, unique_table_test_name):
     assert df == df_all_dtypes
 
 
-@pytest.mark.skip_bigquery_todo('https://github.com/objectiv/objectiv-analytics/issues/1375')
-@pytest.mark.skip_athena_todo('https://github.com/objectiv/objectiv-analytics/issues/1375')
 def test_from_model_column_ordering(engine, unique_table_test_name):
     # This is essentially the same test as test_from_table_model_ordering(), but tests creating the dataframe with
     # from_model instead of from_table
@@ -248,19 +253,29 @@ def test_from_model_column_ordering(engine, unique_table_test_name):
     sql_model: SqlModel = CustomSqlModelBuilder(sql=f'select * from {table_name}')()
 
     df = DataFrame.from_model(engine=engine, model=sql_model, index=['b'])
+
+    expected_dtypes = {'a': 'int64', 'c': 'float64', 'd': 'date', 'e': 'timestamp', 'F': 'bool'}
+    expected_base_node_columns = ('b', 'a', 'c', 'd', 'e', 'F')
+    if is_athena(engine):  # Athena automatically lower-cases capital letters in column-names of tables.
+        expected_dtypes = {k.lower(): v for k, v in expected_dtypes.items()}
+        expected_base_node_columns = tuple(n.lower() for n in expected_base_node_columns)
+
     assert df.index_dtypes == {'b': 'string'}
-    assert df.dtypes == {'a': 'int64', 'c': 'float64', 'd': 'date', 'e': 'timestamp', 'F': 'bool'}
+    assert df.dtypes == expected_dtypes
     assert df.is_materialized
     # We should have an extra model in the sql-model graph, because 'b' is the index and should thus be the
     # first column.
-    assert df.base_node.series_names == ('b', 'a', 'c', 'd', 'e', 'F')
+    assert df.base_node.series_names == expected_base_node_columns
     assert 'prev' in df.base_node.references
     assert df.base_node.references['prev'].references == {}
     df.to_pandas()  # test that the main function works on the created DataFrame
 
+    all_dtypes = {'a': 'int64', 'b': 'string', 'c': 'float64', 'd': 'date', 'e': 'timestamp', 'F': 'bool'}
+    if is_athena(engine):
+        all_dtypes = {k.lower(): v for k, v in all_dtypes.items()}
     df_all_dtypes = DataFrame.from_model(
         engine=engine, model=sql_model, index=['b'],
-        all_dtypes={'a': 'int64', 'b': 'string', 'c': 'float64', 'd': 'date', 'e': 'timestamp', 'F': 'bool'}
+        all_dtypes=all_dtypes
     )
     assert df == df_all_dtypes
 

--- a/bach/tests/functional/bach/test_df_variables.py
+++ b/bach/tests/functional/bach/test_df_variables.py
@@ -197,7 +197,6 @@ def test_merge_variable_different_types(engine):
     )
 
 
-@pytest.mark.skip_athena_todo('https://github.com/objectiv/objectiv-analytics/issues/1375')
 def test_get_all_variable_usage(engine):
     df1 = get_df_with_test_data(engine, full_data_set=False)[['skating_order', 'inhabitants']]
     assert df1.get_all_variable_usage() == []
@@ -233,11 +232,6 @@ def test_get_all_variable_usage(engine):
         DefinedVariable(name='second', dtype='string', value='test', ref_path=(), old_value=str_old_value),
         DefinedVariable(name='first', dtype='int64', value=1234, ref_path=('prev',), old_value='1234')
     ]
-
-    if is_bigquery(df1.engine):
-        # TODO remove this check after in 'https://github.com/objectiv/objectiv-analytics/issues/1375'
-        # DataFrame.from_model is not supported for big query
-        return
 
     sql_model = CustomSqlModelBuilder(sql='select * from {{model}}')(model=df1.base_node)
     df2 = DataFrame.from_model(engine=df1.engine, model=sql_model, index=list(df1.index.keys()))


### PR DESCRIPTION
Changes:
* `get_dtypes_from_model()` execute sql-model with `limit 0`, and look at meta-data from cursor to determine the types. This works across all databases
* Enable tests that now work