### PR TITLE
Bach: Explicit casting when extracting string from JSON

### DIFF
--- a/bach/bach/series/series_json.py
+++ b/bach/bach/series/series_json.py
@@ -750,7 +750,7 @@ class JsonPostgresAccessorImpl(Generic[TSeriesJson]):
         result = self._series_object.copy_override(expression=expression)
         if as_str:
             from bach.series import SeriesString
-            return result.copy_override_type(SeriesString)
+            return result.astype('string').copy_override_type(SeriesString)
         return result
 
     def get_array_length(self) -> 'SeriesInt64':

--- a/bach/tests/functional/bach/test_series_json.py
+++ b/bach/tests/functional/bach/test_series_json.py
@@ -444,3 +444,23 @@ def test_json_str_as_str(engine, dtype) -> None:
             [3, '"hola"'],
         ],
     )
+
+
+def test_json_concat_scalar_str(engine, dtype) -> None:
+    bt = get_df_with_json_data(engine=engine, dtype='json')
+    bt['a'] = bt.dict_column.json.get_value('_type', as_str=True)
+    bt['b'] = bt.dict_column.json.get_value('id', as_str=True)
+
+    bt['c'] = bt.a + bt.b
+
+    assert_equals_data(
+        bt.c,
+        expected_columns=['_index_row', 'c'],
+        expected_data=[
+            [0, None],
+            [1, 'SectionContexthome'],
+            [2, None],
+            [3, None],
+            [4, None]
+        ]
+    )


### PR DESCRIPTION
Postgres complains when casting is not explicit. 