### PR TITLE
Fix selecting from df with value propagation

### DIFF
--- a/bach/bach/operations/value_propagation.py
+++ b/bach/bach/operations/value_propagation.py
@@ -81,7 +81,7 @@ class ValuePropagation:
 
         # sort values, this way we respect the provided order by
         df = df.sort_values(by=self.ROW_NUMBER_SERIES_NAME)
-        return df[self._df.data_columns]
+        return df[self._df.data_columns].materialize(node_name='nafilled')
 
     def _add_partition_per_data_columns(self, df: DataFrame) -> DataFrame:
         """

--- a/bach/tests/functional/bach/test_df_fillna.py
+++ b/bach/tests/functional/bach/test_df_fillna.py
@@ -130,13 +130,13 @@ def test_fillna_w_methods(engine) -> None:
         expected_columns=['_index_0', 'A', 'B', 'C', 'D', 'E', 'F', 'G'],
         expected_data=[
             # last 3 rows are non-deterministic because A, B, C were initially all nulls
-            [ANY,  1,    3,    1] + [ANY] * 4,
+            [0,  1,    3,    1] + [ANY] * 4,
             [1,    3,    4, None,    1,    1, None, datetime(2022, 1, 2)],
             [2,    1,    3, None,    4,    1,  'b', datetime(2022, 1, 5)],
             [3,    1,    2, None,    0,    1,  'c', datetime(2022, 1, 5)],
-            [ANY, 1, 3, 1] + [ANY] * 4,
+            [4, 1, 3, 1] + [ANY] * 4,
             [5,    1,    4, None,    1,    1,  'd', datetime(2022, 1, 5)],
-            [ANY,  1,    3,    1] + [ANY] * 4,
+            [6,  1,    3,    1] + [ANY] * 4,
             [7,    1,    3,    1,    4,    1,  'f', datetime(2022, 1, 5)],
         ]
     )
@@ -150,13 +150,13 @@ def test_fillna_w_methods(engine) -> None:
         expected_columns=['_index_0', 'A', 'B', 'C', 'D', 'E', 'F', 'G'],
         expected_data=[
             # last 3 rows are non-deterministic because A, B, C are all nulls
-            [ANY, None, None, None] + [ANY] * 4,
+            [0, None, None, None] + [ANY] * 4,
             [1,    3,    4,    1,    1,    1,  'd', datetime(2022, 1, 2)],
             [2, None,    3,    1,    4,  ANY,  'b',                 ANY],
             [3, None,    2,    1,    0,  ANY,  'c',                 ANY],
-            [ANY, None, None, None] + [ANY] * 4,
+            [4, None, None, None] + [ANY] * 4,
             [5,    1,    2,    1,    0,  ANY,  'd', datetime(2022, 1, 5)],
-            [ANY, None, None, None] + [ANY] * 4,
+            [6, None, None, None] + [ANY] * 4,
             [7, None, None,    1,  ANY,  ANY,  'f',                 ANY],
         ],
     )

--- a/bach/tests/functional/bach/test_df_fillna.py
+++ b/bach/tests/functional/bach/test_df_fillna.py
@@ -81,6 +81,14 @@ def test_fillna_w_methods_against_pandas(engine) -> None:
         check_names=False,
     )
 
+    # test selecting from ffilled df
+    pd.testing.assert_frame_equal(
+        fillna_check_ffill_expected[fillna_check_ffill_expected.F=='f'],
+        fillna_check_ffill_result[fillna_check_ffill_result.F=='f'].to_pandas(),
+        check_index_type=False,
+        check_names=False,
+    )
+
     fillna_check_bfill_expected = check_sort_expected.fillna(method='bfill')
     fillna_check_bfill_result = check_sort_result.fillna(method='bfill')
     pd.testing.assert_frame_equal(

--- a/bach/tests/functional/bach/test_df_fillna.py
+++ b/bach/tests/functional/bach/test_df_fillna.py
@@ -129,7 +129,6 @@ def test_fillna_w_methods(engine) -> None:
         use_to_pandas=True,
         expected_columns=['_index_0', 'A', 'B', 'C', 'D', 'E', 'F', 'G'],
         expected_data=[
-            # last 3 rows are non-deterministic because A, B, C were initially all nulls
             [0,  1,    3,    1] + [ANY] * 4,
             [1,    3,    4, None,    1,    1, None, datetime(2022, 1, 2)],
             [2,    1,    3, None,    4,    1,  'b', datetime(2022, 1, 5)],
@@ -149,7 +148,6 @@ def test_fillna_w_methods(engine) -> None:
         use_to_pandas=True,
         expected_columns=['_index_0', 'A', 'B', 'C', 'D', 'E', 'F', 'G'],
         expected_data=[
-            # last 3 rows are non-deterministic because A, B, C are all nulls
             [0, None, None, None] + [ANY] * 4,
             [1,    3,    4,    1,    1,    1,  'd', datetime(2022, 1, 2)],
             [2, None,    3,    1,    4,  ANY,  'b',                 ANY],

--- a/bach/tests/functional/bach/test_df_fillna.py
+++ b/bach/tests/functional/bach/test_df_fillna.py
@@ -125,41 +125,42 @@ def test_fillna_w_methods(engine) -> None:
 
     result_ffill = df.fillna(method='ffill', sort_by=sort_by, ascending=ascending)
     assert_equals_data(
-        result_ffill,
+        result_ffill.sort_index(),
         use_to_pandas=True,
         expected_columns=['_index_0', 'A', 'B', 'C', 'D', 'E', 'F', 'G'],
         expected_data=[
-            [1,    3,    4, None,    1,    1, None, datetime(2022, 1, 2)],
-            [5,    1,    4, None,    1,    1,  'd', datetime(2022, 1, 5)],
-            [3,    1,    2, None,    0,    1,  'c', datetime(2022, 1, 5)],
-            [2,    1,    3, None,    4,    1,  'b', datetime(2022, 1, 5)],
-            [7,    1,    3,    1,    4,    1,  'f', datetime(2022, 1, 5)],
             # last 3 rows are non-deterministic because A, B, C were initially all nulls
             [ANY,  1,    3,    1] + [ANY] * 4,
+            [1,    3,    4, None,    1,    1, None, datetime(2022, 1, 2)],
+            [2,    1,    3, None,    4,    1,  'b', datetime(2022, 1, 5)],
+            [3,    1,    2, None,    0,    1,  'c', datetime(2022, 1, 5)],
+            [ANY, 1, 3, 1] + [ANY] * 4,
+            [5,    1,    4, None,    1,    1,  'd', datetime(2022, 1, 5)],
             [ANY,  1,    3,    1] + [ANY] * 4,
-            [ANY,  1,    3,    1] + [ANY] * 4,
-        ],
+            [7,    1,    3,    1,    4,    1,  'f', datetime(2022, 1, 5)],
+        ]
     )
 
     result_bfill = df.fillna(
         method='bfill', sort_by=['A', 'B', 'C'], ascending=[False, True, False],
     )
     assert_equals_data(
-        result_bfill,
+        result_bfill.sort_index(),
         use_to_pandas=True,
         expected_columns=['_index_0', 'A', 'B', 'C', 'D', 'E', 'F', 'G'],
         expected_data=[
-            [1,    3,    4,    1,    1,    1,  'd', datetime(2022, 1, 2)],
-            [5,    1,    2,    1,    0,  ANY,  'd', datetime(2022, 1, 5)],
-            [3, None,    2,    1,    0,  ANY,  'c',                 ANY],
-            [2, None,    3,    1,    4,  ANY,  'b',                 ANY],
-            [7, None, None,    1,  ANY,  ANY,  'f',                 ANY],
             # last 3 rows are non-deterministic because A, B, C are all nulls
             [ANY, None, None, None] + [ANY] * 4,
+            [1,    3,    4,    1,    1,    1,  'd', datetime(2022, 1, 2)],
+            [2, None,    3,    1,    4,  ANY,  'b',                 ANY],
+            [3, None,    2,    1,    0,  ANY,  'c',                 ANY],
             [ANY, None, None, None] + [ANY] * 4,
+            [5,    1,    2,    1,    0,  ANY,  'd', datetime(2022, 1, 5)],
             [ANY, None, None, None] + [ANY] * 4,
+            [7, None, None,    1,  ANY,  ANY,  'f',                 ANY],
         ],
     )
+
 
 
 def test_fillna_w_methods_w_sorted_df(engine) -> None:


### PR DESCRIPTION
Simple selections were not possible from a df with ffill. See added test. With a materialization the test passes.


https://github.com/objectiv/objectiv-analytics/pull/1360/files contains this fix as well, but more clear to split it.