### PR TITLE
Disable cronjob to fetch locale codes

### DIFF
--- a/.github/workflows/verify-locale-codes.yml
+++ b/.github/workflows/verify-locale-codes.yml
@@ -7,8 +7,9 @@ on:
       - 'tracker/plugins/locale-context/**'
       - '.github/workflows/verify-locale-codes.yml'
 
-  schedule:
-    - cron:  '30 10,22 * * *'
+# Disabled temporarily, host has been banned
+#  schedule:
+#    - cron:  '30 10,22 * * *'
 
 jobs:
   verify-locale-codes:


### PR DESCRIPTION
GHA hosts have been banned by the target pages we are scraping, we need to back off a bit.