### PR TITLE
Fix Jupyter input with dots

### DIFF
--- a/bach/docs/source/_ext/sphinx_docusaurus_builder/docusaurus_writer.py
+++ b/bach/docs/source/_ext/sphinx_docusaurus_builder/docusaurus_writer.py
@@ -562,10 +562,11 @@ class DocusaurusTranslator(Translator):
 
             if node['language'] != 'jupyter-notebook-out':
                 for i, line in enumerate(node_lines):
-                    if((line[0:3] == ">>>") or (node['language'] == 'jupyter-notebook')):
+                    if((line[0:3] == ">>>") or (line[0:3] == '...') 
+                        or (node['language'] == 'jupyter-notebook')):
                         if (i != 0): 
                             node_input += "\n"
-                        if (line[0:3] == '>>>'):
+                        if (line[0:3] == '>>>' or line[0:3] == '...'):
                             node_input += line[4:]
                         else:
                             node_input += line


### PR DESCRIPTION
Fixes an issue where Jupyter notebook input with prepended dots (`...`) would actually end up in the output. 

Corresponding result: https://github.com/objectiv/objectiv.io/pull/600