### PR TITLE
Make sorting in a test deterministic

### DIFF
--- a/bach/tests/functional/bach/test_df_append.py
+++ b/bach/tests/functional/bach/test_df_append.py
@@ -60,9 +60,9 @@ def test_append_w_ignore_index_n_sort(engine) -> None:
     other_df = DataFrame.from_pandas(engine=engine, df=other_pdf, convert_objects=True)
     other_df = other_df.set_index(['d'])
 
-    result = caller_df.append(other_df, ignore_index=True).sort_values('a')
+    result = caller_df.append(other_df, ignore_index=True).sort_values(['a', 'c'])
 
-    expected = pd.concat([caller_pdf, other_pdf.set_index(['d'])], ignore_index=True).sort_values('a')
+    expected = pd.concat([caller_pdf, other_pdf.set_index(['d'])], ignore_index=True).sort_values(['a', 'c'])
     pd.testing.assert_frame_equal(expected, result.to_pandas())
 
     assert_equals_data(


### PR DESCRIPTION
Make sorting in a test deterministic. Reason: this test randomly failed once for another PR, see [here](https://github.com/objectiv/objectiv-analytics/actions/runs/3378157942/jobs/5607992626) and that seemed related to the sorting