### PR TITLE
Bach strftime support `%V`

### DIFF
--- a/bach/bach/series/series_datetime.py
+++ b/bach/bach/series/series_datetime.py
@@ -74,8 +74,8 @@ class DateTimeOperation:
         code semantics: https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes
 
         The subset of codes that are supported across all databases is:
-            `%A`, `%B`, `%F`, `%H`, `%I`, `%M`, `%R`, `%S`, `%T`, `%Y`, `%a`, `%b`, `%d`, `%j`, `%m`, `%y`,
-            `%%`
+            `%A`, `%B`, `%F`, `%H`, `%I`, `%M`, `%R`, `%S`, `%T`, `%V`, %Y`, `%a`, `%b`, `%d`, `%j`, `%m`,
+            `%y`, `%%`
 
         Additionally one specific combination is supported: `%S.%f`
 

--- a/bach/bach/series/series_datetime.py
+++ b/bach/bach/series/series_datetime.py
@@ -15,7 +15,7 @@ from bach.series import Series, SeriesString, SeriesBoolean, SeriesFloat64, Seri
 from bach.expression import Expression, join_expressions, StringValueToken
 from bach.series.series import WrappedPartition, ToPandasInfo
 from bach.series.utils.datetime_formats import parse_c_standard_code_to_postgres_code, \
-    parse_c_code_to_bigquery_code, parse_c_code_to_athena_code, warn_non_supported_format_codes
+    parse_c_code_to_bigquery_code, warn_non_supported_format_codes, parse_c_code_to_athena_expression
 from bach.types import DtypeOrAlias, StructuredDtype, value_to_series_type, get_series_type_from_dtype
 from sql_models.constants import DBDialect
 from sql_models.util import is_postgres, is_bigquery, DatabaseNotSupportedException, is_athena
@@ -98,15 +98,12 @@ class DateTimeOperation:
                 'to_char({}, {})', series, Expression.string_value(parsed_format_str)
             )
         elif is_athena(engine):
-            parsed_format_str = parse_c_code_to_athena_code(format_str)
             if isinstance(series, SeriesTime):
                 # for time series, we should convert the float values into a timestamp,
                 # otherwise date_format won't work
                 series = SeriesTimestamp.from_total_seconds(series.copy_override_type(SeriesFloat64))
 
-            expression = Expression.construct(
-                'date_format({}, {})', series, Expression.string_value(parsed_format_str)
-            )
+            expression = parse_c_code_to_athena_expression(series.expression, format_str)
         elif is_bigquery(engine):
             if isinstance(series, SeriesTime):
                 # BigQuery provides a different function for formatting time, parsing a time to timestamp

--- a/bach/bach/series/utils/datetime_formats.py
+++ b/bach/bach/series/utils/datetime_formats.py
@@ -4,18 +4,23 @@ Copyright 2022 Objectiv B.V.
 import re
 import string
 import warnings
+from typing import List
 
+from bach.expression import Expression, join_expressions
 
 CODES_SUPPORTED_IN_ALL_DIALECTS = {
     # These are the codes that we support for all database dialects.
 
-    # week codes
+    # weekday codes
     '%a',  # WEEKDAY_ABBREVIATED
     '%A',  # WEEKDAY_FULL_NAME
 
     # day codes
     '%d',  # DAY_OF_MONTH
     '%j',  # DAY_OF_YEAR
+
+    # week codes
+    '%V',  # ISO_8601_WEEK_NUMBER_OF_YEAR
 
     # month codes
     '%b',  # MONTH_ABBREVIATED
@@ -209,18 +214,19 @@ def parse_c_standard_code_to_postgres_code(date_format: str) -> str:
     return ''.join(new_date_format_tokens)
 
 
-def parse_c_code_to_athena_code(date_format: str) -> str:
+def _parse_c_code_to_athena_code(date_format: str) -> str:
     """
     Parses a date format string, and return a string that's compatible with Athena's date_format() function.
 
     Some python format codes are different on Athena, or might even raise an error. Such codes are converted
     or escaped; using the returned string with Athena's date_format will never raise an error.
 
-    Codes in CODES_SUPPORTED_IN_ALL_DIALECTS are guaranteed to be correctly represented in the returned
-    format string. If date_format contains codes that are not in that set, then the returned format might
-    evaluate to a different string than the original date_format would with python's strftime() function.
+    Does not support '%V', but besides that All codes in CODES_SUPPORTED_IN_ALL_DIALECTS are guaranteed to
+    be correctly represented in the returned format string. If date_format contains codes that are not
+    supported, then the returned format might evaluate to a different string than the original date_format
+    would with python's strftime() function.
     """
-    # Athena code spec: https://prestodb.io/docs/0.217/functions/datetime.html
+    # Athena code spec: https://trino.io/docs/current/functions/datetime.html#mysql-date-functions
     # Python code spec: https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes
     c_code_to_athena_mapping = {
         # if there is no code, i.e. a lone '%' that's not followed by an alphabetic character, then that
@@ -234,6 +240,9 @@ def parse_c_code_to_athena_code(date_format: str) -> str:
         '%B': '%M',
         '%F': '%Y-%m-%d',
         '%R': '%H:%i',
+        # List not-supported codes that are in CODES_SUPPORTED_IN_ALL_DIALECTS and will trigger an error
+        # See also inline comments below
+        '%V': '%%V'
     }
     codes_to_consider = set(string.ascii_letters + '%')
     result = []
@@ -263,10 +272,83 @@ def parse_c_code_to_athena_code(date_format: str) -> str:
     return ''.join(result)
 
 
+def _split_format_string_V(date_format: str) -> List[str]:
+    """
+    Split the date format string in a list of format strings. Each occurrence of the format code `%V` will
+    be a separate format string in the resulting list, the rest of the format string is split as little as
+    possible.
+
+    Example: _split_format_string_V('xxx%V-%m-%%V') == ['xxx', '%V', '-%m-%%V']
+
+    :param date_format: C date format string.
+    :return: list of sub format strings.
+    """
+    result = []
+    current_date_format = []
+    i = 0
+    while i < len(date_format):
+        current = date_format[i]
+        i += 1
+        if current != '%' or i == len(date_format):
+            current_date_format.append(current)
+        else:
+            # This is the start of a code sequence.
+            code = current + date_format[i]
+            i += 1
+            if code != '%V':
+                current_date_format.append(code)
+            else:
+                if current_date_format:
+                    result.append(''.join(current_date_format))
+                    current_date_format = []
+                result.append('%V')
+    if current_date_format or not result:
+        result.append(''.join(current_date_format))
+    return result
+
+
+def parse_c_code_to_athena_expression(series_expression: Expression, date_format: str) -> Expression:
+    """
+    Parses a date format string, and return an Expression that represents the formatted date/timestamp/time.
+    Depending on the date_format, the expression might combine calls to the Athena functions
+    `date_format()` and `format_datetime()`.
+
+    Codes in CODES_SUPPORTED_IN_ALL_DIALECTS are guaranteed to be correctly represented in the returned
+    expression. If date_format contains codes that are not in that set, then the returned format might
+    evaluate to a different string than the original date_format would with python's strftime() function.
+
+    :param series_expression: The expression of the Date/Time/Timestamp/Timedelta Series that needs to be
+        formatted
+    :param date_format: C date format string
+    """
+    # Athena docs
+    # format_datetime(): https://trino.io/docs/current/functions/datetime.html#java-date-functions
+    # date_format():     https://trino.io/docs/current/functions/datetime.html#mysql-date-functions
+    split_date_formats = _split_format_string_V(date_format)
+    expressions: List[Expression] = []
+    for sub_df in split_date_formats:
+        if sub_df == '%V':
+            expression = Expression.construct(
+                "format_datetime({}, 'w')", series_expression
+            )
+        else:
+            parsed_format_str = _parse_c_code_to_athena_code(sub_df)
+            if not parsed_format_str:
+                expression = Expression.string_value('')
+            else:
+                expression = Expression.construct(
+                    'date_format({}, {})', series_expression, Expression.string_value(parsed_format_str)
+                )
+        expressions.append(expression)
+    return join_expressions(expressions, ' || ')
+
+
 def parse_c_code_to_bigquery_code(date_format: str) -> str:
     """
     Replaces all '%S.%f' with '%E6S', since BigQuery does not support microseconds c-code.
     """
+    # See BigQuery docs for more information:
+    # https://cloud.google.com/bigquery/docs/reference/standard-sql/format-elements#format_elements_date_time
     if '%S.%f' in date_format:
         date_format = re.sub(r'%S\.%f', '%E6S', date_format)
     return date_format

--- a/bach/bach/series/utils/datetime_formats.py
+++ b/bach/bach/series/utils/datetime_formats.py
@@ -329,7 +329,7 @@ def parse_c_code_to_athena_expression(series_expression: Expression, date_format
     for sub_df in split_date_formats:
         if sub_df == '%V':
             expression = Expression.construct(
-                "format_datetime({}, 'w')", series_expression
+                "format_datetime({}, 'ww')", series_expression
             )
         else:
             parsed_format_str = _parse_c_code_to_athena_code(sub_df)

--- a/bach/bach/series/utils/datetime_formats.py
+++ b/bach/bach/series/utils/datetime_formats.py
@@ -221,7 +221,7 @@ def _parse_c_code_to_athena_code(date_format: str) -> str:
     Some python format codes are different on Athena, or might even raise an error. Such codes are converted
     or escaped; using the returned string with Athena's date_format will never raise an error.
 
-    Does not support '%V', but besides that All codes in CODES_SUPPORTED_IN_ALL_DIALECTS are guaranteed to
+    Does not support '%V', but besides that all codes in CODES_SUPPORTED_IN_ALL_DIALECTS are guaranteed to
     be correctly represented in the returned format string. If date_format contains codes that are not
     supported, then the returned format might evaluate to a different string than the original date_format
     would with python's strftime() function.
@@ -240,8 +240,8 @@ def _parse_c_code_to_athena_code(date_format: str) -> str:
         '%B': '%M',
         '%F': '%Y-%m-%d',
         '%R': '%H:%i',
-        # List not-supported codes that are in CODES_SUPPORTED_IN_ALL_DIALECTS and will trigger an error
-        # See also inline comments below
+        # List not-supported codes that are in CODES_SUPPORTED_IN_ALL_DIALECTS and will trigger an error if
+        # not escaped. See also inline comments below.
         '%V': '%%V'
     }
     codes_to_consider = set(string.ascii_letters + '%')
@@ -275,10 +275,11 @@ def _parse_c_code_to_athena_code(date_format: str) -> str:
 def _split_format_string_V(date_format: str) -> List[str]:
     """
     Split the date format string in a list of format strings. Each occurrence of the format code `%V` will
-    be a separate format string in the resulting list, the rest of the format string is split as little as
-    possible.
+    be a separate format string in the resulting list, otherwise the format string is not split up.
 
-    Example: _split_format_string_V('xxx%V-%m-%%V') == ['xxx', '%V', '-%m-%%V']
+    Examples:
+    _split_format_string_V('%Y-%m-%d') == ['%Y-%m-%d']                          # zero '%V': no splits
+    _split_format_string_V('xxx%V-%m-%%V%V') == ['xxx', '%V', '-%m-%%V', '%V']  # two '%V': split in four
 
     :param date_format: C date format string.
     :return: list of sub format strings.

--- a/bach/tests/functional/bach/test_series_date.py
+++ b/bach/tests/functional/bach/test_series_date.py
@@ -64,7 +64,9 @@ def test_date_format(engine, recwarn):
 
     all_formats = [
         # tuple, types: (str, bool). Content: format, whether the format should raise a warning
+        ('', False),
         ('Year: %Y', False),
+        ('ISO Week: %V', False),
         ('%Y', False),
         ('%y%Y', False),
         ('%Y-%m-%d', False),
@@ -97,7 +99,9 @@ def test_date_format(engine, recwarn):
         expected_columns=expected_columns,
         expected_data=[
             [
+                '', '',
                 'Year: 2022', 'Year: 2021',
+                'ISO Week: 52', 'ISO Week: 18',
                 '2022', '2021',
                 '222022', '212021',
                 '2022-01-01', '2021-05-03',
@@ -110,8 +114,8 @@ def test_date_format(engine, recwarn):
                 'HH24:MI:SS MS', 'HH24:MI:SS MS',
                 '00:00:00.000000', '11:28:36.388000',
                 '%q %1 %_', '%q %1 %_',
-                '%: % | A: Saturday | B: January | F: 2022-01-01 | H: 00 | I: 12 | M: 00 | R: 00:00 | S: 00 | T: 00:00:00 | Y: 2022 | a: Sat | b: Jan | d: 01 | j: 001 | m: 01 | y: 22',
-                '%: % | A: Monday | B: May | F: 2021-05-03 | H: 11 | I: 11 | M: 28 | R: 11:28 | S: 36 | T: 11:28:36 | Y: 2021 | a: Mon | b: May | d: 03 | j: 123 | m: 05 | y: 21',
+                '%: % | A: Saturday | B: January | F: 2022-01-01 | H: 00 | I: 12 | M: 00 | R: 00:00 | S: 00 | T: 00:00:00 | V: 52 | Y: 2022 | a: Sat | b: Jan | d: 01 | j: 001 | m: 01 | y: 22',
+                '%: % | A: Monday | B: May | F: 2021-05-03 | H: 11 | I: 11 | M: 28 | R: 11:28 | S: 36 | T: 11:28:36 | V: 18 | Y: 2021 | a: Mon | b: May | d: 03 | j: 123 | m: 05 | y: 21',
                 '00.000000', '36.388000'
             ],
         ],

--- a/bach/tests/functional/bach/test_series_date.py
+++ b/bach/tests/functional/bach/test_series_date.py
@@ -153,7 +153,7 @@ def test_date_format_week_edge_cases(engine):
             datetime.date(year, 12, 31)
         ])
 
-    df = DataFrame.from_pandas(engine=engine, df=pd.DataFrame({'date': dates}), convert_objects=True)
+    df = DataFrame.from_pandas(engine=engine, df=pd.DataFrame({'date': dates}))
     for code in codes:
         df[code] = df['date'].dt.strftime(code)
     df = df.sort_index()

--- a/bach/tests/unit/bach/test_series_utils_datetime_formats.py
+++ b/bach/tests/unit/bach/test_series_utils_datetime_formats.py
@@ -72,7 +72,7 @@ def test__split_format_string_V():
     assert _split_format_string_V('%V-%Y-%m-%d-%V') == ['%V', '-%Y-%m-%d-', '%V']
     assert _split_format_string_V('%V-%V-%V') == ['%V', '-', '%V', '-', '%V']
     assert _split_format_string_V('%%V-%V-%%V') == ['%%V-', '%V', '-%%V']
-    assert _split_format_string_V('xxx%V-%m-%%V') == ['xxx', '%V', '-%m-%%V']
+    assert _split_format_string_V('xxx%V-%m-%%V%V') == ['xxx', '%V', '-%m-%%V', '%V']
     assert _split_format_string_V('%') == ['%']
     assert _split_format_string_V('') == ['']
 

--- a/modelhub/setup.cfg
+++ b/modelhub/setup.cfg
@@ -32,7 +32,7 @@ install_requires =
     plotly
     # sklearn requires wheel to properly install
     wheel
-    sklearn
+    scikit-learn
     typing-extensions
 python_requires = >=3.7
 packages = find:


### PR DESCRIPTION
Added support for `%V` in `strftime()`. This addresses issue https://github.com/objectiv/objectiv-analytics/issues/1215

# Changes
* Postgres, BigQuery: simply added `%V` to the allowed codes
* Athena:
  * Split format string on `%V`
  * non-%V parts generate expressions that use `date_format({}, {})`
  * The sub strings that are `%V` generate expressions that use `format_datetime({}, 'ww')` to get the equivalent value
  * Resulting expressions are concatenated
* Added test that checks %V (plus some other codes) for a lot of dates


# Discussion
Implemented `%V`. The issue mentioned `%W`, but `%V` was easier to do, seemed just as powerful, and was actually also suggested in the earlier discussion [here](https://github.com/objectiv/objectiv-analytics/pull/1204#discussion_r960983964) 