### PR TITLE
Migrate all imports of assert_equals_data to use the new location

### DIFF
--- a/bach/tests/functional/bach/test_bt_custom_types.py
+++ b/bach/tests/functional/bach/test_bt_custom_types.py
@@ -6,9 +6,10 @@ from sqlalchemy.engine import Dialect
 
 from bach import Series
 from bach.expression import Expression
+from bach.testing import assert_equals_data
 from bach.types import TypeRegistry
 from sql_models.constants import DBDialect
-from tests.functional.bach.test_data_and_utils import assert_equals_data, get_df_with_test_data
+from tests.functional.bach.test_data_and_utils import get_df_with_test_data
 
 
 class ReversedStringType(Series):

--- a/bach/tests/functional/bach/test_data_and_utils.py
+++ b/bach/tests/functional/bach/test_data_and_utils.py
@@ -16,7 +16,6 @@ from bach import DataFrame, Series
 from sql_models.constants import DBDialect
 from sql_models.util import is_bigquery, quote_identifier
 from tests.unit.bach.util import get_pandas_df
-from bach.testing import assert_equals_data
 
 # Three data tables for testing are defined here that can be used in tests
 # 1. cities: 3 rows (or 11 for the full dataset) of data on cities

--- a/bach/tests/functional/bach/test_df.py
+++ b/bach/tests/functional/bach/test_df.py
@@ -5,7 +5,8 @@ import numpy as np
 import pandas as pd
 import pytest
 from bach import DataFrame, SeriesBoolean
-from tests.functional.bach.test_data_and_utils import assert_equals_data, get_df_with_test_data
+from bach.testing import assert_equals_data
+from tests.functional.bach.test_data_and_utils import get_df_with_test_data
 
 
 def test_basic(engine):

--- a/bach/tests/functional/bach/test_df_append.py
+++ b/bach/tests/functional/bach/test_df_append.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 
 from bach import DataFrame
-from tests.functional.bach.test_data_and_utils import assert_equals_data
+from bach.testing import assert_equals_data
 
 
 def test_append_w_aligned_columns(engine) -> None:

--- a/bach/tests/functional/bach/test_df_astype.py
+++ b/bach/tests/functional/bach/test_df_astype.py
@@ -7,9 +7,10 @@ import pytest
 
 from bach import SeriesFloat64, SeriesString, SeriesInt64, SeriesBoolean, SeriesDate, SeriesTimestamp, \
     SeriesTime, SeriesJson
+from bach.testing import assert_equals_data
 from sql_models.constants import DBDialect
 from sql_models.util import is_postgres
-from tests.functional.bach.test_data_and_utils import assert_equals_data, get_df_with_json_data, \
+from tests.functional.bach.test_data_and_utils import get_df_with_json_data, \
     CITIES_INDEX_AND_COLUMNS, get_df_with_test_data, assert_series_db_types
 
 

--- a/bach/tests/functional/bach/test_df_database_create.py
+++ b/bach/tests/functional/bach/test_df_database_create.py
@@ -5,8 +5,9 @@ from random import randrange
 
 import pytest
 
+from bach.testing import assert_equals_data
 from sql_models.model import Materialization
-from tests.functional.bach.test_data_and_utils import get_df_with_test_data, assert_equals_data
+from tests.functional.bach.test_data_and_utils import get_df_with_test_data
 from sql_models.sql_generator import to_sql
 
 

--- a/bach/tests/functional/bach/test_df_drop_duplicates.py
+++ b/bach/tests/functional/bach/test_df_drop_duplicates.py
@@ -2,7 +2,7 @@ import pandas as pd
 import pytest
 
 from bach import DataFrame
-from tests.functional.bach.test_data_and_utils import assert_equals_data
+from bach.testing import assert_equals_data
 
 
 def test_df_basic_drop_duplicates(engine) -> None:

--- a/bach/tests/functional/bach/test_df_fillna.py
+++ b/bach/tests/functional/bach/test_df_fillna.py
@@ -8,7 +8,7 @@ import pytest
 from datetime import datetime
 
 from bach import DataFrame
-from tests.functional.bach.test_data_and_utils import assert_equals_data
+from bach.testing import assert_equals_data
 
 
 DATA = [

--- a/bach/tests/functional/bach/test_df_from.py
+++ b/bach/tests/functional/bach/test_df_from.py
@@ -12,13 +12,13 @@ import pytest
 from sqlalchemy.engine import Engine
 
 from bach import DataFrame
+from bach.testing import assert_equals_data
 from bach.utils import merge_sql_statements
 from sql_models.constants import DBDialect
 from sql_models.model import CustomSqlModelBuilder, SqlModel, Materialization
 from sql_models.sql_generator import to_sql
 from sql_models.util import is_athena
 from tests.conftest import DB_ATHENA_LOCATION
-from tests.functional.bach.test_data_and_utils import assert_equals_data
 
 
 def _create_test_table(engine: Engine, table_name: str, add_data: bool):

--- a/bach/tests/functional/bach/test_df_from_pandas.py
+++ b/bach/tests/functional/bach/test_df_from_pandas.py
@@ -4,9 +4,10 @@ Copyright 2021 Objectiv B.V.
 import pytest
 
 from bach import DataFrame, SeriesFloat64, SeriesInt64, SeriesBoolean, SeriesTimestamp, SeriesString
+from bach.testing import assert_equals_data
 from sql_models.constants import DBDialect
 from tests.functional.bach.test_data_and_utils import TEST_DATA_CITIES, CITIES_COLUMNS, \
-    assert_equals_data, convert_expected_data_timestamps, assert_series_db_types
+    convert_expected_data_timestamps, assert_series_db_types
 import datetime
 from uuid import UUID
 import pandas as pd

--- a/bach/tests/functional/bach/test_df_get_dummies.py
+++ b/bach/tests/functional/bach/test_df_get_dummies.py
@@ -2,8 +2,8 @@ import pandas as pd
 import pytest
 
 from bach import DataFrame
+from bach.testing import assert_equals_data
 from sql_models.util import is_postgres
-from tests.functional.bach.test_data_and_utils import assert_equals_data
 
 
 def test_basic_get_dummies(engine) -> None:

--- a/bach/tests/functional/bach/test_df_getitem.py
+++ b/bach/tests/functional/bach/test_df_getitem.py
@@ -7,8 +7,8 @@ from typing import List
 import pytest
 
 from bach import DataFrame, Series, SeriesDict
-from tests.functional.bach.test_data_and_utils import assert_equals_data, df_to_list, \
-    get_df_with_test_data, TEST_DATA_CITIES_FULL
+from bach.testing import assert_equals_data
+from tests.functional.bach.test_data_and_utils import get_df_with_test_data, TEST_DATA_CITIES_FULL
 
 
 def test_get_item_single(engine):

--- a/bach/tests/functional/bach/test_df_indexing.py
+++ b/bach/tests/functional/bach/test_df_indexing.py
@@ -4,7 +4,8 @@ import pandas as pd
 import pytest
 
 from bach import Series, DataFrame
-from tests.functional.bach.test_data_and_utils import assert_equals_data, get_df_with_test_data
+from bach.testing import assert_equals_data
+from tests.functional.bach.test_data_and_utils import get_df_with_test_data
 
 
 @pytest.fixture()

--- a/bach/tests/functional/bach/test_df_materialize.py
+++ b/bach/tests/functional/bach/test_df_materialize.py
@@ -8,11 +8,11 @@ import pytest
 from sqlalchemy.engine import Engine
 
 from bach import SeriesUuid
+from bach.testing import assert_equals_data
 from sql_models.graph_operations import get_graph_nodes_info
 from sql_models.model import Materialization
 from sql_models.util import is_bigquery, is_postgres, is_athena
-from tests.functional.bach.test_data_and_utils import assert_equals_data, get_df_with_test_data, \
-    get_df_with_json_data
+from tests.functional.bach.test_data_and_utils import get_df_with_test_data, get_df_with_json_data
 
 
 @pytest.mark.parametrize("inplace", [False, True])

--- a/bach/tests/functional/bach/test_df_merge.py
+++ b/bach/tests/functional/bach/test_df_merge.py
@@ -7,10 +7,10 @@ import pandas as pd
 import pytest
 
 from bach import DataFrame
+from bach.testing import assert_equals_data
 
 from tests.functional.bach.test_data_and_utils import (
-    get_df_with_test_data, get_df_with_food_data,
-    assert_equals_data, get_df_with_railway_data
+    get_df_with_test_data, get_df_with_food_data, get_df_with_railway_data
 )
 
 

--- a/bach/tests/functional/bach/test_df_rename.py
+++ b/bach/tests/functional/bach/test_df_rename.py
@@ -2,7 +2,8 @@
 Copyright 2021 Objectiv B.V.
 """
 from sql_models.util import is_bigquery, is_athena
-from tests.functional.bach.test_data_and_utils import assert_equals_data, get_df_with_test_data
+from bach.testing import assert_equals_data
+from tests.functional.bach.test_data_and_utils import get_df_with_test_data
 
 EXPECTED_DATA = [
     [1, 1, 'Ljouwert', 'Leeuwarden', 93485, 1285],

--- a/bach/tests/functional/bach/test_df_reset_index.py
+++ b/bach/tests/functional/bach/test_df_reset_index.py
@@ -3,7 +3,8 @@ Copyright 2021 Objectiv B.V.
 """
 import pytest
 
-from tests.functional.bach.test_data_and_utils import assert_equals_data, get_df_with_test_data
+from bach.testing import assert_equals_data
+from tests.functional.bach.test_data_and_utils import get_df_with_test_data
 
 
 def test_reset_index_to_empty(engine):

--- a/bach/tests/functional/bach/test_df_sample.py
+++ b/bach/tests/functional/bach/test_df_sample.py
@@ -5,9 +5,10 @@ from typing import Optional
 
 import pytest
 
+from bach.testing import assert_equals_data
 from sql_models.graph_operations import get_graph_nodes_info
 from sql_models.util import is_bigquery, is_postgres, is_athena
-from tests.functional.bach.test_data_and_utils import assert_equals_data, get_df_with_test_data
+from tests.functional.bach.test_data_and_utils import get_df_with_test_data
 
 
 def test_get_sample(engine, unique_table_test_name):

--- a/bach/tests/functional/bach/test_df_savepoints.py
+++ b/bach/tests/functional/bach/test_df_savepoints.py
@@ -4,8 +4,9 @@ Copyright 2021 Objectiv B.V.
 import pytest
 
 from bach.savepoints import CreatedObject
+from bach.testing import assert_equals_data
 from sql_models.model import Materialization
-from tests.functional.bach.test_data_and_utils import assert_equals_data, get_df_with_test_data
+from tests.functional.bach.test_data_and_utils import get_df_with_test_data
 from tests.functional.bach.test_savepoints import remove_created_db_objects
 
 

--- a/bach/tests/functional/bach/test_df_scale.py
+++ b/bach/tests/functional/bach/test_df_scale.py
@@ -1,8 +1,9 @@
 import pytest
 from sklearn.preprocessing import StandardScaler, MinMaxScaler
 
+from bach.testing import assert_equals_data
 from tests.functional.bach.test_data_and_utils import (
-    get_df_with_test_data, assert_equals_data,
+    get_df_with_test_data,
     TEST_DATA_CITIES_FULL, CITIES_COLUMNS
 )
 import numpy as np

--- a/bach/tests/functional/bach/test_df_setitem.py
+++ b/bach/tests/functional/bach/test_df_setitem.py
@@ -11,9 +11,10 @@ from pandas.core.indexes.numeric import Int64Index
 
 from bach import SeriesInt64, SeriesString, SeriesFloat64, SeriesDate, SeriesTimestamp, \
     SeriesTime, SeriesTimedelta, Series, SeriesJson, SeriesBoolean
+from bach.testing import assert_equals_data
 from sql_models.constants import DBDialect
-from tests.functional.bach.test_data_and_utils import assert_equals_data, CITIES_INDEX_AND_COLUMNS,\
-    get_df_with_test_data, get_df_with_railway_data, assert_series_db_types
+from tests.functional.bach.test_data_and_utils import CITIES_INDEX_AND_COLUMNS, get_df_with_test_data,\
+    get_df_with_railway_data, assert_series_db_types
 
 
 def check_set_const(

--- a/bach/tests/functional/bach/test_df_sort_index.py
+++ b/bach/tests/functional/bach/test_df_sort_index.py
@@ -1,7 +1,7 @@
 import pytest
 
-from tests.functional.bach.test_data_and_utils import assert_equals_data, \
-    get_df_with_test_data, get_df_with_railway_data
+from bach.testing import assert_equals_data
+from tests.functional.bach.test_data_and_utils import get_df_with_test_data, get_df_with_railway_data
 
 
 def test_sort_index_basic(engine):

--- a/bach/tests/functional/bach/test_df_sort_values.py
+++ b/bach/tests/functional/bach/test_df_sort_values.py
@@ -8,7 +8,8 @@ import pandas as pd
 import pytest
 
 from bach import DataFrame
-from tests.functional.bach.test_data_and_utils import assert_equals_data, df_to_list, get_df_with_test_data
+from bach.testing import assert_equals_data
+from tests.functional.bach.test_data_and_utils import df_to_list, get_df_with_test_data
 
 
 @pytest.fixture

--- a/bach/tests/functional/bach/test_df_stack.py
+++ b/bach/tests/functional/bach/test_df_stack.py
@@ -1,6 +1,7 @@
 import pandas as pd
 
-from tests.functional.bach.test_data_and_utils import assert_equals_data, get_df_with_test_data
+from bach.testing import assert_equals_data
+from tests.functional.bach.test_data_and_utils import get_df_with_test_data
 
 
 def test_stack(engine) -> None:

--- a/bach/tests/functional/bach/test_df_unstack.py
+++ b/bach/tests/functional/bach/test_df_unstack.py
@@ -1,6 +1,7 @@
 import pytest
 
-from tests.functional.bach.test_data_and_utils import get_df_with_test_data, assert_equals_data
+from bach.testing import assert_equals_data
+from tests.functional.bach.test_data_and_utils import get_df_with_test_data
 
 
 def test_basic_unstack(engine) -> None:

--- a/bach/tests/functional/bach/test_df_value_counts.py
+++ b/bach/tests/functional/bach/test_df_value_counts.py
@@ -1,7 +1,8 @@
 import numpy as np
 import pytest
 
-from tests.functional.bach.test_data_and_utils import assert_equals_data, \
+from bach.testing import assert_equals_data
+from tests.functional.bach.test_data_and_utils import \
     get_df_with_railway_data, get_df_with_test_data, TEST_DATA_CITIES, CITIES_COLUMNS, RAILWAYS_COLUMNS, \
     TEST_DATA_RAILWAYS
 from tests.unit.bach.util import get_pandas_df

--- a/bach/tests/functional/bach/test_df_variables.py
+++ b/bach/tests/functional/bach/test_df_variables.py
@@ -4,10 +4,10 @@ Copyright 2021 Objectiv B.V.
 import pytest
 
 from bach.dataframe import DtypeNamePair, DefinedVariable, DataFrame
+from bach.testing import assert_equals_data
 from sql_models.model import CustomSqlModelBuilder
 from sql_models.util import is_bigquery, is_postgres, is_athena
-from tests.functional.bach.test_data_and_utils import get_df_with_test_data, assert_equals_data, \
-    get_df_with_food_data
+from tests.functional.bach.test_data_and_utils import get_df_with_test_data, get_df_with_food_data
 
 
 def test_variable_happy_path(engine):

--- a/bach/tests/functional/bach/test_df_window.py
+++ b/bach/tests/functional/bach/test_df_window.py
@@ -3,9 +3,9 @@ import pytest
 
 from bach import DataFrame
 from bach.partitioning import WindowFrameMode, WindowFrameBoundary
+from bach.testing import assert_equals_data
 from tests.functional.bach.test_data_and_utils import (
-    assert_equals_data, get_df_with_test_data,
-    TEST_DATA_CITIES_FULL, CITIES_COLUMNS,
+    get_df_with_test_data, TEST_DATA_CITIES_FULL, CITIES_COLUMNS,
 )
 from tests.unit.bach.util import get_pandas_df
 

--- a/bach/tests/functional/bach/test_injection_column_name_escaping.py
+++ b/bach/tests/functional/bach/test_injection_column_name_escaping.py
@@ -3,7 +3,8 @@ Copyright 2021 Objectiv B.V.
 """
 from sqlalchemy.engine import Engine
 
-from tests.functional.bach.test_data_and_utils import assert_equals_data, get_df_with_test_data
+from bach.testing import assert_equals_data
+from tests.functional.bach.test_data_and_utils import get_df_with_test_data
 
 
 def test_column_names(engine):

--- a/bach/tests/functional/bach/test_injection_escaping.py
+++ b/bach/tests/functional/bach/test_injection_escaping.py
@@ -6,7 +6,8 @@ The test below are to prevent regressions in the escaping logic.
 We use(d) format() in multiple places, which means `{` and `}` need to be escaped at times.
 The pandas.read_sql_query() function that uses '%' for placeholders, which means all `%` need to be escaped.
 """
-from tests.functional.bach.test_data_and_utils import get_df_with_test_data, assert_equals_data
+from bach.testing import assert_equals_data
+from tests.functional.bach.test_data_and_utils import get_df_with_test_data
 
 
 def test_format_injection_simple(engine):

--- a/bach/tests/functional/bach/test_savepoints.py
+++ b/bach/tests/functional/bach/test_savepoints.py
@@ -7,8 +7,9 @@ import pytest
 from sqlalchemy.future import Engine
 
 from bach.savepoints import Savepoints, CreatedObject
+from bach.testing import assert_equals_data
 from sql_models.model import Materialization
-from tests.functional.bach.test_data_and_utils import get_df_with_test_data, assert_equals_data
+from tests.functional.bach.test_data_and_utils import get_df_with_test_data
 
 
 @pytest.mark.skip_athena_todo()

--- a/bach/tests/functional/bach/test_series.py
+++ b/bach/tests/functional/bach/test_series.py
@@ -9,10 +9,11 @@ import pytest
 
 from bach import DataFrame, SeriesString, SeriesInt64
 from bach.expression import Expression
+from bach.testing import assert_equals_data
 from sql_models.util import is_postgres, is_bigquery, is_athena
 from tests.functional.bach.test_data_and_utils import (
-    get_df_with_test_data, assert_equals_data, df_to_list,
-    get_df_with_railway_data, get_df_with_food_data, TEST_DATA_CITIES_FULL, CITIES_COLUMNS,
+    get_df_with_test_data, get_df_with_railway_data, get_df_with_food_data, df_to_list,
+    TEST_DATA_CITIES_FULL, CITIES_COLUMNS,
 )
 from tests.unit.bach.util import get_pandas_df
 

--- a/bach/tests/functional/bach/test_series_append.py
+++ b/bach/tests/functional/bach/test_series_append.py
@@ -1,7 +1,8 @@
 import pytest
 
 from bach import Series
-from tests.functional.bach.test_data_and_utils import assert_equals_data, get_df_with_test_data
+from bach.testing import assert_equals_data
+from tests.functional.bach.test_data_and_utils import get_df_with_test_data
 
 
 def test_series_append_same_dtype(engine) -> None:

--- a/bach/tests/functional/bach/test_series_boolean.py
+++ b/bach/tests/functional/bach/test_series_boolean.py
@@ -1,6 +1,7 @@
 import numpy
 
-from tests.functional.bach.test_data_and_utils import assert_equals_data, get_df_with_test_data
+from bach.testing import assert_equals_data
+from tests.functional.bach.test_data_and_utils import get_df_with_test_data
 
 
 def test_from_const(engine):

--- a/bach/tests/functional/bach/test_series_date.py
+++ b/bach/tests/functional/bach/test_series_date.py
@@ -7,8 +7,8 @@ import pandas as pd
 import pytest
 
 from bach import DataFrame
-from tests.functional.bach.test_data_and_utils import assert_equals_data, get_df_with_test_data,\
-    get_df_with_food_data
+from bach.testing import assert_equals_data
+from tests.functional.bach.test_data_and_utils import get_df_with_test_data, get_df_with_food_data
 from tests.functional.bach.test_series_timestamp import types_plus_min
 
 from bach.series.utils.datetime_formats import _C_STANDARD_CODES_X_POSTGRES_DATE_CODES, \

--- a/bach/tests/functional/bach/test_series_dict.py
+++ b/bach/tests/functional/bach/test_series_dict.py
@@ -3,7 +3,8 @@ Copyright 2022 Objectiv B.V.
 """
 import pytest
 from bach.series import SeriesDict
-from tests.functional.bach.test_data_and_utils import get_df_with_test_data, assert_equals_data
+from bach.testing import assert_equals_data
+from tests.functional.bach.test_data_and_utils import get_df_with_test_data
 
 
 pytestmark = [

--- a/bach/tests/functional/bach/test_series_int.py
+++ b/bach/tests/functional/bach/test_series_int.py
@@ -2,8 +2,8 @@
 Copyright 2021 Objectiv B.V.
 """
 from bach import Series, SeriesInt64
-from tests.functional.bach.test_data_and_utils import assert_equals_data, get_df_with_test_data, \
-    assert_series_db_types
+from bach.testing import assert_equals_data
+from tests.functional.bach.test_data_and_utils import get_df_with_test_data, assert_series_db_types
 from tests.functional.bach.test_series_numeric import helper_test_simple_arithmetic
 
 

--- a/bach/tests/functional/bach/test_series_list.py
+++ b/bach/tests/functional/bach/test_series_list.py
@@ -4,7 +4,8 @@ Copyright 2022 Objectiv B.V.
 import pytest
 
 from bach.series import SeriesList
-from tests.functional.bach.test_data_and_utils import get_df_with_test_data, assert_equals_data
+from bach.testing import assert_equals_data
+from tests.functional.bach.test_data_and_utils import get_df_with_test_data
 
 
 pytestmark = [

--- a/bach/tests/functional/bach/test_series_materialize.py
+++ b/bach/tests/functional/bach/test_series_materialize.py
@@ -5,10 +5,11 @@ Copyright 2022 Objectiv B.V.
 import pytest
 
 from bach.series import Series
+from bach.testing import assert_equals_data
 from sql_models.graph_operations import get_graph_nodes_info
 from sql_models.model import Materialization
 from sql_models.util import is_bigquery, is_postgres, is_athena
-from tests.functional.bach.test_data_and_utils import assert_equals_data, get_df_with_test_data
+from tests.functional.bach.test_data_and_utils import get_df_with_test_data
 
 
 @pytest.mark.skip_athena_todo()  # TODO: Athena

--- a/bach/tests/functional/bach/test_series_string.py
+++ b/bach/tests/functional/bach/test_series_string.py
@@ -4,7 +4,8 @@ Copyright 2021 Objectiv B.V.
 import pandas as pd
 
 from bach import Series, SeriesString, DataFrame
-from tests.functional.bach.test_data_and_utils import assert_equals_data, get_df_with_test_data
+from bach.testing import assert_equals_data
+from tests.functional.bach.test_data_and_utils import get_df_with_test_data
 from tests.unit.bach.util import get_pandas_df
 
 

--- a/bach/tests/functional/bach/test_series_timestamp.py
+++ b/bach/tests/functional/bach/test_series_timestamp.py
@@ -9,9 +9,9 @@ import pandas as pd
 import pytest
 from sqlalchemy.engine import Engine
 
+from bach.testing import assert_equals_data
 from sql_models.util import is_athena
-from tests.functional.bach.test_data_and_utils import assert_equals_data, get_df_with_test_data,\
-    get_df_with_food_data
+from tests.functional.bach.test_data_and_utils import get_df_with_test_data, get_df_with_food_data
 
 
 def floor_datetime(engine, dt: datetime.datetime) -> datetime.datetime:

--- a/bach/tests/functional/bach/test_series_uuid.py
+++ b/bach/tests/functional/bach/test_series_uuid.py
@@ -9,8 +9,9 @@ import pytest
 from sqlalchemy.engine import Engine
 
 from bach import SeriesUuid
+from bach.testing import assert_equals_data
 from sql_models.util import is_postgres, is_bigquery, is_athena
-from tests.functional.bach.test_data_and_utils import assert_equals_data, run_query, get_df_with_test_data
+from tests.functional.bach.test_data_and_utils import run_query, get_df_with_test_data
 
 
 def test_uuid_value_to_expression(engine):

--- a/modelhub/Makefile
+++ b/modelhub/Makefile
@@ -11,7 +11,7 @@ tests-bigquery:
 # against Postgres
 	mypy modelhub
 	pycodestyle modelhub
-	pytest --all -n 8 --dist loadgroup --big-query tests_modelhub
+	pytest --big-query -n 8 --dist loadgroup tests_modelhub
 
 tests-athena:
 # Similar to `tests`, but tests that can run against multiple databases will be run against Athena instead
@@ -19,7 +19,7 @@ tests-athena:
 # against Postgres
 	mypy modelhub
 	pycodestyle modelhub
-	pytest --all -n 8 --dist loadgroup --athena tests_modelhub
+	pytest --athena -n 8 --dist loadgroup tests_modelhub
 
 
 

--- a/modelhub/tests_modelhub/functional/modelhub/test_model_hub_drop_off_locations.py
+++ b/modelhub/tests_modelhub/functional/modelhub/test_model_hub_drop_off_locations.py
@@ -2,12 +2,10 @@
 Copyright 2022 Objectiv B.V.
 """
 
-import pytest
-
 # Any import from modelhub initializes all the types, do not remove
 from modelhub import __version__
+from bach.testing import assert_equals_data
 from tests_modelhub.data_and_utils.utils import get_objectiv_dataframe_test
-from tests.functional.bach.test_data_and_utils import assert_equals_data
 
 
 def test_drop_off_locations_basic(db_params):

--- a/modelhub/tests_modelhub/functional/modelhub/test_pipelines_extracted_contexts.py
+++ b/modelhub/tests_modelhub/functional/modelhub/test_pipelines_extracted_contexts.py
@@ -7,8 +7,8 @@ from typing import List
 import bach
 import pandas as pd
 import pytest
+from bach.testing import assert_equals_data
 from sql_models.util import is_bigquery
-from tests.functional.bach.test_data_and_utils import assert_equals_data
 
 from modelhub.pipelines.extracted_contexts import BaseExtractedContextsPipeline, get_extracted_context_pipeline
 from tests_modelhub.data_and_utils.utils import create_engine_from_db_params, DBParams

--- a/modelhub/tests_modelhub/functional/modelhub/test_pipelines_util.py
+++ b/modelhub/tests_modelhub/functional/modelhub/test_pipelines_util.py
@@ -1,5 +1,4 @@
 import pandas as pd
-import pytest
 
 from modelhub.pipelines.util import get_objectiv_data
 from tests_modelhub.data_and_utils.utils import create_engine_from_db_params


### PR DESCRIPTION
change:
* import for `assert_equals_data` previous: `from tests.functional.bach.test_data_and_utils`, new: `from bach.testing`
  * removed the import from `test.functional.bach`, so there is no way that there are any forgotten imports as those would be broken now.
* small tweak of Makefile