### PR TITLE
SnowPlow transport

### DIFF
--- a/tracker/CONTRIBUTING.md
+++ b/tracker/CONTRIBUTING.md
@@ -42,6 +42,7 @@ This is a complete list of the currently available packages.
 | @objectiv/tracker-react-native                   | tracker   | /trackers/react-native                   | [README](/tracker/trackers/react-native/README.md)                   |
 | @objectiv/transport-debug                        | transport | /transports/browser                      | [README](/tracker/transports/debug/README.md)                        |
 | @objectiv/transport-fetch                        | transport | /transports/browser                      | [README](/tracker/transports/fetch/README.md)                        |
+| @objectiv/transport-snowplow                     | transport | /transports/snowplow                     | [README](/tracker/transports/snowplow/README.md)                     |
 | @objectiv/transport-xhr                          | transport | /transports/browser                      | [README](/tracker/transports/xhr/README.md)                          |
 
 >Note: Packages may be completely independent of each other. Currently, many of them share the same testing framework or bundler but that's not required. Each has its own local configurations and may diverge if needed.

--- a/tracker/transports/snowplow/.prettierignore
+++ b/tracker/transports/snowplow/.prettierignore
@@ -1,0 +1,26 @@
+# Logs
+*.log
+
+# Yarn 2
+.yarn/*
+!.yarn/releases
+!.yarn/plugins
+
+# Dependencies
+node_modules/
+
+# OS X temporary files
+.DS_Store
+
+# Test coverage reports
+coverage/
+
+# Distribution files
+dist/
+
+# IDE files
+.idea/
+.vscode/
+
+# Markdown
+*.md

--- a/tracker/transports/snowplow/.prettierrc.json
+++ b/tracker/transports/snowplow/.prettierrc.json
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "printWidth": 120
+}

--- a/tracker/transports/snowplow/README.md
+++ b/tracker/transports/snowplow/README.md
@@ -1,0 +1,26 @@
+# Objectiv Snowplow Transport
+
+Allows sending events directly via Snowplow's JavaScript Tracker without the need of the Objectiv Collector. 
+
+---
+## Package Installation
+To install the most recent stable version:
+
+```sh
+yarn add @objectiv/transport-snowplow
+```
+
+### or
+```sh
+npm install @objectiv/transport-snowplow
+```
+
+# Usage
+For a detailed usage guide, see the documentation: [https://objectiv.io/docs](https://objectiv.io/docs)
+
+# Copyright and license
+Licensed and distributed under the Apache 2.0 License (An OSI Approved License).
+
+Copyright (c) 2022 Objectiv B.V.
+
+All rights reserved.

--- a/tracker/transports/snowplow/jest.config.js
+++ b/tracker/transports/snowplow/jest.config.js
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2021-2022 Objectiv B.V.
+ */
+
+module.exports = {
+  preset: 'ts-jest',
+  globals: {
+    'ts-jest': {
+      isolatedModules: true,
+    },
+  },
+  testEnvironment: 'jsdom',
+  collectCoverageFrom: ['src/**/*.ts'],
+  moduleNameMapper: {
+    '@objectiv/developer-tools': '<rootDir>../../core/developer-tools/src',
+    '@objectiv/testing-tools': '<rootDir>../../core/testing-tools/src',
+    '@objectiv/tracker-core': '<rootDir>../../core/tracker/src',
+    '@objectiv/plugin-(.*)': '<rootDir>/../../plugins/$1/src',
+  },
+};

--- a/tracker/transports/snowplow/package.json
+++ b/tracker/transports/snowplow/package.json
@@ -1,0 +1,65 @@
+{
+  "name": "@objectiv/transport-snowplow",
+  "version": "0.0.26",
+  "description": "Allows sending events directly via Snowplow's JavaScript Tracker without the need of the Objectiv Collector",
+  "license": "Apache-2.0",
+  "homepage": "https://objectiv.io",
+  "keywords": [
+    "objectiv",
+    "tracking",
+    "web",
+    "analytics",
+    "events",
+    "taxonomy",
+    "transport",
+    "snowplow"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/objectiv/objectiv-analytics.git",
+    "directory": "tracker/transports/snowplow"
+  },
+  "bugs": "https://github.com/objectiv/objectiv-analytics/issues",
+  "contributors": [
+    {
+      "name": "Surai Di Rosa",
+      "email": "surai.dirosa@gmail.com",
+      "url": "https://github.com/sdirosa"
+    }
+  ],
+  "main": "./dist/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./dist/esm/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsup src/index.ts --format cjs,esm --legacy-output --minify --dts --sourcemap --clean",
+    "deploy:verdaccio": "npm publish",
+    "prettify": "prettier --write .",
+    "tsc": "tsc --noEmit",
+    "test": "jest --silent",
+    "test:ci": "jest --silent --ci",
+    "test:coverage": "jest --silent --coverage",
+    "depcheck": "npx depcheck"
+  },
+  "devDependencies": {
+    "@objectiv/developer-tools": "^0.0.26",
+    "@objectiv/testing-tools": "^0.0.26",
+    "jest": "^28.1.3",
+    "prettier": "^2.7.1",
+    "ts-jest": "^28.0.7",
+    "tsup": "^6.2.1",
+    "typescript": "^4.7.4"
+  },
+  "peerDependencies": {
+    "@objectiv/tracker-core": "^0.0.26"
+  }
+}

--- a/tracker/transports/snowplow/src/SnowplowTransport.ts
+++ b/tracker/transports/snowplow/src/SnowplowTransport.ts
@@ -1,0 +1,40 @@
+import { NonEmptyArray, TrackerTransportInterface, TransportableEvent } from '@objectiv/tracker-core';
+import { makeSnowplowContexts } from "./makeSnowplowContexts";
+
+/**
+ * SnowplowTransport converts incoming events from Objectiv's TrackerEvent instances to Snowplow's Tracker Protocol.
+ */
+export class SnowplowTransport implements TrackerTransportInterface {
+  readonly transportName = `SnowplowTransport`;
+
+  /**
+   * The constructor is merely responsible for logging
+   */
+  constructor() {
+    globalThis.objectiv.devTools?.TrackerConsole.log(
+      `%c｢objectiv:${this.transportName}｣ Initialized`,
+      'font-weight: bold'
+    );
+  }
+
+  /**
+   * Converts incoming TrackerEvents to Snowplow's payloads and sends them via snowplow's 'trackStructEvent'
+   */
+  async handle(...args: NonEmptyArray<TransportableEvent>): Promise<Response | void> {
+    (await Promise.all(args)).forEach(event => {
+      window.snowplow('trackStructEvent', {
+        action: event._type,
+        // TODO category: serialized event._types, we don't have this yet in FE. We need the new factories
+        category: `["${event._type}"]`,
+        context: makeSnowplowContexts(event),
+      })
+    });
+  }
+
+  /**
+   * Make this transport usable if snowplow is available in the window interface
+   */
+  isUsable(): boolean {
+    return typeof window !== 'undefined' && typeof window.snowplow !== 'undefined';
+  }
+}

--- a/tracker/transports/snowplow/src/index.ts
+++ b/tracker/transports/snowplow/src/index.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2021-2022 Objectiv B.V.
+ */
+
+/**
+ * Set package version in globals
+ */
+import pkg from '../package.json';
+globalThis.objectiv = globalThis.objectiv ?? {};
+globalThis.objectiv.versions = globalThis.objectiv.versions ?? new Map();
+globalThis.objectiv.versions.set(pkg.name, pkg.version);
+
+declare global {
+  interface Window {
+    snowplow: (method: 'trackStructEvent', event: unknown) => void
+  }
+}
+
+export const GLOBAL_CONTEXT_SCHEMA_BASE = 'iglu:io.objectiv.context';
+export const LOCATION_STACK_SCHEMA_BASE = 'iglu:io.objectiv/location_stack';
+
+export * from './makeSnowplowContexts';
+export * from './SnowplowTransport';

--- a/tracker/transports/snowplow/src/makeSnowplowContexts.ts
+++ b/tracker/transports/snowplow/src/makeSnowplowContexts.ts
@@ -1,0 +1,32 @@
+import { TrackerEvent } from '@objectiv/tracker-core';
+import { GLOBAL_CONTEXT_SCHEMA_BASE, LOCATION_STACK_SCHEMA_BASE } from "./index";
+
+/**
+ * Helper function to convert Contexts from our Event format to Snowplow's
+ */
+export const makeSnowplowContexts = (event: TrackerEvent) => {
+  let snowplowContexts: any[] = [];
+
+  //TODO temporarily hardcoded. We need to use the new factories to get this from the event instance.
+  const version = '1-0-0';
+
+  event.global_contexts.forEach(({_type, ...data}) => {
+    snowplowContexts.push({
+      schema: `${GLOBAL_CONTEXT_SCHEMA_BASE}/${_type}/jsonschema/${version}`,
+      data: {
+        ...data,
+        _types: [_type]
+      }
+    })
+  });
+
+  snowplowContexts.push({
+    schema: `${LOCATION_STACK_SCHEMA_BASE}/jsonschema/${version}`,
+    data: {
+      location_stack: event.location_stack
+    }
+  });
+
+  return snowplowContexts;
+}
+

--- a/tracker/transports/snowplow/tsconfig.json
+++ b/tracker/transports/snowplow/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/tracker/yarn.lock
+++ b/tracker/yarn.lock
@@ -2754,6 +2754,22 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@objectiv/transport-snowplow@workspace:transports/snowplow":
+  version: 0.0.0-use.local
+  resolution: "@objectiv/transport-snowplow@workspace:transports/snowplow"
+  dependencies:
+    "@objectiv/developer-tools": ^0.0.26
+    "@objectiv/testing-tools": ^0.0.26
+    jest: ^28.1.3
+    prettier: ^2.7.1
+    ts-jest: ^28.0.7
+    tsup: ^6.2.1
+    typescript: ^4.7.4
+  peerDependencies:
+    "@objectiv/tracker-core": ^0.0.26
+  languageName: unknown
+  linkType: soft
+
 "@objectiv/transport-xhr@^0.0.26, @objectiv/transport-xhr@workspace:transports/xhr":
   version: 0.0.0-use.local
   resolution: "@objectiv/transport-xhr@workspace:transports/xhr"


### PR DESCRIPTION
A transport module meant to be used in place of the default transport we ship with our SDKs. It will repackage events in Snowplow's format and send them over using their javascript API.