### PR TITLE
Modelhub tweaks

### DIFF
--- a/modelhub/modelhub/pipelines/extracted_contexts.py
+++ b/modelhub/modelhub/pipelines/extracted_contexts.py
@@ -59,6 +59,8 @@ class BaseExtractedContextsPipeline(BaseDataPipeline):
             engine=self._engine,
             table_name=self._table_name,
         )
+        if not dtypes:
+            raise Exception(f'Table is missing or has 0 columns. Table name: {table_name}. ')
 
         self._global_contexts_dtypes = self._get_global_contexts_dtypes_from_db_dtypes(db_dtypes=dtypes)
         self._validate_data_dtypes(

--- a/modelhub/tests_modelhub/functional/modelhub/test_model_hub.py
+++ b/modelhub/tests_modelhub/functional/modelhub/test_model_hub.py
@@ -605,8 +605,8 @@ def test_get_objectiv_dataframe_db_connection(db_params: DBParams, monkeypatch):
 
     elif 'bigquery' in db_params.url:
         monkeypatch.delenv('GOOGLE_APPLICATION_CREDENTIALS', raising=False)
-        # Check that we get a nice error to help the user
-        with pytest.raises(ValueError, match="credentials or path is required"):
+        # Check that we get a sort of nice error to help the user
+        with pytest.raises(Exception, match="Could not automatically determine credentials."):
             mh.get_objectiv_dataframe(db_url=db_params.url)
 
         mh.get_objectiv_dataframe(


### PR DESCRIPTION
Two changes:
1. Give an earlier error if `get_dtypes_from_table()` returns an empty dictionary. This usually means that the table doesn't exist, but the error we gave was about missing columns. That was not really helpful imo.
2. No longer require `bq_credentials` or `bq_credentials_path` if `db_url` is a BigQuery url. This behaviour was inconsistent, if the environment variable `DSN` was set to a BigQuery url we didn't require the additional parameters, but if the same url was specified as `db_url` we did require it.

The second change was triggered by a question from @borft about why we didn't support 'the normal' way of authenticating. I think he had a point :)