### PR TITLE
Bach improve column name escaping

### DIFF
--- a/bach/bach/merge.py
+++ b/bach/bach/merge.py
@@ -666,8 +666,9 @@ def _resolve_merge_expression_references(
 
 def _get_series_name_from_column_name(model: BachSqlModel, dialect: Dialect, column_name: str) -> str:
     """
-    Given a column_name, and the BachSqlModel that the column appears in. Determine what the series-name
-    by converting all series-names in the BachSqlModel meta-data to column names and seeing which matches.
+    Given a column_name and the BachSqlModel that the column appears in, determine what the series-name
+    of the column name was. This is done by converting all series names in the BachSqlModel meta-data to
+    column names, and seeing which matches the given column name.
     """
     series_names = list(model.column_expressions.keys())
     for series_name in series_names:

--- a/bach/bach/utils.py
+++ b/bach/bach/utils.py
@@ -199,25 +199,6 @@ def get_name_to_column_mapping(dialect: Dialect, names: Iterable[str]) -> Dict[s
     }
 
 
-def get_name_from_sql_column_name(sql_column_name: str) -> str:
-    """
-    Given a sql column name, give the Series name.
-
-    This is the reverese operation of :meth:`get_sql_column_name()`.
-    """
-    escape_indicator = '__esc_'
-    if not sql_column_name.startswith(escape_indicator):
-        return sql_column_name
-    rest = sql_column_name[len(escape_indicator):]
-    # In get_sql_column_name() we removed the padding, but b32decode() requires the padding, so add it again.
-    # Padding should make each string a multiple of 8 characters [1].
-    # [1]: https://datatracker.ietf.org/doc/html/rfc4648.html#section-6
-    padding = '=' * (8 - (len(rest) % 8))
-    b32_encoded = (rest + padding).upper()
-    original = base64.b32decode(b32_encoded.encode('utf-8')).decode('utf-8')
-    return original
-
-
 def validate_node_column_references_in_sorting_expressions(
     dialect: Dialect, node: BachSqlModel, order_by: List[SortColumn],
 ) -> None:

--- a/bach/bach/utils.py
+++ b/bach/bach/utils.py
@@ -66,6 +66,7 @@ def escape_parameter_characters(conn: Connection, raw_sql: str) -> str:
 
 
 _BQ_COLUMN_NAME_RESERVED_PREFIXES = [
+    # https://cloud.google.com/bigquery/docs/schemas#column_names
     '_TABLE_',
     '_FILE_',
     '_PARTITION',

--- a/bach/tests/functional/bach/test_revert_merge.py
+++ b/bach/tests/functional/bach/test_revert_merge.py
@@ -28,7 +28,6 @@ def test_revert_merge_columns_special_chars(engine):
     mt = mt.materialize('https://github.com/objectiv/objectiv-analytics/issues/1430')
     merged = bt.merge(mt)
 
-    print(mt.view_sql())
     result_bt, result_mt = revert_merge(merged)
 
     _compare_source_with_replicate(bt, result_bt)

--- a/bach/tests/unit/bach/test_series.py
+++ b/bach/tests/unit/bach/test_series.py
@@ -209,7 +209,7 @@ def test_init_conditions(dialect, monkeypatch) -> None:
         FakeSeries(**params_w_agg_expression_wo_gb)
 
     params_w_wrong_name = base_params.copy()
-    params_w_wrong_name['name'] = '-' * 300
+    params_w_wrong_name['name'] = 'a' * 301
     # invalid name: it is too long for all databases and/or cannot be encoded short enough
     with pytest.raises(ValueError, match=r'not valid for SQL dialect'):
         FakeSeries(**params_w_wrong_name)

--- a/bach/tests/unit/bach/test_utils.py
+++ b/bach/tests/unit/bach/test_utils.py
@@ -5,7 +5,7 @@ import pytest
 from bach.expression import Expression
 from bach.sql_model import BachSqlModel
 from bach.utils import get_merged_series_dtype, is_valid_column_name, SortColumn, \
-    validate_node_column_references_in_sorting_expressions, get_name_from_sql_column_name, \
+    validate_node_column_references_in_sorting_expressions, \
     get_sql_column_name, merge_sql_statements, athena_construct_engine_url
 from sql_models.model import Materialization, CustomSqlModelBuilder
 from sql_models.util import is_athena

--- a/bach/tests/unit/bach/test_utils.py
+++ b/bach/tests/unit/bach/test_utils.py
@@ -71,8 +71,8 @@ def test_get_sql_column_name(dialect):
                        'test'),
         ColNameEncoded('Test',
                        'Test',
-                       '__esc_krsxg5a',
-                       '__esc_krsxg5a'),
+                       'test__bs6gmepvkq',
+                       'test__bs6gmepvkq'),
         ColNameEncoded('test_test',
                        'test_test',
                        'test_test',
@@ -84,7 +84,7 @@ def test_get_sql_column_name(dialect):
         ColNameEncoded('012345test',
                        '012345test',
                        '012345test',
-                       '__esc_gaytemzugv2gk43u'),
+                       '_012345test__kozpee4by6'),
         ColNameEncoded('_',
                        '_',
                        '_',
@@ -95,20 +95,36 @@ def test_get_sql_column_name(dialect):
                        '__column0'),
         ColNameEncoded('0_00.1%',
                        '0_00.1%',
-                       '__esc_gbptambogesq',
-                       '__esc_gbptambogesq'),
+                       '0_001__bgc5mnmich',
+                       '_0_001__bgc5mnmich'),
         ColNameEncoded('_X!@',
                        '_X!@',
-                       '__esc_l5mccqa',
-                       '__esc_l5mccqa'),
+                       '_x__owpedgg7pz',
+                       '_x__owpedgg7pz'),
         ColNameEncoded('test_X!@_test_123',
                        'test_X!@_test_123',
-                       '__esc_orsxg5c7laquax3umvzxixzrgizq',
-                       '__esc_orsxg5c7laquax3umvzxixzrgizq'),
+                       'test_x_test_123__bdsu7fgwbz',
+                       'test_x_test_123__bdsu7fgwbz'),
+        ColNameEncoded('¼ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþ',
+                       '¼ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþ',
+                       '14aaaaaaceeeeiiiinooooouuuuyaaaaaaceeeeiiiinooooouuuuy__7ix4q3jx7f',
+                       '_14aaaaaaceeeeiiiinooooouuuuyaaaaaaceeeeiiiinooooouuuuy__7ix4q3jx7f'),
+        ColNameEncoded('¶',
+                       '¶',
+                       'empty__prnak4rr43',
+                       'empty__prnak4rr43'),
+        ColNameEncoded('¶¶',
+                       '¶¶',
+                       'empty__z4ywntjpwq',
+                       'empty__z4ywntjpwq'),
         ColNameEncoded('Aa_!#!$*(aA®Řﬦ‎	⛔',
                        'Aa_!#!$*(aA®Řﬦ‎	⛔',
-                       '__esc_ifqv6ijdeescukdbihbk5rmy56wknyuarye6fg4u',
-                       '__esc_ifqv6ijdeescukdbihbk5rmy56wknyuarye6fg4u')
+                       'aa_aar__ad4drrvdk2',
+                       'aa_aar__ad4drrvdk2'),
+        ColNameEncoded('__ROOT__test',
+                       '__ROOT__test',
+                       '__root__test__b44plskaze',
+                       'x___root__test__b44plskaze')
     ]
     for test in tests:
         expected = getattr(test, dialect.name)
@@ -148,10 +164,9 @@ def test_get_sql_column_name_raises_exception(dialect):
             assert error is not None, f'Expected error not raised; {case_msg}.'
 
 
-def test_get_sql_column_name_back_and_forth(dialect):
-    # Test that:
-    # 1. get_sql_column_name() can turn series names into valid column name.
-    # 2. get_name_from_sql_column_name() can translate the column names back to series names.
+def test_get_sql_column_name_more_names(dialect):
+    # Just test some additional names, to make sure they can be encoded with all dialects. Without
+    # going to the trouble of defining expected outputs
     names = [
         'test',
         'test' * 15 + 'tes',
@@ -176,9 +191,7 @@ def test_get_sql_column_name_back_and_forth(dialect):
     ]
     for name in names:
         sql_column_name = get_sql_column_name(dialect, name)
-        reverted_name = get_name_from_sql_column_name(name)
         assert is_valid_column_name(dialect, sql_column_name)
-        assert name == reverted_name
 
 
 def test_validate_sorting_expressions(dialect) -> None:


### PR DESCRIPTION
Changed the way we encode series-names as column-names, when the series name is not a valid column name.
The resulting column names contain more of the original characters, but they are not reversible anymore. The exact method can be found by inspecting `get_sql_column_name()`