### PR TITLE
Enable typevars for Sphinx Docusaurus builder

### DIFF
--- a/bach/docs/requirements.txt
+++ b/bach/docs/requirements.txt
@@ -5,6 +5,7 @@ PyYAML==6.0
 setuptools==61.0.0
 Sphinx==4.5.0
 sphinx_exec_code==0.8
+sphinx-toolbox==3.2.0
 
 ## theme we load/adapt
 numpydoc

--- a/bach/docs/source/_ext/sphinx_docusaurus_builder/docusaurus_writer.py
+++ b/bach/docs/source/_ext/sphinx_docusaurus_builder/docusaurus_writer.py
@@ -147,8 +147,6 @@ class DocusaurusTranslator(Translator):
         """The root of the tree.
         https://docutils.sourceforge.io/docs/ref/doctree.html#document"""
         self.title = getattr(self.builder, 'current_docname')
-        if ('explore-data' in self.title):
-            print("DOCUMENT:", node)
 
 
     def depart_document(self, node):

--- a/bach/docs/source/_ext/sphinx_docusaurus_builder/docusaurus_writer.py
+++ b/bach/docs/source/_ext/sphinx_docusaurus_builder/docusaurus_writer.py
@@ -147,6 +147,8 @@ class DocusaurusTranslator(Translator):
         """The root of the tree.
         https://docutils.sourceforge.io/docs/ref/doctree.html#document"""
         self.title = getattr(self.builder, 'current_docname')
+        if ('explore-data' in self.title):
+            print("DOCUMENT:", node)
 
 
     def depart_document(self, node):
@@ -588,7 +590,9 @@ class DocusaurusTranslator(Translator):
                 self.add('\n<div className="jupyter-notebook-in-output">\n\n')
                 self.add('\n<div className="jupyter-notebook-in">In:</div>\n\n')
                 self.add('<div className="jupyter-notebook-input">\n\n')
-                if node['language'] == 'pycon3' or node['language'] == 'jupyter-notebook':
+                if (node['language'] == 'pycon'
+                    or node['language'] == 'pycon3' 
+                    or node['language'] == 'jupyter-notebook'):
                     self.add('```python\n')
                 else:
                     self.add('```\n')

--- a/bach/docs/source/conf.py
+++ b/bach/docs/source/conf.py
@@ -58,6 +58,7 @@ extensions = [
     'sphinx.ext.autosummary',  # auto generate autodoc directives
     'sphinx.ext.doctest',  # run examples /tests
     'sphinx_exec_code',
+    'sphinx_toolbox.more_autodoc.typevars',
     # 'sphinx.ext.intersphinx',       # generate links to external sphinx projects
     'numpydoc',  # use numpy style docs
     "IPython.sphinxext.ipython_directive",


### PR DESCRIPTION
Based on the comment in https://github.com/objectiv/objectiv-analytics/pull/1053, enables https://sphinx-toolbox.readthedocs.io/en/latest/extensions/more_autodoc/typevars.html

Corresponding objectiv.io PR: https://github.com/objectiv/objectiv.io/pull/602