### PR TITLE
Fix doctest code-blocks

### DIFF
--- a/bach/docs/source/_ext/sphinx_docusaurus_builder/docusaurus_writer.py
+++ b/bach/docs/source/_ext/sphinx_docusaurus_builder/docusaurus_writer.py
@@ -565,10 +565,10 @@ class DocusaurusTranslator(Translator):
                     if((line[0:3] == ">>>") or (node['language'] == 'jupyter-notebook')):
                         if (i != 0): 
                             node_input += "\n"
-                        if (node['language'] == 'jupyter-notebook'):
-                            node_input += line
-                        else:
+                        if (line[0:3] == '>>>'):
                             node_input += line[3:]
+                        else:
+                            node_input += line
                         output_index = i+1
                     else:
                         break


### PR DESCRIPTION
Fixes an issue where the code-blocks in the example notebooks weren't parsed correctly with the switch to the exec-code sphinx extension.