### PR TITLE
Fix bach functional tests on BQ after fix on BigQueries side

### DIFF
--- a/bach/tests/functional/bach/test_df_astype.py
+++ b/bach/tests/functional/bach/test_df_astype.py
@@ -258,7 +258,5 @@ def test_astype_db_types(engine):
             'timestamp2': SeriesTimestamp,
             'time': SeriesTime,
             'json': SeriesJson,
-        },
-        # There is a bug in bqutil.fn.typeof() that causes it to not recognize some strings as a string.
-        expected_db_type_overrides={DBDialect.BIGQUERY: {'json': 'UNKNOWN'}}
+        }
     )

--- a/bach/tests/functional/bach/test_df_setitem.py
+++ b/bach/tests/functional/bach/test_df_setitem.py
@@ -137,9 +137,7 @@ def test_set_const_json(engine):
         ['a', 'b', 'c'],
         {'a': 'b', 'c': 'd'},
     ]
-    # There is a bug in bqutil.fn.typeof() that causes it to not recognize the string as a string.
-    expected_db_type_override = {DBDialect.BIGQUERY: 'UNKNOWN'}
-    check_set_const(engine, constants, SeriesJson, expected_db_type_override=expected_db_type_override)
+    check_set_const(engine, constants, SeriesJson)
 
 
 def test_set_const_int_from_series(engine):


### PR DESCRIPTION
We had some exceptions in our functional tests for BigQuery, because `bqutil.fn.typeof()` sometimes gave `"UNKOWN"` as type. That bug in `typeof()` was fixed ([here](https://github.com/GoogleCloudPlatform/bigquery-utils/pull/309#issuecomment-1277570129)), so now we need to remove the exception in our code.