### PR TITLE
Docusaurus parsing improvements

### DIFF
--- a/bach/docs/source/_ext/sphinx_docusaurus_builder/docusaurus_writer.py
+++ b/bach/docs/source/_ext/sphinx_docusaurus_builder/docusaurus_writer.py
@@ -856,6 +856,8 @@ class DocusaurusTranslator(Translator):
     def visit_desc_parameter(self, node):
         """Single method/class parameter."""
         self.add('<span className="parameter" id="'+ node[0].astext() + '">')
+        # do not escape the parameters printed in visit_Text(), by setting self._escape_text to False
+        self._escape_text = False
 
 
     def depart_desc_parameter(self, node):

--- a/bach/docs/source/_ext/sphinx_docusaurus_builder/docusaurus_writer.py
+++ b/bach/docs/source/_ext/sphinx_docusaurus_builder/docusaurus_writer.py
@@ -566,7 +566,7 @@ class DocusaurusTranslator(Translator):
                         if (i != 0): 
                             node_input += "\n"
                         if (line[0:3] == '>>>'):
-                            node_input += line[3:]
+                            node_input += line[4:]
                         else:
                             node_input += line
                         output_index = i+1


### PR DESCRIPTION
Two improvements to the Sphinx Docusaurus builder:

1. Removes a leading space for all code examples with language 'jupyter-notebook'.
2. Disables escaping the text for parameters of functions, which made them look like `get_logistic_regression(\*args, \*\*kwargs)` instead of `get_logistic_regression(*args, **kwargs)`.

Corresponding changes to the docs in https://github.com/objectiv/objectiv.io/pull/598 (all double-checked).